### PR TITLE
Fix: Convert specific open_ticket fields to strings

### DIFF
--- a/routers/public/tickets.py
+++ b/routers/public/tickets.py
@@ -270,4 +270,10 @@ async def save_settings(request: Request):
 async def open_ticket_json(channel_id: int, request: Request):
 
     open_ticket = await db_client.open_tickets.find_one({"channel" : channel_id}, {"_id" : 0})
+
+    if open_ticket:
+        for key in ["user", "channel", "thread", "server"]:
+            if key in open_ticket:
+                open_ticket[key] = str(open_ticket[key])
+
     return open_ticket


### PR DESCRIPTION
This pull request ensures that the fields `user`, `channel`, `thread`, and `server` in the `open_ticket` function are converted to strings to prevent issues with large integers.