### PR TITLE
feat: add POST /v2/cdn/upload + migrate CDN domain to cdn.clashk.ing

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -172,6 +172,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/v2/cdn/upload": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Uploads an arbitrary file and returns its public CDN URL. Requires authentication.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "CDN"
+                ],
+                "summary": "Upload a file to the ClashKing CDN",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to upload (max 25 MB)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v2/clan/compo": {
             "get": {
                 "description": "Returns town hall, role, and league composition for the requested clan tags.",

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -165,6 +165,73 @@
                 }
             }
         },
+        "/v2/cdn/upload": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Uploads an arbitrary file and returns its public CDN URL. Requires authentication.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "CDN"
+                ],
+                "summary": "Upload a file to the ClashKing CDN",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "File to upload (max 25 MB)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v2/clan/compo": {
             "get": {
                 "description": "Returns town hall, role, and league composition for the requested clan tags.",

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -870,6 +870,50 @@ paths:
       summary: Get static categories
       tags:
       - Static Data
+  /v2/cdn/upload:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Uploads an arbitrary file and returns its public CDN URL. Requires
+        authentication.
+      parameters:
+      - description: File to upload (max 25 MB)
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "413":
+          description: Request Entity Too Large
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "415":
+          description: Unsupported Media Type
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - ApiKeyAuth: []
+      summary: Upload a file to the ClashKing CDN
+      tags:
+      - CDN
   /v2/clan/{clan_tag}/board/totals:
     get:
       description: Returns aggregate board totals for one or more player tags.

--- a/internal/routes/v2/cdn.go
+++ b/internal/routes/v2/cdn.go
@@ -1,0 +1,116 @@
+package v2
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+)
+
+// maxCDNUploadSize is 25 MB — enough for Discord attachment limits.
+const maxCDNUploadSize = 25 * 1024 * 1024
+
+var cdnAllowedExtensions = map[string]bool{
+	// images
+	"png": true, "jpg": true, "jpeg": true, "gif": true, "webp": true, "svg": true,
+	// video
+	"mp4": true, "mov": true, "webm": true,
+	// audio
+	"mp3": true, "ogg": true, "wav": true,
+	// documents / misc
+	"pdf": true, "txt": true, "json": true,
+}
+
+// uploadFileToCDN godoc
+// @Summary Upload a file to the ClashKing CDN
+// @Description Uploads an arbitrary file and returns its public CDN URL. Requires authentication.
+// @Tags CDN
+// @Accept multipart/form-data
+// @Produce json
+// @Security ApiKeyAuth
+// @Param file formData file true "File to upload (max 25 MB)"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} map[string]string
+// @Failure 413 {object} map[string]string
+// @Failure 415 {object} map[string]string
+// @Router /v2/cdn/upload [post]
+func uploadFileToCDN(a apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		fileHeader, err := c.FormFile("file")
+		if err != nil || fileHeader == nil {
+			return apptypes.Error(http.StatusBadRequest, "A 'file' field is required")
+		}
+
+		if fileHeader.Size > maxCDNUploadSize {
+			return apptypes.Error(http.StatusRequestEntityTooLarge, "File too large (max 25 MB)")
+		}
+
+		// Derive and validate extension from original filename.
+		originalName := fileHeader.Filename
+		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(originalName), "."))
+		if ext == "" {
+			ext = "bin"
+		}
+		if !cdnAllowedExtensions[ext] {
+			return apptypes.Error(http.StatusUnsupportedMediaType, fmt.Sprintf("Unsupported file type: .%s", ext))
+		}
+
+		f, err := fileHeader.Open()
+		if err != nil {
+			return apptypes.Error(http.StatusBadRequest, "Failed to open uploaded file")
+		}
+		defer f.Close()
+
+		data, err := io.ReadAll(f)
+		if err != nil {
+			return apptypes.Error(http.StatusBadRequest, "Failed to read uploaded file")
+		}
+
+		// Double-check size after reading (in case Content-Length was missing).
+		if len(data) > maxCDNUploadSize {
+			return apptypes.Error(http.StatusRequestEntityTooLarge, "File too large (max 25 MB)")
+		}
+
+		title := fmt.Sprintf("embed_%s", uuid.New().String())
+		cdnURL, err := bunnyUploadFileWithExt(a.Config.BunnyAccessKey, title, ext, data)
+		if err != nil {
+			return apptypes.Error(http.StatusInternalServerError, "Failed to upload file to CDN")
+		}
+
+		return apptypes.JSON(c, http.StatusOK, map[string]string{
+			"url":      cdnURL,
+			"filename": fmt.Sprintf("%s.%s", title, ext),
+		})
+	}
+}
+
+// bunnyUploadFileWithExt uploads bytes to BunnyCDN preserving the given extension.
+func bunnyUploadFileWithExt(accessKey, title, ext string, data []byte) (string, error) {
+	title = strings.ToLower(strings.ReplaceAll(title, " ", "_"))
+	path := fmt.Sprintf("%s.%s", title, ext)
+	uploadURL := fmt.Sprintf("https://storage.bunnycdn.com/clashking-files/%s", path)
+
+	req, err := http.NewRequest(http.MethodPut, uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("AccessKey", accessKey)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("BunnyCDN upload failed: status %d", resp.StatusCode)
+	}
+	return fmt.Sprintf("https://cdn.clashk.ing/%s", path), nil
+}

--- a/internal/routes/v2/register.go
+++ b/internal/routes/v2/register.go
@@ -248,4 +248,6 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 
 	app.Get("/v2/exports/war/cwl-summary", wrap(exportCWLSummary(a)))
 	app.Post("/v2/exports/war/player-stats", wrap(exportPlayerWarStats(a)))
+
+	app.Post("/v2/cdn/upload", wrap(uploadFileToCDN(a)))
 }

--- a/internal/routes/v2/server/giveaways.go
+++ b/internal/routes/v2/server/giveaways.go
@@ -765,15 +765,22 @@ func bunnyUploadFile(accessKey, title string, data []byte) (string, error) {
 	if resp.StatusCode >= 300 {
 		return "", fmt.Errorf("BunnyCDN upload failed: status %d", resp.StatusCode)
 	}
-	return fmt.Sprintf("https://cdn.clashking.xyz/%s.png", title), nil
+	return fmt.Sprintf("https://cdn.clashk.ing/%s.png", title), nil
 }
 
 func bunnyDeleteFile(accessKey, imageURL string) error {
-	const prefix = "https://cdn.clashking.xyz/"
-	if !strings.HasPrefix(imageURL, prefix) {
+	const prefix = "https://cdn.clashk.ing/"
+	// Also handle legacy cdn.clashking.xyz URLs so old records can still be deleted.
+	const legacyPrefix = "https://cdn.clashking.xyz/"
+	var filePath string
+	switch {
+	case strings.HasPrefix(imageURL, prefix):
+		filePath = imageURL[len(prefix):]
+	case strings.HasPrefix(imageURL, legacyPrefix):
+		filePath = imageURL[len(legacyPrefix):]
+	default:
 		return nil
 	}
-	filePath := imageURL[len(prefix):]
 	deleteURL := fmt.Sprintf("https://storage.bunnycdn.com/clashking-files/%s", filePath)
 	req, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
 	if err != nil {


### PR DESCRIPTION
- New endpoint POST /v2/cdn/upload: accepts multipart file (max 25 MB), validates extension, uploads to BunnyCDN with original extension, returns {url, filename}. Requires JWT auth.
- Migrate bunnyUploadFile return URL from cdn.clashking.xyz to cdn.clashk.ing
- bunnyDeleteFile now handles both cdn.clashk.ing and legacy cdn.clashking.xyz URLs so existing giveaway images can still be deleted

Allowed types: png jpg jpeg gif webp svg mp4 mov webm mp3 ogg wav pdf txt json