### PR TITLE
Add global privacy compliance controls

### DIFF
--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -1,0 +1,25 @@
+# Privacy Compliance Notes
+
+ClashKing API exposes public Clash of Clans statistics and authenticated management endpoints. Global mobile deployment means the service must support privacy rights consistently with the mobile app, dashboard, bot, and tracking services.
+
+## Data handled here
+
+- Public Clash of Clans player, clan, war, raid, ranking, and history data retrieved from official game APIs.
+- Authenticated API user accounts, permissions, password hashes, and short-lived JWTs.
+- Server, roster, ticketing, giveaway, and token records used by ClashKing services.
+- Generated media and CDN URLs for user-configured bot/dashboard features.
+
+## Controls added
+
+- `POST /auth/export` and `GET /privacy/export` return authenticated API account data without password hashes or Mongo identifiers.
+- `DELETE /auth/me` and `POST /privacy/delete-request` create a verified erasure request in `clashking.privacy_requests`.
+- `GET /privacy/retention` publishes the retention contract for tokens, API accounts, privacy requests, and public game statistics.
+- Privacy requests are recorded with `username`, `type`, `status`, `received_at`, and `source` so operators can action GDPR/CCPA/LGPD/PIPEDA/APPI/PIPL/PDPA access and erasure requests.
+
+## Operational requirements
+
+- Complete verified export/deletion requests within 30 days unless a stricter local rule applies.
+- Do not include password hashes, raw API tokens, bot tokens, or internal credentials in exports.
+- Delete or anonymize user-authored records unless retention is needed for fraud, security, audit, or legal obligations.
+- Keep public game telemetry separate from user account data. If a player tag is linked to a Discord/user account, treat that link as personal data.
+- Keep CORS and token-bearing endpoints behind HTTPS in production.

--- a/routers/v2/privacy.py
+++ b/routers/v2/privacy.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from routers.v2.auth import User, get_current_user
+from utils.utils import db_client, remove_id_fields
+
+router = APIRouter(tags=["Privacy"], include_in_schema=True)
+
+
+def _utc_now() -> datetime:
+    return datetime.utcnow()
+
+
+def _safe_user(user: User) -> dict[str, Any]:
+    return {
+        "username": user.username,
+        "admin": user.admin,
+        "permissions": user.permissions.dict(),
+    }
+
+
+async def _record_privacy_request(username: str, request_type: str) -> dict[str, Any]:
+    now = _utc_now()
+    record = {
+        "username": username,
+        "type": request_type,
+        "status": "received",
+        "received_at": now,
+        "source": "api",
+    }
+    await db_client.privacy_requests.update_one(
+        {"username": username, "type": request_type, "status": {"$in": ["received", "in_progress"]}},
+        {"$set": record, "$setOnInsert": {"created_at": now}},
+        upsert=True,
+    )
+    return {"status": "received", "received_at": now.isoformat() + "Z"}
+
+
+@router.post("/auth/export")
+@router.get("/privacy/export")
+async def export_current_user(current_user: User = Depends(get_current_user)) -> dict[str, Any]:
+    """Return the authenticated API account data without secrets."""
+    raw_user = await db_client.api_users.find_one({"username": current_user.username}, {"_id": 0, "password": 0})
+    export = {
+        "account": _safe_user(current_user),
+        "stored_account": raw_user or {},
+        "privacy_requests": await db_client.privacy_requests.find(
+            {"username": current_user.username},
+            {"_id": 0},
+        ).to_list(length=100),
+    }
+    return remove_id_fields(export)
+
+
+@router.delete("/auth/me")
+@router.post("/privacy/delete-request")
+async def request_current_user_deletion(current_user: User = Depends(get_current_user)) -> dict[str, Any]:
+    """Register an erasure request for the authenticated API account.
+
+    API accounts can carry operational permissions, so this endpoint records the
+    verified request for review instead of silently deleting production access.
+    """
+    result = await _record_privacy_request(current_user.username, "account_deletion")
+    return {
+        "ok": True,
+        "message": "Account deletion request received and queued for operator review.",
+        **result,
+    }
+
+
+@router.get("/privacy/retention")
+async def privacy_retention() -> dict[str, Any]:
+    return {
+        "api_auth_tokens": "JWT access tokens expire after 30 minutes.",
+        "api_user_records": "Kept while the API account is active or required for security/audit purposes.",
+        "privacy_requests": "Kept as compliance evidence for the legal limitation period.",
+        "public_game_statistics": "Sourced from the official Clash of Clans API and retained only where needed for ClashKing features.",
+    }

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -76,6 +76,7 @@ class DBClient():
         self.player_history: collection_class = self.new_looper.get_collection("player_history")
         self.link_shortner: collection_class = client.clashking.short_links
         self.api_users: collection_class = client.clashking.api_users
+        self.privacy_requests: collection_class = client.clashking.privacy_requests
         self.tokens: collection_class = client.clashking.tokens
         self.giveaways: collection_class = client.clashking.giveaways
 


### PR DESCRIPTION
## Summary
- add authenticated privacy export and deletion-request endpoints for API users
- add retention metadata and privacy request storage
- document global privacy obligations for API-operated data

## Validation
- python -m py_compile routers\\v2\\privacy.py routers\\v2\\auth.py utils\\utils.py