### PR TITLE
feat: add achievement catalog and account checks

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -198,6 +198,68 @@ const docTemplate = `{
                 }
             }
         },
+        "/v2/achievements": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Lists every available achievement with its model asset and the authenticated user's earned count.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Achievements"
+                ],
+                "summary": "List achievements",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.AchievementsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/achievements/check": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Checks verified linked players for achievements that can currently be evaluated, awards new matches, and returns the full catalog.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Achievements"
+                ],
+                "summary": "Check achievements",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.AchievementsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/activity/guild-summary": {
             "get": {
                 "description": "Returns clan and member activity totals for a Discord guild.",
@@ -13949,6 +14011,34 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                }
+            }
+        },
+        "modelsv2.Achievement": {
+            "type": "object",
+            "properties": {
+                "asset_url": {
+                    "type": "string"
+                },
+                "earned_count": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "repeatable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "modelsv2.AchievementsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/modelsv2.Achievement"
                     }
                 }
             }

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -198,37 +198,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/v2/achievements": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Lists every available achievement with its model asset and the authenticated user's earned count.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Achievements"
-                ],
-                "summary": "List achievements",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.AchievementsResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/v2/achievements/check": {
             "post": {
                 "security": [

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -191,37 +191,6 @@
                 }
             }
         },
-        "/v2/achievements": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Lists every available achievement with its model asset and the authenticated user's earned count.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Achievements"
-                ],
-                "summary": "List achievements",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.AchievementsResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/v2/achievements/check": {
             "post": {
                 "security": [

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -191,6 +191,68 @@
                 }
             }
         },
+        "/v2/achievements": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Lists every available achievement with its model asset and the authenticated user's earned count.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Achievements"
+                ],
+                "summary": "List achievements",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.AchievementsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/achievements/check": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Checks verified linked players for achievements that can currently be evaluated, awards new matches, and returns the full catalog.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Achievements"
+                ],
+                "summary": "Check achievements",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.AchievementsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v2/activity/guild-summary": {
             "get": {
                 "description": "Returns clan and member activity totals for a Discord guild.",
@@ -13942,6 +14004,34 @@
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                }
+            }
+        },
+        "modelsv2.Achievement": {
+            "type": "object",
+            "properties": {
+                "asset_url": {
+                    "type": "string"
+                },
+                "earned_count": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "repeatable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "modelsv2.AchievementsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/modelsv2.Achievement"
                     }
                 }
             }

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -90,6 +90,24 @@ definitions:
           type: string
         type: array
     type: object
+  modelsv2.Achievement:
+    properties:
+      asset_url:
+        type: string
+      earned_count:
+        type: integer
+      id:
+        type: string
+      repeatable:
+        type: boolean
+    type: object
+  modelsv2.AchievementsResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/modelsv2.Achievement'
+        type: array
+    type: object
   modelsv2.ActiveAnnouncementResponse:
     properties:
       item:
@@ -6206,6 +6224,46 @@ paths:
       summary: List tracked town halls
       tags:
       - Lists
+  /v2/achievements:
+    get:
+      description: Lists every available achievement with its model asset and the
+        authenticated user's earned count.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/modelsv2.AchievementsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: List achievements
+      tags:
+      - Achievements
+  /v2/achievements/check:
+    post:
+      description: Checks verified linked players for achievements that can currently
+        be evaluated, awards new matches, and returns the full catalog.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/modelsv2.AchievementsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Check achievements
+      tags:
+      - Achievements
   /v2/activity/guild-summary:
     get:
       description: Returns clan and member activity totals for a Discord guild.

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -6224,26 +6224,6 @@ paths:
       summary: List tracked town halls
       tags:
       - Lists
-  /v2/achievements:
-    get:
-      description: Lists every available achievement with its model asset and the
-        authenticated user's earned count.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/modelsv2.AchievementsResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/modelsv2.ErrorResponse'
-      security:
-      - ApiKeyAuth: []
-      summary: List achievements
-      tags:
-      - Achievements
   /v2/achievements/check:
     post:
       description: Checks verified linked players for achievements that can currently

--- a/internal/models/v2/achievements.go
+++ b/internal/models/v2/achievements.go
@@ -1,0 +1,12 @@
+package modelsv2
+
+type Achievement struct {
+	ID          string `json:"id"`
+	AssetURL    string `json:"asset_url"`
+	Repeatable  bool   `json:"repeatable"`
+	EarnedCount int    `json:"earned_count"`
+}
+
+type AchievementsResponse struct {
+	Items []Achievement `json:"items"`
+}

--- a/internal/routes/achievements.go
+++ b/internal/routes/achievements.go
@@ -1,0 +1,172 @@
+package routes
+
+import (
+	"context"
+
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	clashy "github.com/clashkinginc/clashy.go"
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	townhall18AchievementID          = "townhall_18"
+	warWarriorAchievementID          = "war_warrior"
+	mrLegendAchievementID            = "mr_legend"
+	defenseDoesntMatterAchievementID = "defense_doesnt_matter"
+	achievementLifetimeOccurrenceKey = "lifetime"
+	achievementAssetBaseURL          = "https://assets.clashk.ing/achievements/"
+)
+
+var achievementDefinitions = []modelsv2.Achievement{
+	{
+		ID:         townhall18AchievementID,
+		AssetURL:   achievementAssetBaseURL + "town-hall-18-achievement-badge.glb",
+		Repeatable: true,
+	},
+	{
+		ID:         warWarriorAchievementID,
+		AssetURL:   achievementAssetBaseURL + "war-champion-achievement-badge.glb",
+		Repeatable: true,
+	},
+	{
+		ID:         mrLegendAchievementID,
+		AssetURL:   achievementAssetBaseURL + "perfect-legends-day-achievement-badge.glb",
+		Repeatable: true,
+	},
+	{
+		ID:         defenseDoesntMatterAchievementID,
+		AssetURL:   achievementAssetBaseURL + "bad-legends-achievement-badge.glb",
+		Repeatable: true,
+	},
+}
+
+// @Summary List achievements
+// @Description Lists every available achievement with its model asset and the authenticated user's earned count.
+// @Tags Achievements
+// @Produce json
+// @Security ApiKeyAuth
+// @Success 200 {object} modelsv2.AchievementsResponse
+// @Failure 401 {object} modelsv2.ErrorResponse
+// @Router /v2/achievements [get]
+func listAchievements(a apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		counts, err := achievementAwardCounts(c.UserContext(), a, apptypes.UserID(c.UserContext()))
+		if err != nil {
+			return err
+		}
+		return apptypes.JSON(c, fiber.StatusOK, achievementCatalog(counts))
+	}
+}
+
+// @Summary Check achievements
+// @Description Checks verified linked players for achievements that can currently be evaluated, awards new matches, and returns the full catalog.
+// @Tags Achievements
+// @Produce json
+// @Security ApiKeyAuth
+// @Success 200 {object} modelsv2.AchievementsResponse
+// @Failure 401 {object} modelsv2.ErrorResponse
+// @Router /v2/achievements/check [post]
+func checkAchievements(a apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		ctx := c.UserContext()
+		userID := apptypes.UserID(ctx)
+		tags, err := verifiedAchievementPlayerTags(ctx, a, userID)
+		if err != nil {
+			return err
+		}
+
+		for result := range a.Clash.FetchPlayers(ctx, tags) {
+			if result.Err != nil || result.Player == nil {
+				continue
+			}
+			for _, achievementID := range evaluatedAchievementIDs(result.Player) {
+				if _, err := a.Store.SQL.Exec(ctx, `
+					INSERT INTO achievement_player_awards (
+						achievement_id,
+						player_tag,
+						occurrence_key
+					)
+					VALUES ($1, $2, $3)
+					ON CONFLICT DO NOTHING
+				`, achievementID, apptypes.NormalizeTag(result.Player.Tag), achievementLifetimeOccurrenceKey); err != nil {
+					return err
+				}
+			}
+		}
+
+		counts, err := achievementAwardCounts(ctx, a, userID)
+		if err != nil {
+			return err
+		}
+		return apptypes.JSON(c, fiber.StatusOK, achievementCatalog(counts))
+	}
+}
+
+func verifiedAchievementPlayerTags(ctx context.Context, a apptypes.Deps, userID string) ([]string, error) {
+	rows, err := a.Store.SQL.Query(ctx, `
+		SELECT tag
+		FROM player_links
+		WHERE user_id = $1 AND is_verified = true
+		ORDER BY order_index ASC, added_at ASC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tags := make([]string, 0)
+	for rows.Next() {
+		var tag string
+		if err := rows.Scan(&tag); err != nil {
+			return nil, err
+		}
+		tags = append(tags, tag)
+	}
+	return tags, rows.Err()
+}
+
+func achievementAwardCounts(ctx context.Context, a apptypes.Deps, userID string) (map[string]int, error) {
+	rows, err := a.Store.SQL.Query(ctx, `
+		SELECT awards.achievement_id, count(*)
+		FROM achievement_player_awards AS awards
+		JOIN player_links AS links ON links.tag = awards.player_tag
+		WHERE links.user_id = $1 AND links.is_verified = true
+		GROUP BY awards.achievement_id
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var achievementID string
+		var count int
+		if err := rows.Scan(&achievementID, &count); err != nil {
+			return nil, err
+		}
+		counts[achievementID] = count
+	}
+	return counts, rows.Err()
+}
+
+func evaluatedAchievementIDs(player *clashy.Player) []string {
+	ids := make([]string, 0, 2)
+	if player.TownHall >= 18 {
+		ids = append(ids, townhall18AchievementID)
+	}
+	if player.WarStars >= 5000 {
+		ids = append(ids, warWarriorAchievementID)
+	}
+	return ids
+}
+
+func achievementCatalog(counts map[string]int) modelsv2.AchievementsResponse {
+	items := make([]modelsv2.Achievement, len(achievementDefinitions))
+	for index, definition := range achievementDefinitions {
+		definition.EarnedCount = counts[definition.ID]
+		items[index] = definition
+	}
+	return modelsv2.AchievementsResponse{Items: items}
+}

--- a/internal/routes/achievements.go
+++ b/internal/routes/achievements.go
@@ -41,24 +41,6 @@ var achievementDefinitions = []modelsv2.Achievement{
 	},
 }
 
-// @Summary List achievements
-// @Description Lists every available achievement with its model asset and the authenticated user's earned count.
-// @Tags Achievements
-// @Produce json
-// @Security ApiKeyAuth
-// @Success 200 {object} modelsv2.AchievementsResponse
-// @Failure 401 {object} modelsv2.ErrorResponse
-// @Router /v2/achievements [get]
-func listAchievements(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		counts, err := achievementAwardCounts(c.UserContext(), a, apptypes.UserID(c.UserContext()))
-		if err != nil {
-			return err
-		}
-		return apptypes.JSON(c, fiber.StatusOK, achievementCatalog(counts))
-	}
-}
-
 // @Summary Check achievements
 // @Description Checks verified linked players for achievements that can currently be evaluated, awards new matches, and returns the full catalog.
 // @Tags Achievements

--- a/internal/routes/achievements.go
+++ b/internal/routes/achievements.go
@@ -58,7 +58,13 @@ func checkAchievements(a apptypes.Deps) fiber.Handler {
 			return err
 		}
 
-		for result := range a.Clash.FetchPlayers(ctx, tags) {
+		fetchCtx, cancelFetch := context.WithCancel(ctx)
+		defer cancelFetch()
+		var awardErr error
+		for result := range a.Clash.FetchPlayers(fetchCtx, tags) {
+			if awardErr != nil {
+				continue
+			}
 			if result.Err != nil || result.Player == nil {
 				continue
 			}
@@ -72,9 +78,14 @@ func checkAchievements(a apptypes.Deps) fiber.Handler {
 					VALUES ($1, $2, $3)
 					ON CONFLICT DO NOTHING
 				`, achievementID, apptypes.NormalizeTag(result.Player.Tag), achievementLifetimeOccurrenceKey); err != nil {
-					return err
+					awardErr = err
+					cancelFetch()
+					break
 				}
 			}
+		}
+		if awardErr != nil {
+			return awardErr
 		}
 
 		counts, err := achievementAwardCounts(ctx, a, userID)

--- a/internal/routes/achievements_test.go
+++ b/internal/routes/achievements_test.go
@@ -1,0 +1,89 @@
+package routes
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
+	clashy "github.com/clashkinginc/clashy.go"
+)
+
+func TestAchievementCatalogIncludesAllAchievements(t *testing.T) {
+	t.Parallel()
+
+	response := achievementCatalog(map[string]int{
+		townhall18AchievementID: 2,
+		warWarriorAchievementID: 1,
+	})
+	if len(response.Items) != 4 {
+		t.Fatalf("items length = %d, want 4", len(response.Items))
+	}
+
+	wantIDs := []string{
+		townhall18AchievementID,
+		warWarriorAchievementID,
+		mrLegendAchievementID,
+		defenseDoesntMatterAchievementID,
+	}
+	for index, wantID := range wantIDs {
+		item := response.Items[index]
+		if item.ID != wantID {
+			t.Errorf("item %d id = %q, want %q", index, item.ID, wantID)
+		}
+		if !item.Repeatable {
+			t.Errorf("item %q is not repeatable", item.ID)
+		}
+		if !strings.HasPrefix(item.AssetURL, achievementAssetBaseURL) || !strings.HasSuffix(item.AssetURL, ".glb") {
+			t.Errorf("item %q has unexpected asset URL %q", item.ID, item.AssetURL)
+		}
+	}
+	if response.Items[2].EarnedCount != 0 || response.Items[3].EarnedCount != 0 {
+		t.Fatalf("unwired Legend achievements should remain unearned: %#v", response.Items)
+	}
+}
+
+func TestEvaluatedAchievementIDsOnlyWiresTownhallAndWarWarrior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		player clashy.Player
+		want   []string
+	}{
+		{name: "neither", player: clashy.Player{TownHall: 17, WarStars: 4999}},
+		{name: "townhall", player: clashy.Player{TownHall: 18, WarStars: 4999}, want: []string{townhall18AchievementID}},
+		{name: "war warrior", player: clashy.Player{TownHall: 17, WarStars: 5000}, want: []string{warWarriorAchievementID}},
+		{name: "both", player: clashy.Player{TownHall: 18, WarStars: 5000}, want: []string{townhall18AchievementID, warWarriorAchievementID}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := evaluatedAchievementIDs(&test.player)
+			if strings.Join(got, ",") != strings.Join(test.want, ",") {
+				t.Fatalf("ids = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAchievementResponseJSONContract(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(achievementCatalog(map[string]int{townhall18AchievementID: 3}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response modelsv2.AchievementsResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatal(err)
+	}
+	jsonBody := string(body)
+	for _, field := range []string{`"items"`, `"id"`, `"asset_url"`, `"repeatable"`, `"earned_count"`} {
+		if !strings.Contains(jsonBody, field) {
+			t.Errorf("response is missing %s: %s", field, jsonBody)
+		}
+	}
+	if strings.Contains(jsonBody, "observed_value") || strings.Contains(jsonBody, "source") {
+		t.Fatalf("response contains an excluded field: %s", jsonBody)
+	}
+}

--- a/internal/routes/register.go
+++ b/internal/routes/register.go
@@ -33,6 +33,8 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 	}
 
 	app.Get("/v2/clan/:clan_tag/badge", clanBadge(a))
+	app.Get("/v2/achievements", wrap(listAchievements(a)))
+	app.Post("/v2/achievements/check", wrap(checkAchievements(a)))
 
 	// Register the static server path before the generic two-parameter link paths.
 	// Fiber dispatches in registration order, so DELETE/PATCH would otherwise match

--- a/internal/routes/register.go
+++ b/internal/routes/register.go
@@ -33,7 +33,6 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 	}
 
 	app.Get("/v2/clan/:clan_tag/badge", clanBadge(a))
-	app.Get("/v2/achievements", wrap(listAchievements(a)))
 	app.Post("/v2/achievements/check", wrap(checkAchievements(a)))
 
 	// Register the static server path before the generic two-parameter link paths.


### PR DESCRIPTION
## What changed

- adds authenticated `POST /v2/achievements/check`
- returns the complete achievement catalog with GLB asset URLs and per-account earned counts
- evaluates Town Hall 18 and 5,000-war-star achievements across verified linked players, with idempotent lifetime awards
- registers the route and regenerates the OpenAPI contracts

## Why

The app needs a stable account-scoped way to evaluate and persist achievements earned by verified Clash of Clans players. The check response includes the refreshed catalog, so a separate read endpoint is unnecessary.

## Stack

This is the third layer of the native API stack and targets `codex/app-audit-fixes-stacked` (PR #37), which targets `feat/golang-sql` (PR #36).

## Validation

- `git diff --check codex/app-audit-fixes-stacked...HEAD`
- `go test ./... -count=1`