### PR TITLE
fix: remove unused pytz import from utils

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -11,7 +11,6 @@ import aiohttp
 import coc
 import orjson
 import pendulum as pend
-import pytz
 from bson import json_util
 from dotenv import load_dotenv
 from fastapi import HTTPException


### PR DESCRIPTION
## Summary
Removed an unused `pytz` import from the utils module to clean up dependencies and reduce unnecessary imports.

## Key Changes
- Removed `import pytz` from `utils/utils.py` as it was not being utilized in the module

## Details
The `pytz` library was imported but never referenced in the code. Since `pendulum` is already being used for timezone handling (which provides similar functionality), the `pytz` import is redundant and has been removed to improve code cleanliness and reduce the module's dependency footprint.

https://claude.ai/code/session_01NLiBro2CZXF5qHZbmZsLrb