### PR TITLE
feat(i18n): localize account emails

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,9 @@
+preserve_hierarchy: true
+
+files:
+  - source: /locales/en.json
+    dest: /api/en.json
+    translation: /locales/%locale%.json
+    update_option: update_as_unapproved
+
+commit_message: "chore(l10n): new Crowdin translations"

--- a/internal/models/v2/auth.go
+++ b/internal/models/v2/auth.go
@@ -45,10 +45,12 @@ type AuthEmailRegisterRequest struct {
 	Username   string `json:"username"`
 	DeviceID   string `json:"device_id"`
 	DeviceName string `json:"device_name"`
+	Locale     string `json:"locale,omitempty"`
 }
 
 type AuthForgotPasswordRequest struct {
-	Email string `json:"email"`
+	Email  string `json:"email"`
+	Locale string `json:"locale,omitempty"`
 }
 
 type AuthResetPasswordRequest struct {

--- a/internal/routes/auth.go
+++ b/internal/routes/auth.go
@@ -298,7 +298,8 @@ func register(a apptypes.Deps) fiber.Handler {
 		if err := insertEmailVerification(c.UserContext(), a, record); err != nil {
 			return err
 		}
-		if err := sendVerificationEmail(c.UserContext(), a, body.Email, body.Username, code); err != nil {
+		locale := requestedAuthLocale(c, body.Locale, "")
+		if err := sendVerificationEmail(c.UserContext(), a, body.Email, body.Username, code, locale); err != nil {
 			_ = deleteEmailVerification(c.UserContext(), a, emailHash)
 			return apptypes.Error(fiber.StatusServiceUnavailable, "Verification email could not be sent. Please try again.")
 		}
@@ -355,7 +356,8 @@ func resendVerification(a apptypes.Deps) fiber.Handler {
 		if err := insertEmailVerification(c.UserContext(), a, pending); err != nil {
 			return err
 		}
-		if err := sendVerificationEmail(c.UserContext(), a, body.Email, pending.Username, code); err != nil {
+		locale := requestedAuthLocale(c, body.Locale, "")
+		if err := sendVerificationEmail(c.UserContext(), a, body.Email, pending.Username, code, locale); err != nil {
 			return apptypes.Error(fiber.StatusServiceUnavailable, "Verification email could not be sent. Please try again.")
 		}
 		return apptypes.JSON(c, fiber.StatusOK, modelsv2.AuthVerificationResponse{
@@ -452,7 +454,9 @@ func forgotPassword(a apptypes.Deps) fiber.Handler {
 			apptypes.Logger().Error("password_reset_record_failed", "error", err, "email_hash", emailHash)
 			return apptypes.JSON(c, fiber.StatusOK, response)
 		}
-		if err := sendPasswordResetEmail(c.UserContext(), a, body.Email, authUserName(user), code); err != nil {
+		storedLocale := storedAuthLocale(c.UserContext(), a, user.UserID)
+		locale := requestedAuthLocale(c, body.Locale, storedLocale)
+		if err := sendPasswordResetEmail(c.UserContext(), a, body.Email, authUserName(user), code, locale); err != nil {
 			_ = deletePasswordReset(c.UserContext(), a, emailHash, code)
 			apptypes.Logger().Error("password_reset_email_failed", "error", err, "email_hash", emailHash)
 			return apptypes.JSON(c, fiber.StatusOK, response)
@@ -580,24 +584,52 @@ func localCodePtr(a apptypes.Deps, code string) *string {
 	return nil
 }
 
-func sendVerificationEmail(ctx context.Context, a apptypes.Deps, email, username, code string) error {
+func sendVerificationEmail(ctx context.Context, a apptypes.Deps, email, username, code, locale string) error {
 	if a.Mailer == nil {
 		if a.Config.Local {
 			return nil
 		}
 		return fmt.Errorf("mailer is not configured")
 	}
-	return a.Mailer.SendVerification(ctx, strings.TrimSpace(email), username, code)
+	return a.Mailer.SendVerification(ctx, strings.TrimSpace(email), username, code, locale)
 }
 
-func sendPasswordResetEmail(ctx context.Context, a apptypes.Deps, email, username, code string) error {
+func sendPasswordResetEmail(ctx context.Context, a apptypes.Deps, email, username, code, locale string) error {
 	if a.Mailer == nil {
 		if a.Config.Local {
 			return nil
 		}
 		return fmt.Errorf("mailer is not configured")
 	}
-	return a.Mailer.SendPasswordReset(ctx, strings.TrimSpace(email), username, code)
+	return a.Mailer.SendPasswordReset(ctx, strings.TrimSpace(email), username, code, locale)
+}
+
+func requestedAuthLocale(c *fiber.Ctx, explicit, stored string) string {
+	for _, candidate := range []string{explicit, c.Query("locale"), c.Get("X-Locale"), stored, c.Get("Accept-Language")} {
+		candidate = strings.TrimSpace(strings.Split(strings.Split(candidate, ",")[0], ";")[0])
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return "en"
+}
+
+func storedAuthLocale(ctx context.Context, a apptypes.Deps, userID string) string {
+	if a.Store.SQL == nil || strings.TrimSpace(userID) == "" {
+		return ""
+	}
+	var locale string
+	err := a.Store.SQL.QueryRow(ctx, `
+		SELECT locale
+		FROM mobile_push_devices
+		WHERE user_id = $1 AND locale IS NOT NULL AND locale <> ''
+		ORDER BY last_seen_at DESC
+		LIMIT 1
+	`, userID).Scan(&locale)
+	if err != nil {
+		return ""
+	}
+	return locale
 }
 
 func buildAuthResponse(a apptypes.Deps, user modelsv2.AuthUserInfo, deviceID string) (modelsv2.AuthResponse, error) {

--- a/internal/utils/mailer.go
+++ b/internal/utils/mailer.go
@@ -16,6 +16,8 @@ import (
 	"net/textproto"
 	"strings"
 	"time"
+
+	"github.com/ClashKingInc/ClashKingAPI/locales"
 )
 
 const authEmailLogoURL = "https://assets.clashk.ing/logos/crown-arrow-dark-bg/ClashKing-1.png"
@@ -34,38 +36,51 @@ type AuthEmail struct {
 	Security    string
 	Subject     string
 	PlainAction string
+	CodeLabel   string
+	Footer      string
+	Locale      string
 }
 
 func NewMailer(cfg Config) *Mailer {
 	return &Mailer{cfg: cfg}
 }
 
-func (m *Mailer) SendVerification(ctx context.Context, recipient, username, code string) error {
-	return m.sendAuthEmail(ctx, recipient, AuthEmail{
-		Subject:     "Your ClashKing verification code",
-		Title:       "Verify your email",
-		Preheader:   "Use this code to finish creating your ClashKing account.",
-		Greeting:    authEmailGreeting(username),
-		Body:        "Enter this code in ClashKing to verify your email address.",
-		Code:        code,
-		Expiry:      "This code expires in 15 minutes.",
-		Security:    "If you did not create a ClashKing account, you can ignore this email.",
-		PlainAction: "Enter this code in the ClashKing app to verify your email address.",
-	})
+func (m *Mailer) SendVerification(ctx context.Context, recipient, username, code, locale string) error {
+	return m.sendAuthEmail(ctx, recipient, localizedAuthEmail(locale, username, code, "verification"))
 }
 
-func (m *Mailer) SendPasswordReset(ctx context.Context, recipient, username, code string) error {
-	return m.sendAuthEmail(ctx, recipient, AuthEmail{
-		Subject:     "Reset your ClashKing password",
-		Title:       "Reset your password",
-		Preheader:   "Use this code to reset your ClashKing password.",
-		Greeting:    authEmailGreeting(username),
-		Body:        "Enter this code in ClashKing to choose a new password.",
+func (m *Mailer) SendPasswordReset(ctx context.Context, recipient, username, code, locale string) error {
+	return m.sendAuthEmail(ctx, recipient, localizedAuthEmail(locale, username, code, "password_reset"))
+}
+
+func localizedAuthEmail(locale, username, code, kind string) AuthEmail {
+	catalog, err := locales.Default()
+	if err != nil {
+		panic(err)
+	}
+	locale = catalog.Resolve(locale)
+	text := func(key string, params map[string]string) string { return catalog.Text(locale, key, params) }
+	greetingKey := "email.common.greeting"
+	params := map[string]string(nil)
+	if username = strings.TrimSpace(username); username != "" {
+		greetingKey = "email.common.greeting_named"
+		params = map[string]string{"name": username}
+	}
+	prefix := "email." + kind + "."
+	return AuthEmail{
+		Subject:     text(prefix+"subject", nil),
+		Title:       text(prefix+"heading", nil),
+		Preheader:   text(prefix+"preheader", nil),
+		Greeting:    text(greetingKey, params),
+		Body:        text(prefix+"body", nil),
 		Code:        code,
-		Expiry:      "This code expires in 1 hour.",
-		Security:    "Your password will not change unless this code is used. If you did not request a reset, you can ignore this email.",
-		PlainAction: "Enter this code in the ClashKing app to choose a new password.",
-	})
+		Expiry:      text(prefix+"expiry", nil),
+		Security:    text(prefix+"security", nil),
+		PlainAction: text(prefix+"plain_action", nil),
+		CodeLabel:   text("email.common.code_label", nil),
+		Footer:      text("email.common.footer", nil),
+		Locale:      locale,
+	}
 }
 
 func (m *Mailer) sendAuthEmail(ctx context.Context, recipient string, content AuthEmail) error {
@@ -89,7 +104,7 @@ func (m *Mailer) sendAuthEmail(ctx context.Context, recipient string, content Au
 	if err != nil {
 		return err
 	}
-	plainBody := fmt.Sprintf("%s\n\n%s\n\n%s\n\nCode: %s\n\n%s\n\n%s\n\nClashKing\n", content.Title, content.Greeting, content.PlainAction, content.Code, content.Expiry, content.Security)
+	plainBody := fmt.Sprintf("%s\n\n%s\n\n%s\n\n%s: %s\n\n%s\n\n%s\n\n%s\n", content.Title, content.Greeting, content.PlainAction, content.CodeLabel, content.Code, content.Expiry, content.Security, content.Footer)
 	message, err := buildMIMEMessage(senderAddress, recipientAddress, replyTo, content.Subject, plainBody, htmlBody)
 	if err != nil {
 		return err
@@ -203,16 +218,8 @@ func renderAuthEmail(content AuthEmail) (string, error) {
 	return output.String(), err
 }
 
-func authEmailGreeting(username string) string {
-	username = strings.TrimSpace(username)
-	if username == "" {
-		return "Hello,"
-	}
-	return "Hello " + username + ","
-}
-
 var authEmailTemplate = template.Must(template.New("auth-email").Parse(`<!doctype html>
-<html lang="en">
+<html lang="{{.Locale}}">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{{.Title}}</title></head>
 <body style="margin:0;padding:0;background:#f4f4f4;color:#171719;font-family:Roboto,Arial,sans-serif;">
 <div style="display:none;max-height:0;overflow:hidden;opacity:0;">{{.Preheader}}</div>
@@ -224,7 +231,7 @@ var authEmailTemplate = template.Must(template.New("auth-email").Parse(`<!doctyp
 <tr><td align="center" style="padding:28px;"><div style="display:inline-block;padding:18px 24px;border:2px solid #bf0000;border-radius:12px;background:#fff6f6;color:#a90000;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:34px;line-height:1;font-weight:800;letter-spacing:8px;">{{.Code}}</div></td></tr>
 <tr><td style="padding:0 28px 16px;font-size:14px;line-height:1.5;color:#55555c;"><p style="margin:0;font-weight:700;">{{.Expiry}}</p></td></tr>
 <tr><td style="padding:0 28px 32px;font-size:14px;line-height:1.55;color:#55555c;"><div style="padding:14px 16px;background:#f2f7fb;border-left:4px solid #026cc2;border-radius:8px;">{{.Security}}</div></td></tr>
-<tr><td style="padding:20px 28px;background:#f7f7f8;border-top:1px solid #e5e5e8;font-size:12px;line-height:1.5;color:#6a6a72;">This is an automated security email from ClashKing. Never share this code with anyone.</td></tr>
+<tr><td style="padding:20px 28px;background:#f7f7f8;border-top:1px solid #e5e5e8;font-size:12px;line-height:1.5;color:#6a6a72;">{{.Footer}}</td></tr>
 </table>
 </td></tr></table>
 </body></html>`))

--- a/internal/utils/mailer_test.go
+++ b/internal/utils/mailer_test.go
@@ -39,3 +39,18 @@ func TestBuildMIMEMessageIncludesTextAndHTML(t *testing.T) {
 		}
 	}
 }
+
+func TestLocalizedAuthEmailUsesCatalogAndFallback(t *testing.T) {
+	content := localizedAuthEmail("en-US", "Ada", "123456", "verification")
+	if content.Subject != "Your ClashKing verification code" || content.Greeting != "Hello Ada," {
+		t.Fatalf("unexpected localized verification content: %#v", content)
+	}
+	if content.Footer == "" || content.CodeLabel != "Code" || content.Locale != "en" {
+		t.Fatalf("missing localized common content: %#v", content)
+	}
+
+	fallback := localizedAuthEmail("zz-ZZ", "", "654321", "password_reset")
+	if fallback.Subject != "Reset your ClashKing password" || fallback.Greeting != "Hello," || fallback.Locale != "en" {
+		t.Fatalf("unsupported locale did not fall back to English: %#v", fallback)
+	}
+}

--- a/locales/catalog.go
+++ b/locales/catalog.go
@@ -1,0 +1,118 @@
+package locales
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/text/language"
+)
+
+const English = "en"
+
+//go:embed *.json
+var embedded embed.FS
+
+type Catalog struct {
+	translations map[string]map[string]string
+	matcher      language.Matcher
+	tags         []language.Tag
+}
+
+var (
+	defaultCatalog *Catalog
+	defaultErr     error
+	defaultOnce    sync.Once
+)
+
+func Default() (*Catalog, error) {
+	defaultOnce.Do(func() { defaultCatalog, defaultErr = Load(embedded) })
+	return defaultCatalog, defaultErr
+}
+
+func Load(files fs.FS) (*Catalog, error) {
+	entries, err := fs.ReadDir(files, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read locale catalogs: %w", err)
+	}
+	c := &Catalog{translations: make(map[string]map[string]string)}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := fs.ReadFile(files, entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("read locale %s: %w", entry.Name(), err)
+		}
+		values := map[string]string{}
+		if err := json.Unmarshal(data, &values); err != nil {
+			return nil, fmt.Errorf("decode locale %s: %w", entry.Name(), err)
+		}
+		locale := Normalize(strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())))
+		c.translations[locale] = values
+	}
+	if _, ok := c.translations[English]; !ok {
+		return nil, fmt.Errorf("English locale catalog is required")
+	}
+	c.tags = []language.Tag{language.English}
+	for locale := range c.translations {
+		if locale == English {
+			continue
+		}
+		if tag, err := language.Parse(locale); err == nil {
+			c.tags = append(c.tags, tag)
+		}
+	}
+	c.matcher = language.NewMatcher(c.tags)
+	return c, nil
+}
+
+func Normalize(locale string) string {
+	locale = strings.TrimSpace(strings.ReplaceAll(locale, "_", "-"))
+	if locale == "" {
+		return English
+	}
+	tag, err := language.Parse(locale)
+	if err != nil {
+		return English
+	}
+	base, _ := tag.Base()
+	if base.String() == "und" {
+		return English
+	}
+	return tag.String()
+}
+
+func (c *Catalog) Resolve(locale string) string {
+	if c == nil {
+		return English
+	}
+	tag, err := language.Parse(Normalize(locale))
+	if err != nil {
+		return English
+	}
+	_, index, confidence := c.matcher.Match(tag)
+	if confidence == language.No {
+		return English
+	}
+	return c.tags[index].String()
+}
+
+func (c *Catalog) Text(locale, key string, params map[string]string) string {
+	resolved := c.Resolve(locale)
+	value := c.translations[resolved][key]
+	if value == "" {
+		value = c.translations[English][key]
+	}
+	if value == "" {
+		return key
+	}
+	for name, replacement := range params {
+		value = strings.ReplaceAll(value, "{{"+name+"}}", replacement)
+	}
+	return value
+}

--- a/locales/catalog_test.go
+++ b/locales/catalog_test.go
@@ -1,0 +1,38 @@
+package locales
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestCatalogLocaleResolutionInterpolationAndFallback(t *testing.T) {
+	catalog, err := Load(fstest.MapFS{
+		"en.json": &fstest.MapFile{Data: []byte(`{"hello":"Hello {{name}}","fallback":"English only"}`)},
+		"fr.json": &fstest.MapFile{Data: []byte(`{"hello":"Bonjour {{name}}"}`)},
+	})
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if got := catalog.Text("en-US", "hello", map[string]string{"name": "Ada"}); got != "Hello Ada" {
+		t.Fatalf("English interpolation = %q", got)
+	}
+	if got := catalog.Text("fr_CA", "hello", map[string]string{"name": "Ada"}); got != "Bonjour Ada" {
+		t.Fatalf("French locale normalization/interpolation = %q", got)
+	}
+	if got := catalog.Text("fr", "fallback", nil); got != "English only" {
+		t.Fatalf("missing-key fallback = %q", got)
+	}
+	if got := catalog.Text("zz-ZZ", "hello", map[string]string{"name": "Ada"}); got != "Hello Ada" {
+		t.Fatalf("unsupported-locale fallback = %q", got)
+	}
+}
+
+func TestDefaultEnglishCatalogLoads(t *testing.T) {
+	catalog, err := Default()
+	if err != nil {
+		t.Fatalf("load embedded catalog: %v", err)
+	}
+	if got := catalog.Text("en", "email.verification.subject", nil); got != "Your ClashKing verification code" {
+		t.Fatalf("verification subject = %q", got)
+	}
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,20 @@
+{
+  "email.common.footer": "This is an automated security email from ClashKing. Never share this code with anyone.",
+  "email.common.code_label": "Code",
+  "email.common.greeting": "Hello,",
+  "email.common.greeting_named": "Hello {{name}},",
+  "email.verification.subject": "Your ClashKing verification code",
+  "email.verification.heading": "Verify your email",
+  "email.verification.preheader": "Use this code to finish creating your ClashKing account.",
+  "email.verification.body": "Enter this code in ClashKing to verify your email address.",
+  "email.verification.expiry": "This code expires in 15 minutes.",
+  "email.verification.security": "If you did not create a ClashKing account, you can ignore this email.",
+  "email.verification.plain_action": "Enter this code in the ClashKing app to verify your email address.",
+  "email.password_reset.subject": "Reset your ClashKing password",
+  "email.password_reset.heading": "Reset your password",
+  "email.password_reset.preheader": "Use this code to reset your ClashKing password.",
+  "email.password_reset.body": "Enter this code in ClashKing to choose a new password.",
+  "email.password_reset.expiry": "This code expires in 1 hour.",
+  "email.password_reset.security": "Your password will not change unless this code is used. If you did not request a reset, you can ignore this email.",
+  "email.password_reset.plain_action": "Enter this code in the ClashKing app to choose a new password."
+}


### PR DESCRIPTION
## What changed

- add an embedded JSON localization catalog with BCP-47 normalization and English fallback
- move verification and password-reset email copy, including HTML and plain-text content, into the catalog
- resolve explicit request locales, locale headers, and stored mobile-device preferences for account emails
- add Crowdin configuration and focused localization tests

## Impact

Account security emails can now use translated catalogs as they become available, while unsupported locales and missing keys remain safely readable in English. Existing stable API error codes are unchanged, and logs and internal errors remain unlocalized.

## Validation

- `go test ./locales ./internal/utils ./internal/routes`
- `git diff --check`
