### PR TITLE
fix: off by one error when returning list of seasons

### DIFF
--- a/routers/public/list.py
+++ b/routers/public/list.py
@@ -29,7 +29,7 @@ async def list_townhalls(request: Request, response: Response):
 async def list_seasons(request: Request, response: Response, last: int = 12):
     last = min(last, 1000)
     dates = []
-    for x in range(0, last + 1):
+    for x in range(0, last):
         end = coc.utils.get_season_end().replace(tzinfo=utc) - dateutil.relativedelta.relativedelta(months=x)
         month = end.month
         if end.month <= 9:


### PR DESCRIPTION
Currently list/seasons returns a list of length last + 1. (last is the arg given for the number of seasons)

I believe that it makes most sense that this endpoint should return a list that is the length of last and not last + 1. For example, if I want a list of the last 4 seasons I should enter 4 as last, not 3. 

I understand that this might cause some issues with projects built on using this endpoint but this change makes most sense from a pure functionality point of view, in my own opinion.  

