### PR TITLE
feat(search): add Elasticsearch clan and player queries

### DIFF
--- a/example.env
+++ b/example.env
@@ -11,6 +11,12 @@ VALKEY_HOST=valkey
 VALKEY_PORT=6379
 VALKEY_PASSWORD=replace_me
 
+# Read-only Elasticsearch search access. Use a separate API key from PGSync.
+ELASTICSEARCH_URL=http://elasticsearch:9200
+ELASTICSEARCH_API_KEY=replace_with_base64_api_key_credential
+ELASTICSEARCH_PLAYERS_ALIAS=clashking_players
+ELASTICSEARCH_CLANS_ALIAS=clashking_clans
+
 # ClashKing service origins. Origins never include API path prefixes.
 CLASHKING_LANDING_ORIGIN=https://clashk.ing
 CLASHKING_DASHBOARD_ORIGIN=https://dash.clashk.ing

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -7506,33 +7506,27 @@ const docTemplate = `{
             }
         },
         "/v2/search/clan": {
-            "get": {
-                "description": "Returns clans from recent searches, bookmarks, guild-linked clans, and CoC API.",
+            "post": {
+                "description": "Searches the clan Elasticsearch alias by name or exact tag with optional filters and cursor pagination.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Search"
                 ],
-                "summary": "Search for a clan by name or tag",
+                "summary": "Search clans",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "Search query (clan name or tag)",
-                        "name": "query",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Discord user ID for personalised results",
-                        "name": "user_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Discord guild ID for guild clan filtering",
-                        "name": "guild_id",
-                        "in": "query"
+                        "description": "Clan search query",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.SearchClanQuery"
+                        }
                     }
                 ],
                 "responses": {
@@ -7541,8 +7535,80 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/modelsv2.SearchClanResponse"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
                     }
-                }
+                },
+                "x-http-method": "QUERY"
+            }
+        },
+        "/v2/search/player": {
+            "post": {
+                "description": "Searches the player Elasticsearch alias by name or exact tag with optional filters and cursor pagination.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Search"
+                ],
+                "summary": "Search players",
+                "parameters": [
+                    {
+                        "description": "Player search query",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.SearchPlayerQuery"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.SearchPlayerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                },
+                "x-http-method": "QUERY"
             }
         },
         "/v2/search/{guild_id}/banned-players": {
@@ -20406,6 +20472,56 @@ const docTemplate = `{
                 }
             }
         },
+        "modelsv2.SearchClanFilters": {
+            "type": "object",
+            "properties": {
+                "clan_level": {
+                    "$ref": "#/definitions/modelsv2.SearchIntegerRange"
+                },
+                "cwl_league_ids": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "location_ids": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "members": {
+                    "$ref": "#/definitions/modelsv2.SearchIntegerRange"
+                }
+            }
+        },
+        "modelsv2.SearchClanQuery": {
+            "type": "object",
+            "required": [
+                "query"
+            ],
+            "properties": {
+                "cursor": {
+                    "type": "string"
+                },
+                "filters": {
+                    "$ref": "#/definitions/modelsv2.SearchClanFilters"
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "maximum": 200,
+                    "minimum": 1
+                },
+                "query": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2
+                }
+            }
+        },
         "modelsv2.SearchClanResponse": {
             "type": "object",
             "properties": {
@@ -20414,16 +20530,25 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/modelsv2.SearchClanResult"
                     }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/modelsv2.SearchCursorPage"
                 }
             }
         },
         "modelsv2.SearchClanResult": {
             "type": "object",
             "properties": {
-                "level": {
+                "badge": {
+                    "type": "string"
+                },
+                "clanLevel": {
                     "type": "integer"
                 },
-                "memberCount": {
+                "location": {
+                    "$ref": "#/definitions/modelsv2.SearchLocation"
+                },
+                "members": {
                     "type": "integer"
                 },
                 "name": {
@@ -20432,11 +20557,134 @@ const docTemplate = `{
                 "tag": {
                     "type": "string"
                 },
-                "type": {
+                "warLeague": {
+                    "$ref": "#/definitions/modelsv2.SearchLeagueReference"
+                }
+            }
+        },
+        "modelsv2.SearchCursorPage": {
+            "type": "object",
+            "properties": {
+                "has_more": {
+                    "type": "boolean"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "next_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchIntegerRange": {
+            "type": "object",
+            "properties": {
+                "max": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "min": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            }
+        },
+        "modelsv2.SearchLeagueReference": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchLocation": {
+            "type": "object",
+            "properties": {
+                "countryCode": {
                     "type": "string"
                 },
-                "warLeague": {
+                "id": {
+                    "type": "integer"
+                },
+                "isCountry": {
+                    "type": "boolean"
+                },
+                "localizedName": {
                     "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchPlayerClan": {
+            "type": "object",
+            "properties": {
+                "badge": {
+                    "type": "string"
+                },
+                "clanLevel": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchPlayerFilters": {
+            "type": "object",
+            "properties": {
+                "clan_tags": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "league_ids": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "townhall_levels": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "modelsv2.SearchPlayerQuery": {
+            "type": "object",
+            "required": [
+                "query"
+            ],
+            "properties": {
+                "cursor": {
+                    "type": "string"
+                },
+                "filters": {
+                    "$ref": "#/definitions/modelsv2.SearchPlayerFilters"
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "maximum": 200,
+                    "minimum": 1
+                },
+                "query": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2
                 }
             }
         },
@@ -20459,6 +20707,40 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/modelsv2.SearchPlayerReference"
                     }
+                }
+            }
+        },
+        "modelsv2.SearchPlayerResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/modelsv2.SearchPlayerResult"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/modelsv2.SearchCursorPage"
+                }
+            }
+        },
+        "modelsv2.SearchPlayerResult": {
+            "type": "object",
+            "properties": {
+                "clan": {
+                    "$ref": "#/definitions/modelsv2.SearchPlayerClan"
+                },
+                "leagueTier": {
+                    "$ref": "#/definitions/modelsv2.SearchLeagueReference"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "townHallLevel": {
+                    "type": "integer"
                 }
             }
         },

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -7499,33 +7499,27 @@
             }
         },
         "/v2/search/clan": {
-            "get": {
-                "description": "Returns clans from recent searches, bookmarks, guild-linked clans, and CoC API.",
+            "post": {
+                "description": "Searches the clan Elasticsearch alias by name or exact tag with optional filters and cursor pagination.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Search"
                 ],
-                "summary": "Search for a clan by name or tag",
+                "summary": "Search clans",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "Search query (clan name or tag)",
-                        "name": "query",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Discord user ID for personalised results",
-                        "name": "user_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Discord guild ID for guild clan filtering",
-                        "name": "guild_id",
-                        "in": "query"
+                        "description": "Clan search query",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.SearchClanQuery"
+                        }
                     }
                 ],
                 "responses": {
@@ -7534,8 +7528,80 @@
                         "schema": {
                             "$ref": "#/definitions/modelsv2.SearchClanResponse"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
                     }
-                }
+                },
+                "x-http-method": "QUERY"
+            }
+        },
+        "/v2/search/player": {
+            "post": {
+                "description": "Searches the player Elasticsearch alias by name or exact tag with optional filters and cursor pagination.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Search"
+                ],
+                "summary": "Search players",
+                "parameters": [
+                    {
+                        "description": "Player search query",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.SearchPlayerQuery"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.SearchPlayerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                },
+                "x-http-method": "QUERY"
             }
         },
         "/v2/search/{guild_id}/banned-players": {
@@ -20399,6 +20465,56 @@
                 }
             }
         },
+        "modelsv2.SearchClanFilters": {
+            "type": "object",
+            "properties": {
+                "clan_level": {
+                    "$ref": "#/definitions/modelsv2.SearchIntegerRange"
+                },
+                "cwl_league_ids": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "location_ids": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "members": {
+                    "$ref": "#/definitions/modelsv2.SearchIntegerRange"
+                }
+            }
+        },
+        "modelsv2.SearchClanQuery": {
+            "type": "object",
+            "required": [
+                "query"
+            ],
+            "properties": {
+                "cursor": {
+                    "type": "string"
+                },
+                "filters": {
+                    "$ref": "#/definitions/modelsv2.SearchClanFilters"
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "maximum": 200,
+                    "minimum": 1
+                },
+                "query": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2
+                }
+            }
+        },
         "modelsv2.SearchClanResponse": {
             "type": "object",
             "properties": {
@@ -20407,16 +20523,25 @@
                     "items": {
                         "$ref": "#/definitions/modelsv2.SearchClanResult"
                     }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/modelsv2.SearchCursorPage"
                 }
             }
         },
         "modelsv2.SearchClanResult": {
             "type": "object",
             "properties": {
-                "level": {
+                "badge": {
+                    "type": "string"
+                },
+                "clanLevel": {
                     "type": "integer"
                 },
-                "memberCount": {
+                "location": {
+                    "$ref": "#/definitions/modelsv2.SearchLocation"
+                },
+                "members": {
                     "type": "integer"
                 },
                 "name": {
@@ -20425,11 +20550,134 @@
                 "tag": {
                     "type": "string"
                 },
-                "type": {
+                "warLeague": {
+                    "$ref": "#/definitions/modelsv2.SearchLeagueReference"
+                }
+            }
+        },
+        "modelsv2.SearchCursorPage": {
+            "type": "object",
+            "properties": {
+                "has_more": {
+                    "type": "boolean"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "next_cursor": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchIntegerRange": {
+            "type": "object",
+            "properties": {
+                "max": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "min": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            }
+        },
+        "modelsv2.SearchLeagueReference": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchLocation": {
+            "type": "object",
+            "properties": {
+                "countryCode": {
                     "type": "string"
                 },
-                "warLeague": {
+                "id": {
+                    "type": "integer"
+                },
+                "isCountry": {
+                    "type": "boolean"
+                },
+                "localizedName": {
                     "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchPlayerClan": {
+            "type": "object",
+            "properties": {
+                "badge": {
+                    "type": "string"
+                },
+                "clanLevel": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "modelsv2.SearchPlayerFilters": {
+            "type": "object",
+            "properties": {
+                "clan_tags": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "league_ids": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "townhall_levels": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "modelsv2.SearchPlayerQuery": {
+            "type": "object",
+            "required": [
+                "query"
+            ],
+            "properties": {
+                "cursor": {
+                    "type": "string"
+                },
+                "filters": {
+                    "$ref": "#/definitions/modelsv2.SearchPlayerFilters"
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "maximum": 200,
+                    "minimum": 1
+                },
+                "query": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 2
                 }
             }
         },
@@ -20452,6 +20700,40 @@
                     "items": {
                         "$ref": "#/definitions/modelsv2.SearchPlayerReference"
                     }
+                }
+            }
+        },
+        "modelsv2.SearchPlayerResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/modelsv2.SearchPlayerResult"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/modelsv2.SearchCursorPage"
+                }
+            }
+        },
+        "modelsv2.SearchPlayerResult": {
+            "type": "object",
+            "properties": {
+                "clan": {
+                    "$ref": "#/definitions/modelsv2.SearchPlayerClan"
+                },
+                "leagueTier": {
+                    "$ref": "#/definitions/modelsv2.SearchLeagueReference"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "townHallLevel": {
+                    "type": "integer"
                 }
             }
         },

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -4382,27 +4382,151 @@ definitions:
         - clan
         type: string
     type: object
+  modelsv2.SearchClanFilters:
+    properties:
+      clan_level:
+        $ref: '#/definitions/modelsv2.SearchIntegerRange'
+      cwl_league_ids:
+        items:
+          type: integer
+        maxItems: 5
+        type: array
+      location_ids:
+        items:
+          type: integer
+        maxItems: 5
+        type: array
+      members:
+        $ref: '#/definitions/modelsv2.SearchIntegerRange'
+    type: object
+  modelsv2.SearchClanQuery:
+    properties:
+      cursor:
+        type: string
+      filters:
+        $ref: '#/definitions/modelsv2.SearchClanFilters'
+      limit:
+        default: 25
+        maximum: 200
+        minimum: 1
+        type: integer
+      query:
+        maxLength: 100
+        minLength: 2
+        type: string
+    required:
+    - query
+    type: object
   modelsv2.SearchClanResponse:
     properties:
       items:
         items:
           $ref: '#/definitions/modelsv2.SearchClanResult'
         type: array
+      pagination:
+        $ref: '#/definitions/modelsv2.SearchCursorPage'
     type: object
   modelsv2.SearchClanResult:
     properties:
-      level:
+      badge:
+        type: string
+      clanLevel:
         type: integer
-      memberCount:
+      location:
+        $ref: '#/definitions/modelsv2.SearchLocation'
+      members:
         type: integer
       name:
         type: string
       tag:
         type: string
-      type:
-        type: string
       warLeague:
+        $ref: '#/definitions/modelsv2.SearchLeagueReference'
+    type: object
+  modelsv2.SearchCursorPage:
+    properties:
+      has_more:
+        type: boolean
+      limit:
+        type: integer
+      next_cursor:
         type: string
+    type: object
+  modelsv2.SearchIntegerRange:
+    properties:
+      max:
+        minimum: 0
+        type: integer
+      min:
+        minimum: 0
+        type: integer
+    type: object
+  modelsv2.SearchLeagueReference:
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+    type: object
+  modelsv2.SearchLocation:
+    properties:
+      countryCode:
+        type: string
+      id:
+        type: integer
+      isCountry:
+        type: boolean
+      localizedName:
+        type: string
+      name:
+        type: string
+    type: object
+  modelsv2.SearchPlayerClan:
+    properties:
+      badge:
+        type: string
+      clanLevel:
+        type: integer
+      name:
+        type: string
+      tag:
+        type: string
+    type: object
+  modelsv2.SearchPlayerFilters:
+    properties:
+      clan_tags:
+        items:
+          type: string
+        maxItems: 100
+        type: array
+      league_ids:
+        items:
+          type: integer
+        maxItems: 5
+        type: array
+      townhall_levels:
+        items:
+          type: integer
+        maxItems: 100
+        type: array
+    type: object
+  modelsv2.SearchPlayerQuery:
+    properties:
+      cursor:
+        type: string
+      filters:
+        $ref: '#/definitions/modelsv2.SearchPlayerFilters'
+      limit:
+        default: 25
+        maximum: 200
+        minimum: 1
+        type: integer
+      query:
+        maxLength: 100
+        minLength: 2
+        type: string
+    required:
+    - query
     type: object
   modelsv2.SearchPlayerReference:
     properties:
@@ -4417,6 +4541,28 @@ definitions:
         items:
           $ref: '#/definitions/modelsv2.SearchPlayerReference'
         type: array
+    type: object
+  modelsv2.SearchPlayerResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/modelsv2.SearchPlayerResult'
+        type: array
+      pagination:
+        $ref: '#/definitions/modelsv2.SearchCursorPage'
+    type: object
+  modelsv2.SearchPlayerResult:
+    properties:
+      clan:
+        $ref: '#/definitions/modelsv2.SearchPlayerClan'
+      leagueTier:
+        $ref: '#/definitions/modelsv2.SearchLeagueReference'
+      name:
+        type: string
+      tag:
+        type: string
+      townHallLevel:
+        type: integer
     type: object
   modelsv2.SearchRecentBadgeURLs:
     properties:
@@ -11047,22 +11193,18 @@ paths:
       tags:
       - Search
   /v2/search/clan:
-    get:
-      description: Returns clans from recent searches, bookmarks, guild-linked clans,
-        and CoC API.
+    post:
+      consumes:
+      - application/json
+      description: Searches the clan Elasticsearch alias by name or exact tag with
+        optional filters and cursor pagination.
       parameters:
-      - description: Search query (clan name or tag)
-        in: query
-        name: query
-        type: string
-      - description: Discord user ID for personalised results
-        in: query
-        name: user_id
-        type: integer
-      - description: Discord guild ID for guild clan filtering
-        in: query
-        name: guild_id
-        type: integer
+      - description: Clan search query
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/modelsv2.SearchClanQuery'
       produces:
       - application/json
       responses:
@@ -11070,9 +11212,58 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/modelsv2.SearchClanResponse'
-      summary: Search for a clan by name or tag
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+        "415":
+          description: Unsupported Media Type
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+      summary: Search clans
       tags:
       - Search
+      x-http-method: QUERY
+  /v2/search/player:
+    post:
+      consumes:
+      - application/json
+      description: Searches the player Elasticsearch alias by name or exact tag with
+        optional filters and cursor pagination.
+      parameters:
+      - description: Player search query
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/modelsv2.SearchPlayerQuery'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/modelsv2.SearchPlayerResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+        "415":
+          description: Unsupported Media Type
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/modelsv2.ErrorResponse'
+      summary: Search players
+      tags:
+      - Search
+      x-http-method: QUERY
   /v2/server/{server_id}/autoboards:
     get:
       description: Returns typed autoboards and resolves each stored webhook back

--- a/internal/models/v2/search.go
+++ b/internal/models/v2/search.go
@@ -1,16 +1,89 @@
 package modelsv2
 
+type SearchIntegerRange struct {
+	Min *int `json:"min,omitempty" minimum:"0"`
+	Max *int `json:"max,omitempty" minimum:"0"`
+}
+
+type SearchClanFilters struct {
+	LocationIDs  []int               `json:"location_ids,omitempty" validate:"max=5"`
+	CWLLeagueIDs []int               `json:"cwl_league_ids,omitempty" validate:"max=5"`
+	ClanLevel    *SearchIntegerRange `json:"clan_level,omitempty"`
+	Members      *SearchIntegerRange `json:"members,omitempty"`
+}
+
+type SearchPlayerFilters struct {
+	ClanTags       []string `json:"clan_tags,omitempty" validate:"max=100"`
+	LeagueIDs      []int    `json:"league_ids,omitempty" validate:"max=5"`
+	TownhallLevels []int    `json:"townhall_levels,omitempty" validate:"max=100"`
+}
+
+type SearchClanQuery struct {
+	Query   string            `json:"query" binding:"required" minLength:"2" maxLength:"100"`
+	Filters SearchClanFilters `json:"filters"`
+	Limit   int               `json:"limit,omitempty" minimum:"1" maximum:"200" default:"25"`
+	Cursor  string            `json:"cursor,omitempty"`
+}
+
+type SearchPlayerQuery struct {
+	Query   string              `json:"query" binding:"required" minLength:"2" maxLength:"100"`
+	Filters SearchPlayerFilters `json:"filters"`
+	Limit   int                 `json:"limit,omitempty" minimum:"1" maximum:"200" default:"25"`
+	Cursor  string              `json:"cursor,omitempty"`
+}
+
+type SearchLocation struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	IsCountry     bool   `json:"isCountry"`
+	CountryCode   string `json:"countryCode,omitempty"`
+	LocalizedName string `json:"localizedName,omitempty"`
+}
+
+type SearchLeagueReference struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
 type SearchClanResult struct {
-	Name        string `json:"name"`
-	Tag         string `json:"tag"`
-	MemberCount int    `json:"memberCount"`
-	Level       int    `json:"level"`
-	WarLeague   string `json:"warLeague"`
-	Type        string `json:"type"`
+	Name      string                 `json:"name"`
+	Tag       string                 `json:"tag"`
+	Badge     string                 `json:"badge,omitempty"`
+	ClanLevel int                    `json:"clanLevel"`
+	Location  *SearchLocation        `json:"location,omitempty"`
+	WarLeague *SearchLeagueReference `json:"warLeague,omitempty"`
+	Members   int                    `json:"members"`
+}
+
+type SearchPlayerClan struct {
+	Name      string `json:"name,omitempty"`
+	Tag       string `json:"tag"`
+	Badge     string `json:"badge,omitempty"`
+	ClanLevel int    `json:"clanLevel,omitempty"`
+}
+
+type SearchPlayerResult struct {
+	Name          string                 `json:"name"`
+	Tag           string                 `json:"tag"`
+	TownHallLevel int                    `json:"townHallLevel"`
+	LeagueTier    *SearchLeagueReference `json:"leagueTier,omitempty"`
+	Clan          *SearchPlayerClan      `json:"clan,omitempty"`
+}
+
+type SearchCursorPage struct {
+	Limit      int     `json:"limit"`
+	HasMore    bool    `json:"has_more"`
+	NextCursor *string `json:"next_cursor"`
 }
 
 type SearchClanResponse struct {
-	Items []SearchClanResult `json:"items"`
+	Items      []SearchClanResult `json:"items"`
+	Pagination SearchCursorPage   `json:"pagination"`
+}
+
+type SearchPlayerResponse struct {
+	Items      []SearchPlayerResult `json:"items"`
+	Pagination SearchCursorPage     `json:"pagination"`
 }
 
 type SearchPlayerReference struct {

--- a/internal/routes/register.go
+++ b/internal/routes/register.go
@@ -206,7 +206,8 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 	app.Get("/v2/player/:player_tag/join-leave/shared", playerJoinLeaveShared(a))
 	app.Get("/v2/player/:player_tag/join-leave", playerJoinLeave(a))
 
-	app.Get("/v2/search/clan", searchClan(a))
+	app.Add(apptypes.MethodQuery, "/v2/search/clan", searchClans(a))
+	app.Add(apptypes.MethodQuery, "/v2/search/player", searchPlayers(a))
 	app.Get("/v2/search/:guild_id/banned-players", authServerParamRead(a, wrap, "guild_id", searchBannedPlayers(a)))
 
 	app.Get("/v2/link/server/:server_id/clan/list", serverRead(serverroutes.GetServerClansBasic(a)))

--- a/internal/routes/register_test.go
+++ b/internal/routes/register_test.go
@@ -281,6 +281,22 @@ func TestHomeActivityUsesRFCQueryMethod(t *testing.T) {
 	}
 }
 
+func TestSearchRoutesUseRFCQueryMethod(t *testing.T) {
+	app := newRegisteredRoutesTestApp()
+	Register(app, apptypes.Deps{}, func(next fiber.Handler) fiber.Handler { return next })
+
+	for _, path := range []string{"/v2/search/clan", "/v2/search/player"} {
+		if index := registeredRouteIndex(app, apptypes.MethodQuery, path); index < 0 {
+			t.Fatalf("expected %s to be registered with QUERY", path)
+		}
+		for _, method := range []string{fiber.MethodGet, fiber.MethodPost} {
+			if index := registeredRouteIndex(app, method, path); index >= 0 {
+				t.Fatalf("did not expect a %s compatibility route for %s", method, path)
+			}
+		}
+	}
+}
+
 func TestAutoboardsUseCleanBreakRoutes(t *testing.T) {
 	app := newRegisteredRoutesTestApp()
 	Register(app, apptypes.Deps{}, func(next fiber.Handler) fiber.Handler { return next })

--- a/internal/routes/search.go
+++ b/internal/routes/search.go
@@ -1,375 +1,623 @@
 package routes
 
 import (
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
 	"encoding/json"
+	"net/http"
+	"net/url"
 	"regexp"
-	"strconv"
+	"sort"
 	"strings"
+	"sync"
+	"time"
 
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
 	clashy "github.com/clashkinginc/clashy.go"
 	"github.com/gofiber/fiber/v2"
 )
 
 const (
-	searchTypeBookmarked = "bookmarked"
-	searchTypeRecent     = "recent_search"
-	searchTypeGuild      = "guild_search"
-	searchTypeResult     = "search_result"
+	searchDefaultLimit = 25
+	searchMaximumLimit = 200
+	searchPITKeepAlive = "2m"
+	searchCursorTTL    = 2 * time.Minute
 )
 
-var searchTypeFieldMap = map[int64]string{0: "player", 1: "clan"}
+var searchTagPattern = regexp.MustCompile(`^[PYLQGRJCUV0289]{3,15}$`)
 
-// searchClan godoc
-// @Summary Search for a clan by name or tag
-// @Description Returns clans from recent searches, bookmarks, guild-linked clans, and CoC API.
-// @Tags Search
-// @Produce json
-// @Param query query string false "Search query (clan name or tag)"
-// @Param user_id query int false "Discord user ID for personalised results"
-// @Param guild_id query int false "Discord guild ID for guild clan filtering"
-// @Success 200 {object} modelsv2.SearchClanResponse
-// @Router /v2/search/clan [get]
-func searchClan(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		query := c.Query("query")
-		userID, _ := strconv.ParseInt(c.Query("user_id"), 10, 64)
-		guildID, _ := strconv.ParseInt(c.Query("guild_id"), 10, 64)
+// search_locations.json is a checked-in snapshot of the official Clash of
+// Clans location catalog. Search enrichment must never make a Clash API call.
+//
+//go:embed search_locations.json
+var searchLocationsJSON []byte
 
-		// Fetch user's bookmarks and recent searches
-		recentTags, bookmarkedTags := searchFetchUserData(c, a, userID)
-
-		// Fetch guild-linked clan tags
-		guildTags := searchFetchGuildClans(c, a, guildID, query)
-
-		// Combine all tags (deduplicated)
-		allTagsSet := make(map[string]struct{})
-		for _, t := range recentTags {
-			allTagsSet[t] = struct{}{}
-		}
-		for _, t := range bookmarkedTags {
-			allTagsSet[t] = struct{}{}
-		}
-		for _, t := range guildTags {
-			allTagsSet[t] = struct{}{}
-		}
-		allTags := make([]string, 0, len(allTagsSet))
-		for t := range allTagsSet {
-			allTags = append(allTags, t)
-		}
-
-		// Fetch from local BasicClan DB
-		localClans := searchFetchLocalClans(c, a, allTags)
-		finalData := make([]map[string]any, 0, len(localClans)+5)
-		foundTags := make(map[string]struct{}, len(localClans))
-
-		for _, doc := range localClans {
-			tag := searchGetString(doc, "tag")
-			findType := searchDetermineType(tag, bookmarkedTags, recentTags)
-			finalData = append(finalData, searchBuildClanFromDB(doc, findType))
-			foundTags[tag] = struct{}{}
-		}
-
-		// Fetch remaining tags from CoC API
-		for _, tag := range allTags {
-			if _, exists := foundTags[tag]; exists {
-				continue
-			}
-			clan, err := a.Clash.GetClan(c.UserContext(), tag)
-			if err != nil || clan == nil {
-				continue
-			}
-			findType := searchDetermineType(clan.Tag, bookmarkedTags, recentTags)
-			finalData = append(finalData, map[string]any{
-				"name":        clan.Name,
-				"tag":         clan.Tag,
-				"memberCount": len(clan.Members),
-				"level":       0,
-				"warLeague":   "Unknown",
-				"type":        findType,
-			})
-			foundTags[clan.Tag] = struct{}{}
-		}
-
-		// Filter by query
-		if query != "" {
-			queryLower := strings.ToLower(query)
-			filtered := finalData[:0]
-			for _, clan := range finalData {
-				name := strings.ToLower(searchGetString(clan, "name"))
-				tag := strings.ToLower(searchGetString(clan, "tag"))
-				if strings.Contains(name, queryLower) || tag == queryLower {
-					filtered = append(filtered, clan)
-				}
-			}
-			finalData = filtered
-		}
-
-		// Sort by type priority
-		searchSortByType(finalData)
-
-		return apptypes.JSON(c, fiber.StatusOK, map[string]any{"items": finalData})
-	}
+var searchLocationsCache struct {
+	sync.Once
+	items map[int]modelsv2.SearchLocation
 }
 
-// searchBannedPlayers godoc
-// @Summary Search for banned players in a guild
-// @Description Returns banned players matching the query in the given guild.
-// @Tags Search
-// @Produce json
-// @Security ApiKeyAuth
-// @Param guild_id path int true "Discord guild ID"
-// @Param query query string false "Player name search query"
-// @Success 200 {object} modelsv2.SearchPlayerReferenceResponse
-// @Failure 400 {object} modelsv2.ErrorResponse
-// @Failure 401 {object} modelsv2.ErrorResponse
-// @Router /v2/search/{guild_id}/banned-players [get]
-func searchBannedPlayers(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		guildID, err := strconv.ParseInt(c.Params("guild_id"), 10, 64)
-		if err != nil || guildID == 0 {
-			return apptypes.Error(fiber.StatusBadRequest, "Invalid guild_id")
-		}
-		query := c.Query("query")
+type searchCursor struct {
+	Version       int    `json:"v"`
+	Entity        string `json:"entity"`
+	PITID         string `json:"pit_id"`
+	SearchAfter   []any  `json:"search_after"`
+	RequestHash   string `json:"request_hash"`
+	ExpiresAtUnix int64  `json:"expires_at"`
+}
 
-		_ = regexp.QuoteMeta(query)
-		docs, err := searchBans(c, a, guildID, query)
+type elasticsearchPITResponse struct {
+	ID string `json:"id"`
+}
+
+type elasticsearchSearchResponse struct {
+	PITID string `json:"pit_id"`
+	Hits  struct {
+		Hits []elasticsearchHit `json:"hits"`
+	} `json:"hits"`
+}
+
+type elasticsearchHit struct {
+	Source json.RawMessage `json:"_source"`
+	Sort   []any           `json:"sort"`
+}
+
+type elasticsearchClanSource struct {
+	Tag         string `json:"tag"`
+	Name        string `json:"name"`
+	ClanLevel   int    `json:"clan_level"`
+	BadgeToken  string `json:"badge_token"`
+	LocationID  int    `json:"location_id"`
+	CWLLeagueID int    `json:"cwl_league_id"`
+	MemberCount int    `json:"member_count"`
+}
+
+type elasticsearchPlayerSource struct {
+	Tag           string `json:"tag"`
+	Name          string `json:"name"`
+	LeagueID      int    `json:"league_id"`
+	ClanTag       string `json:"clan_tag"`
+	TownhallLevel int    `json:"townhall_level"`
+}
+
+type elasticsearchMGetResponse struct {
+	Docs []struct {
+		ID     string                  `json:"_id"`
+		Found  bool                    `json:"found"`
+		Source elasticsearchClanSource `json:"_source"`
+	} `json:"docs"`
+}
+
+// searchClans searches the stable clan Elasticsearch alias.
+//
+// Swag only accepts the legacy Swagger 2 method set, so this is generated as
+// POST and promoted to QUERY by swaggerdocs.BuildDoc.
+//
+// @Summary Search clans
+// @Description Searches the clan Elasticsearch alias by name or exact tag with optional filters and cursor pagination.
+// @Tags Search
+// @Accept json
+// @Produce json
+// @Param body body modelsv2.SearchClanQuery true "Clan search query"
+// @Success 200 {object} modelsv2.SearchClanResponse
+// @Failure 400 {object} modelsv2.ErrorResponse
+// @Failure 415 {object} modelsv2.ErrorResponse
+// @Failure 503 {object} modelsv2.ErrorResponse
+// @x-http-method "QUERY"
+// @Router /v2/search/clan [post]
+func searchClans(a apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		var request modelsv2.SearchClanQuery
+		if err := decodeStatsQueryJSON(c, &request); err != nil {
+			return err
+		}
+		limit, err := normalizeClanSearchQuery(&request)
 		if err != nil {
 			return err
 		}
-		items := make([]map[string]any, 0, len(docs))
-		for _, doc := range docs {
-			name := "Missing"
-			if v, ok := doc["VillageName"].(string); ok && v != "" {
-				name = v
+		if a.Search == nil {
+			return apptypes.Error(fiber.StatusServiceUnavailable, "Elasticsearch is not configured")
+		}
+		fingerprint, err := searchRequestFingerprint("clan", request.Query, request.Filters)
+		if err != nil {
+			return err
+		}
+		hits, nextCursor, hasMore, err := executeSearchPage(c, a, "clan", a.Search.ClansAlias, request.Query, request.Filters, limit, request.Cursor, fingerprint)
+		if err != nil {
+			return err
+		}
+
+		references := newReferenceCatalog(a)
+		locations := searchLocations()
+		items := make([]modelsv2.SearchClanResult, 0, len(hits))
+		for _, hit := range hits {
+			var source elasticsearchClanSource
+			if err := json.Unmarshal(hit.Source, &source); err != nil {
+				return searchUpstreamError(err)
 			}
-			items = append(items, map[string]any{
-				"tag":  searchGetString(doc, "VillageTag"),
-				"name": name,
-			})
+			items = append(items, searchClanResult(source, references, locations))
 		}
-		return apptypes.JSON(c, fiber.StatusOK, map[string]any{"items": items})
+		return apptypes.JSON(c, fiber.StatusOK, modelsv2.SearchClanResponse{
+			Items:      items,
+			Pagination: modelsv2.SearchCursorPage{Limit: limit, HasMore: hasMore, NextCursor: nextCursor},
+		})
 	}
 }
 
-// --- helpers ---
-
-func searchFetchUserData(c *fiber.Ctx, a apptypes.Deps, userID int64) (recentTags, bookmarkedTags []string) {
-	if userID == 0 {
-		return nil, nil
-	}
-	searchData, err := searchUserSettings(c, a, userID)
-	if err != nil {
-		return nil, nil
-	}
-	clan, _ := searchData["clan"].(map[string]any)
-	if clan == nil {
-		return nil, nil
-	}
-	recentTags = searchExtractStringSlice(clan["recent"])
-	bookmarkedTags = searchExtractStringSlice(clan["bookmarked"])
-	return
-}
-
-func searchFetchGuildClans(c *fiber.Ctx, a apptypes.Deps, guildID int64, query string) []string {
-	if guildID == 0 {
-		return nil
-	}
-	sqlQuery := `
-		SELECT sc.tag
-		FROM server_clans sc
-		JOIN basic_clan clan ON clan.tag = sc.tag
-		WHERE sc.server_id = $1
-	`
-	args := []any{strconv.FormatInt(guildID, 10)}
-	if len(query) > 1 {
-		sqlQuery += ` AND (clan.name ILIKE $2 OR sc.tag = $3)`
-		args = append(args, "%"+query+"%", clashy.CorrectTag(query))
-	}
-	sqlQuery += ` ORDER BY clan.name ASC LIMIT 25`
-	rows, err := a.Store.SQL.Query(c.UserContext(), sqlQuery, args...)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-	tags := []string{}
-	for rows.Next() {
-		var tag string
-		if err := rows.Scan(&tag); err != nil {
-			return nil
+// searchPlayers searches the stable player Elasticsearch alias.
+//
+// @Summary Search players
+// @Description Searches the player Elasticsearch alias by name or exact tag with optional filters and cursor pagination.
+// @Tags Search
+// @Accept json
+// @Produce json
+// @Param body body modelsv2.SearchPlayerQuery true "Player search query"
+// @Success 200 {object} modelsv2.SearchPlayerResponse
+// @Failure 400 {object} modelsv2.ErrorResponse
+// @Failure 415 {object} modelsv2.ErrorResponse
+// @Failure 503 {object} modelsv2.ErrorResponse
+// @x-http-method "QUERY"
+// @Router /v2/search/player [post]
+func searchPlayers(a apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		var request modelsv2.SearchPlayerQuery
+		if err := decodeStatsQueryJSON(c, &request); err != nil {
+			return err
 		}
-		if tag != "" {
-			tags = append(tags, tag)
+		limit, err := normalizePlayerSearchQuery(&request)
+		if err != nil {
+			return err
 		}
-	}
-	return tags
-}
-
-func searchFetchLocalClans(c *fiber.Ctx, a apptypes.Deps, tags []string) []map[string]any {
-	if len(tags) == 0 {
-		return nil
-	}
-	rows, err := a.Store.SQL.Query(c.UserContext(), `
-		SELECT tag, name, member_count, clan_level
-		FROM basic_clan
-		WHERE tag = ANY($1)
-	`, tags)
-	if err != nil {
-		return nil
-	}
-	defer rows.Close()
-	docs := []map[string]any{}
-	for rows.Next() {
-		var tag, name string
-		var members, level int
-		if err := rows.Scan(&tag, &name, &members, &level); err != nil {
-			return nil
+		if a.Search == nil {
+			return apptypes.Error(fiber.StatusServiceUnavailable, "Elasticsearch is not configured")
 		}
-		doc := map[string]any{"tag": tag, "name": name, "members": members, "level": level}
-		docs = append(docs, doc)
-	}
-	return docs
-}
-
-func searchBuildClanFromDB(doc map[string]any, findType string) map[string]any {
-	memberCount := int(asInt64(doc["members"]))
-	level := int(asInt64(doc["level"]))
-	warLeague := "Unranked"
-	if v, ok := doc["warLeague"].(string); ok && v != "" {
-		warLeague = v
-	}
-	return map[string]any{
-		"name":        searchGetString(doc, "name"),
-		"tag":         searchGetString(doc, "tag"),
-		"memberCount": memberCount,
-		"level":       level,
-		"warLeague":   warLeague,
-		"type":        findType,
-	}
-}
-
-func searchDetermineType(tag string, bookmarked, recent []string) string {
-	for _, t := range bookmarked {
-		if t == tag {
-			return searchTypeBookmarked
+		fingerprint, err := searchRequestFingerprint("player", request.Query, request.Filters)
+		if err != nil {
+			return err
 		}
-	}
-	for _, t := range recent {
-		if t == tag {
-			return searchTypeRecent
+		hits, nextCursor, hasMore, err := executeSearchPage(c, a, "player", a.Search.PlayersAlias, request.Query, request.Filters, limit, request.Cursor, fingerprint)
+		if err != nil {
+			return err
 		}
-	}
-	return searchTypeGuild
-}
 
-func searchSortByType(clans []map[string]any) {
-	typeOrder := map[string]int{
-		searchTypeRecent:     0,
-		searchTypeBookmarked: 1,
-		searchTypeGuild:      2,
-		searchTypeResult:     3,
-	}
-	for i := 1; i < len(clans); i++ {
-		for j := i; j > 0; j-- {
-			a := typeOrder[searchGetString(clans[j-1], "type")]
-			b := typeOrder[searchGetString(clans[j], "type")]
-			if a > b {
-				clans[j-1], clans[j] = clans[j], clans[j-1]
-			} else {
-				break
+		players := make([]elasticsearchPlayerSource, 0, len(hits))
+		clanTags := make([]string, 0, len(hits))
+		seenClans := make(map[string]struct{}, len(hits))
+		for _, hit := range hits {
+			var source elasticsearchPlayerSource
+			if err := json.Unmarshal(hit.Source, &source); err != nil {
+				return searchUpstreamError(err)
+			}
+			players = append(players, source)
+			if source.ClanTag != "" {
+				tag := clashy.CorrectTag(source.ClanTag)
+				if _, exists := seenClans[tag]; !exists {
+					seenClans[tag] = struct{}{}
+					clanTags = append(clanTags, tag)
+				}
 			}
 		}
+		clans, err := searchFetchClans(c, a, clanTags)
+		if err != nil {
+			return err
+		}
+		references := newReferenceCatalog(a)
+		items := make([]modelsv2.SearchPlayerResult, 0, len(players))
+		for _, player := range players {
+			items = append(items, searchPlayerResult(player, clans, references))
+		}
+		return apptypes.JSON(c, fiber.StatusOK, modelsv2.SearchPlayerResponse{
+			Items:      items,
+			Pagination: modelsv2.SearchCursorPage{Limit: limit, HasMore: hasMore, NextCursor: nextCursor},
+		})
 	}
 }
 
-func searchGetString(m map[string]any, key string) string {
-	if v, ok := m[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
-		}
+func normalizeClanSearchQuery(request *modelsv2.SearchClanQuery) (int, error) {
+	request.Query = strings.TrimSpace(request.Query)
+	if len([]rune(request.Query)) < 2 || len([]rune(request.Query)) > 100 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "query must contain between 2 and 100 characters")
 	}
-	return ""
+	limit, err := normalizeSearchLimit(request.Limit)
+	if err != nil {
+		return 0, err
+	}
+	request.Limit = limit
+	if len(request.Filters.LocationIDs) > 5 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "location_ids cannot contain more than 5 values")
+	}
+	if len(request.Filters.CWLLeagueIDs) > 5 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "cwl_league_ids cannot contain more than 5 values")
+	}
+	request.Filters.LocationIDs, err = normalizePositiveIDs(request.Filters.LocationIDs, "location_ids")
+	if err != nil {
+		return 0, err
+	}
+	request.Filters.CWLLeagueIDs, err = normalizePositiveIDs(request.Filters.CWLLeagueIDs, "cwl_league_ids")
+	if err != nil {
+		return 0, err
+	}
+	if err := validateSearchRange(request.Filters.ClanLevel, "clan_level", 1, 0); err != nil {
+		return 0, err
+	}
+	if err := validateSearchRange(request.Filters.Members, "members", 0, 50); err != nil {
+		return 0, err
+	}
+	return limit, nil
 }
 
-func searchExtractStringSlice(v any) []string {
-	switch typed := v.(type) {
-	case []any:
-		out := make([]string, 0, len(typed))
-		for _, item := range typed {
-			if s, ok := item.(string); ok {
-				out = append(out, s)
-			}
+func normalizePlayerSearchQuery(request *modelsv2.SearchPlayerQuery) (int, error) {
+	request.Query = strings.TrimSpace(request.Query)
+	if len([]rune(request.Query)) < 2 || len([]rune(request.Query)) > 100 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "query must contain between 2 and 100 characters")
+	}
+	limit, err := normalizeSearchLimit(request.Limit)
+	if err != nil {
+		return 0, err
+	}
+	request.Limit = limit
+	if len(request.Filters.ClanTags) > 100 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "clan_tags cannot contain more than 100 values")
+	}
+	if len(request.Filters.LeagueIDs) > 5 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "league_ids cannot contain more than 5 values")
+	}
+	if len(request.Filters.TownhallLevels) > 100 {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "townhall_levels cannot contain more than 100 values")
+	}
+	request.Filters.ClanTags, err = normalizeSearchTags(request.Filters.ClanTags)
+	if err != nil {
+		return 0, err
+	}
+	request.Filters.LeagueIDs, err = normalizePositiveIDs(request.Filters.LeagueIDs, "league_ids")
+	if err != nil {
+		return 0, err
+	}
+	request.Filters.TownhallLevels, err = normalizeBoundedIDs(request.Filters.TownhallLevels, "townhall_levels", 1, 100)
+	if err != nil {
+		return 0, err
+	}
+	return limit, nil
+}
+
+func normalizeSearchLimit(limit int) (int, error) {
+	if limit == 0 {
+		return searchDefaultLimit, nil
+	}
+	if limit < 1 || limit > searchMaximumLimit {
+		return 0, apptypes.Error(fiber.StatusBadRequest, "limit must be between 1 and 200")
+	}
+	return limit, nil
+}
+
+func normalizePositiveIDs(values []int, field string) ([]int, error) {
+	return normalizeBoundedIDs(values, field, 1, 0)
+}
+
+func normalizeBoundedIDs(values []int, field string, minimum, maximum int) ([]int, error) {
+	seen := make(map[int]struct{}, len(values))
+	out := make([]int, 0, len(values))
+	for _, value := range values {
+		if value < minimum || maximum > 0 && value > maximum {
+			return nil, apptypes.Error(fiber.StatusBadRequest, field+" contains an unsupported value")
 		}
-		return out
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Ints(out)
+	return out, nil
+}
+
+func normalizeSearchTags(values []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		tag := clashy.CorrectTag(raw)
+		trimmed := strings.TrimPrefix(tag, "#")
+		if !searchTagPattern.MatchString(trimmed) {
+			return nil, apptypes.Error(fiber.StatusBadRequest, "clan_tags contains an invalid tag")
+		}
+		if _, exists := seen[tag]; exists {
+			continue
+		}
+		seen[tag] = struct{}{}
+		out = append(out, tag)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func validateSearchRange(value *modelsv2.SearchIntegerRange, field string, minimum, maximum int) error {
+	if value == nil {
+		return nil
+	}
+	for _, bound := range []*int{value.Min, value.Max} {
+		if bound == nil {
+			continue
+		}
+		if *bound < minimum || maximum > 0 && *bound > maximum {
+			return apptypes.Error(fiber.StatusBadRequest, field+" contains an unsupported bound")
+		}
+	}
+	if value.Min != nil && value.Max != nil && *value.Min > *value.Max {
+		return apptypes.Error(fiber.StatusBadRequest, field+" minimum cannot exceed maximum")
 	}
 	return nil
 }
 
-func searchBans(c *fiber.Ctx, a apptypes.Deps, guildID int64, query string) ([]map[string]any, error) {
-	sqlQuery := `
-		SELECT player_tag, player_name
-		FROM server_bans
-		WHERE server_id = $1
-	`
-	args := []any{strconv.FormatInt(guildID, 10)}
-	if query != "" {
-		sqlQuery += ` AND player_name ILIKE $2`
-		args = append(args, "%"+query+"%")
-	}
-	sqlQuery += ` ORDER BY player_name ASC LIMIT 25`
-	rows, err := a.Store.SQL.Query(c.UserContext(), sqlQuery, args...)
+func searchRequestFingerprint(entity, query string, filters any) (string, error) {
+	raw, err := json.Marshal(struct {
+		Entity  string `json:"entity"`
+		Query   string `json:"query"`
+		Filters any    `json:"filters"`
+	}{Entity: entity, Query: query, Filters: filters})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	defer rows.Close()
-	out := []map[string]any{}
-	for rows.Next() {
-		var tag, name string
-		if err := rows.Scan(&tag, &name); err != nil {
-			return nil, err
-		}
-		out = append(out, map[string]any{"VillageTag": tag, "VillageName": name})
-	}
-	return out, rows.Err()
+	digest := sha256.Sum256(raw)
+	return hex.EncodeToString(digest[:]), nil
 }
 
-func searchUserSettings(c *fiber.Ctx, a apptypes.Deps, userID int64) (map[string]any, error) {
-	var raw []byte
-	err := a.Store.SQL.QueryRow(c.UserContext(), `SELECT search FROM user_settings WHERE user_id = $1`, strconv.FormatInt(userID, 10)).Scan(&raw)
-	if err != nil {
-		return map[string]any{}, err
+func executeSearchPage(c *fiber.Ctx, a apptypes.Deps, entity, alias, query string, filters any, limit int, encodedCursor, fingerprint string) ([]elasticsearchHit, *string, bool, error) {
+	pitID := ""
+	var searchAfter []any
+	if encodedCursor == "" {
+		var pit elasticsearchPITResponse
+		if err := a.Search.DoJSON(c.UserContext(), http.MethodPost, "/"+alias+"/_pit", url.Values{"keep_alive": {searchPITKeepAlive}}, nil, &pit); err != nil || pit.ID == "" {
+			return nil, nil, false, searchUpstreamError(err)
+		}
+		pitID = pit.ID
+	} else {
+		cursor, err := decodeSearchCursor(encodedCursor, entity, fingerprint)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		pitID = cursor.PITID
+		searchAfter = cursor.SearchAfter
 	}
-	out := map[string]any{}
-	_ = json.Unmarshal(raw, &out)
+
+	body := map[string]any{
+		"size":             limit + 1,
+		"track_total_hits": false,
+		"pit":              map[string]any{"id": pitID, "keep_alive": searchPITKeepAlive},
+		"query":            buildElasticsearchSearchQuery(query, filters),
+		"sort":             []any{map[string]any{"_score": "desc"}, map[string]any{"tag": "asc"}},
+	}
+	if entity == "clan" {
+		body["_source"] = []string{"tag", "name", "clan_level", "badge_token", "location_id", "cwl_league_id", "member_count"}
+	} else {
+		body["_source"] = []string{"tag", "name", "league_id", "clan_tag", "townhall_level"}
+	}
+	if len(searchAfter) > 0 {
+		body["search_after"] = searchAfter
+	}
+	var result elasticsearchSearchResponse
+	if err := a.Search.DoJSON(c.UserContext(), http.MethodPost, "/_search", nil, body, &result); err != nil {
+		closeSearchPIT(c, a, pitID)
+		return nil, nil, false, searchUpstreamError(err)
+	}
+	if result.PITID != "" {
+		pitID = result.PITID
+	}
+	hasMore := len(result.Hits.Hits) > limit
+	hits := result.Hits.Hits
+	if hasMore {
+		hits = hits[:limit]
+	}
+	if !hasMore || len(hits) == 0 {
+		closeSearchPIT(c, a, pitID)
+		return hits, nil, false, nil
+	}
+	lastSort := hits[len(hits)-1].Sort
+	if len(lastSort) == 0 {
+		closeSearchPIT(c, a, pitID)
+		return nil, nil, false, searchUpstreamError(nil)
+	}
+	next, err := encodeSearchCursor(searchCursor{
+		Version: 1, Entity: entity, PITID: pitID, SearchAfter: lastSort,
+		RequestHash: fingerprint, ExpiresAtUnix: time.Now().Add(searchCursorTTL).Unix(),
+	})
+	if err != nil {
+		closeSearchPIT(c, a, pitID)
+		return nil, nil, false, err
+	}
+	return hits, &next, true, nil
+}
+
+func buildElasticsearchSearchQuery(query string, filters any) map[string]any {
+	boolQuery := map[string]any{
+		"should": []any{
+			map[string]any{"match": map[string]any{"name": map[string]any{"query": query, "operator": "and"}}},
+		},
+		"minimum_should_match": 1,
+	}
+	if normalizedTag, ok := searchExactTag(query); ok {
+		boolQuery["should"] = append(boolQuery["should"].([]any), map[string]any{
+			"term": map[string]any{"tag": map[string]any{"value": strings.ToLower(normalizedTag), "boost": 100}},
+		})
+	}
+	filterClauses := buildElasticsearchFilters(filters)
+	if len(filterClauses) > 0 {
+		boolQuery["filter"] = filterClauses
+	}
+	return map[string]any{"bool": boolQuery}
+}
+
+func buildElasticsearchFilters(filters any) []any {
+	out := []any{}
+	switch typed := filters.(type) {
+	case modelsv2.SearchClanFilters:
+		out = appendTermsFilter(out, "location_id", intsToAny(typed.LocationIDs))
+		out = appendTermsFilter(out, "cwl_league_id", intsToAny(typed.CWLLeagueIDs))
+		out = appendRangeFilter(out, "clan_level", typed.ClanLevel)
+		out = appendRangeFilter(out, "member_count", typed.Members)
+	case modelsv2.SearchPlayerFilters:
+		clanTags := make([]any, 0, len(typed.ClanTags))
+		for _, tag := range typed.ClanTags {
+			clanTags = append(clanTags, strings.ToLower(tag))
+		}
+		out = appendTermsFilter(out, "clan_tag", clanTags)
+		out = appendTermsFilter(out, "league_id", intsToAny(typed.LeagueIDs))
+		out = appendTermsFilter(out, "townhall_level", intsToAny(typed.TownhallLevels))
+	}
+	return out
+}
+
+func appendTermsFilter(filters []any, field string, values []any) []any {
+	if len(values) == 0 {
+		return filters
+	}
+	return append(filters, map[string]any{"terms": map[string]any{field: values}})
+}
+
+func appendRangeFilter(filters []any, field string, value *modelsv2.SearchIntegerRange) []any {
+	if value == nil || value.Min == nil && value.Max == nil {
+		return filters
+	}
+	bounds := map[string]any{}
+	if value.Min != nil {
+		bounds["gte"] = *value.Min
+	}
+	if value.Max != nil {
+		bounds["lte"] = *value.Max
+	}
+	return append(filters, map[string]any{"range": map[string]any{field: bounds}})
+}
+
+func intsToAny(values []int) []any {
+	out := make([]any, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	return out
+}
+
+func searchExactTag(query string) (string, bool) {
+	tag := clashy.CorrectTag(query)
+	if !searchTagPattern.MatchString(strings.TrimPrefix(tag, "#")) {
+		return "", false
+	}
+	return tag, true
+}
+
+func encodeSearchCursor(cursor searchCursor) (string, error) {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return "", err
+	}
+	return apptypes.EncryptToString(string(raw)), nil
+}
+
+func decodeSearchCursor(value, entity, fingerprint string) (searchCursor, error) {
+	plaintext, err := apptypes.DecryptString(value)
+	if err != nil {
+		return searchCursor{}, apptypes.Error(fiber.StatusBadRequest, "Invalid or expired search cursor")
+	}
+	var cursor searchCursor
+	if err := json.Unmarshal([]byte(plaintext), &cursor); err != nil || cursor.Version != 1 || cursor.PITID == "" || len(cursor.SearchAfter) == 0 {
+		return searchCursor{}, apptypes.Error(fiber.StatusBadRequest, "Invalid or expired search cursor")
+	}
+	if cursor.Entity != entity || cursor.RequestHash != fingerprint {
+		return searchCursor{}, apptypes.Error(fiber.StatusBadRequest, "Search cursor does not match the query and filters")
+	}
+	if time.Now().Unix() >= cursor.ExpiresAtUnix {
+		return searchCursor{}, apptypes.Error(fiber.StatusBadRequest, "Invalid or expired search cursor")
+	}
+	return cursor, nil
+}
+
+func closeSearchPIT(c *fiber.Ctx, a apptypes.Deps, pitID string) {
+	if a.Search == nil || pitID == "" {
+		return
+	}
+	_ = a.Search.DoJSON(c.UserContext(), http.MethodDelete, "/_pit", nil, map[string]any{"id": pitID}, nil)
+}
+
+func searchFetchClans(c *fiber.Ctx, a apptypes.Deps, tags []string) (map[string]elasticsearchClanSource, error) {
+	if len(tags) == 0 {
+		return map[string]elasticsearchClanSource{}, nil
+	}
+	var response elasticsearchMGetResponse
+	body := map[string]any{"ids": tags}
+	query := url.Values{"_source_includes": {"tag,name,clan_level,badge_token"}}
+	if err := a.Search.DoJSON(c.UserContext(), http.MethodPost, "/"+a.Search.ClansAlias+"/_mget", query, body, &response); err != nil {
+		return nil, searchUpstreamError(err)
+	}
+	out := make(map[string]elasticsearchClanSource, len(response.Docs))
+	for _, doc := range response.Docs {
+		if !doc.Found {
+			continue
+		}
+		tag := doc.Source.Tag
+		if tag == "" {
+			tag = doc.ID
+		}
+		out[clashy.CorrectTag(tag)] = doc.Source
+	}
 	return out, nil
 }
 
-func searchSaveUserSettings(c *fiber.Ctx, a apptypes.Deps, userID int64, searchData map[string]any) error {
-	_, err := a.Store.SQL.Exec(c.UserContext(), `
-		INSERT INTO user_settings (user_id, search, updated_at)
-		VALUES ($1, $2::jsonb, now())
-		ON CONFLICT (user_id) DO UPDATE SET search = EXCLUDED.search, updated_at = now()
-	`, strconv.FormatInt(userID, 10), apptypes.Marshal(searchData))
-	return err
+func searchClanResult(source elasticsearchClanSource, references referenceCatalog, locations map[int]modelsv2.SearchLocation) modelsv2.SearchClanResult {
+	item := modelsv2.SearchClanResult{
+		Name: source.Name, Tag: source.Tag, ClanLevel: source.ClanLevel,
+		Members: source.MemberCount,
+	}
+	if source.BadgeToken != "" {
+		item.Badge = badgeURL(source.BadgeToken, 512)
+	}
+	if location, ok := locations[source.LocationID]; ok {
+		copy := location
+		item.Location = &copy
+	}
+	if league := references.warLeague(source.CWLLeagueID); league != nil {
+		item.WarLeague = &modelsv2.SearchLeagueReference{ID: league.ID, Name: league.Name}
+	}
+	return item
 }
 
-func searchUpsertTag(c *fiber.Ctx, a apptypes.Deps, userID int64, typeField, listName, tag string) error {
-	searchData, _ := searchUserSettings(c, a, userID)
-	typeData, _ := searchData[typeField].(map[string]any)
-	if typeData == nil {
-		typeData = map[string]any{}
+func searchPlayerResult(source elasticsearchPlayerSource, clans map[string]elasticsearchClanSource, references referenceCatalog) modelsv2.SearchPlayerResult {
+	item := modelsv2.SearchPlayerResult{Name: source.Name, Tag: source.Tag, TownHallLevel: source.TownhallLevel}
+	if league := references.leagueTier(source.LeagueID); league != nil {
+		item.LeagueTier = &modelsv2.SearchLeagueReference{ID: league.ID, Name: league.Name}
 	}
-	current := searchExtractStringSlice(typeData[listName])
-	next := []string{tag}
-	for _, item := range current {
-		if item != tag {
-			next = append(next, item)
-		}
-		if len(next) == 20 {
-			break
+	if source.ClanTag == "" {
+		return item
+	}
+	tag := clashy.CorrectTag(source.ClanTag)
+	item.Clan = &modelsv2.SearchPlayerClan{Tag: tag}
+	if clan, ok := clans[tag]; ok {
+		item.Clan.Name = clan.Name
+		item.Clan.ClanLevel = clan.ClanLevel
+		if clan.BadgeToken != "" {
+			item.Clan.Badge = badgeURL(clan.BadgeToken, 512)
 		}
 	}
-	typeData[listName] = next
-	searchData[typeField] = typeData
-	return searchSaveUserSettings(c, a, userID, searchData)
+	return item
+}
+
+func searchLocations() map[int]modelsv2.SearchLocation {
+	searchLocationsCache.Do(func() {
+		var items []modelsv2.SearchLocation
+		if err := json.Unmarshal(searchLocationsJSON, &items); err != nil {
+			searchLocationsCache.items = map[int]modelsv2.SearchLocation{}
+			return
+		}
+		searchLocationsCache.items = make(map[int]modelsv2.SearchLocation, len(items))
+		for _, item := range items {
+			searchLocationsCache.items[item.ID] = item
+		}
+	})
+	return searchLocationsCache.items
+}
+
+func searchUpstreamError(err error) error {
+	if err != nil {
+		apptypes.Logger().Error("elasticsearch_search_failed", "error", err)
+	}
+	return apptypes.Error(fiber.StatusServiceUnavailable, "Elasticsearch search is unavailable")
 }

--- a/internal/routes/search_bans.go
+++ b/internal/routes/search_bans.go
@@ -1,0 +1,63 @@
+package routes
+
+import (
+	"strconv"
+	"strings"
+
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+// searchBannedPlayers godoc
+// @Summary Search for banned players in a guild
+// @Description Returns banned players matching the query in the given guild.
+// @Tags Search
+// @Produce json
+// @Security ApiKeyAuth
+// @Param guild_id path int true "Discord guild ID"
+// @Param query query string false "Player name search query"
+// @Success 200 {object} modelsv2.SearchPlayerReferenceResponse
+// @Failure 400 {object} modelsv2.ErrorResponse
+// @Failure 401 {object} modelsv2.ErrorResponse
+// @Router /v2/search/{guild_id}/banned-players [get]
+func searchBannedPlayers(a apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		guildID, err := strconv.ParseInt(c.Params("guild_id"), 10, 64)
+		if err != nil || guildID == 0 {
+			return apptypes.Error(fiber.StatusBadRequest, "Invalid guild_id")
+		}
+		query := strings.TrimSpace(c.Query("query"))
+		sqlQuery := `
+			SELECT player_tag, player_name
+			FROM server_bans
+			WHERE server_id = $1
+		`
+		args := []any{strconv.FormatInt(guildID, 10)}
+		if query != "" {
+			sqlQuery += ` AND player_name ILIKE $2`
+			args = append(args, "%"+query+"%")
+		}
+		sqlQuery += ` ORDER BY player_name ASC LIMIT 25`
+		rows, err := a.Store.SQL.Query(c.UserContext(), sqlQuery, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		items := []modelsv2.SearchPlayerReference{}
+		for rows.Next() {
+			var item modelsv2.SearchPlayerReference
+			if err := rows.Scan(&item.Tag, &item.Name); err != nil {
+				return err
+			}
+			if item.Name == "" {
+				item.Name = "Missing"
+			}
+			items = append(items, item)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return apptypes.JSON(c, fiber.StatusOK, modelsv2.SearchPlayerReferenceResponse{Items: items})
+	}
+}

--- a/internal/routes/search_locations.json
+++ b/internal/routes/search_locations.json
@@ -1,0 +1,1560 @@
+[
+  {
+    "id": 32000000,
+    "name": "Europe",
+    "isCountry": false
+  },
+  {
+    "id": 32000001,
+    "name": "North America",
+    "isCountry": false
+  },
+  {
+    "id": 32000002,
+    "name": "South America",
+    "isCountry": false
+  },
+  {
+    "id": 32000003,
+    "name": "Asia",
+    "isCountry": false
+  },
+  {
+    "id": 32000004,
+    "name": "Australia",
+    "isCountry": false
+  },
+  {
+    "id": 32000005,
+    "name": "Africa",
+    "isCountry": false
+  },
+  {
+    "id": 32000006,
+    "name": "International",
+    "isCountry": false
+  },
+  {
+    "id": 32000007,
+    "name": "Afghanistan",
+    "isCountry": false
+  },
+  {
+    "id": 32000008,
+    "name": "Åland Islands",
+    "isCountry": true,
+    "countryCode": "AX"
+  },
+  {
+    "id": 32000009,
+    "name": "Albania",
+    "isCountry": true,
+    "countryCode": "AL"
+  },
+  {
+    "id": 32000010,
+    "name": "Algeria",
+    "isCountry": true,
+    "countryCode": "DZ"
+  },
+  {
+    "id": 32000011,
+    "name": "American Samoa",
+    "isCountry": true,
+    "countryCode": "AS"
+  },
+  {
+    "id": 32000012,
+    "name": "Andorra",
+    "isCountry": true,
+    "countryCode": "AD"
+  },
+  {
+    "id": 32000013,
+    "name": "Angola",
+    "isCountry": true,
+    "countryCode": "AO"
+  },
+  {
+    "id": 32000014,
+    "name": "Anguilla",
+    "isCountry": true,
+    "countryCode": "AI"
+  },
+  {
+    "id": 32000015,
+    "name": "Antarctica",
+    "isCountry": true,
+    "countryCode": "AQ"
+  },
+  {
+    "id": 32000016,
+    "name": "Antigua and Barbuda",
+    "isCountry": true,
+    "countryCode": "AG"
+  },
+  {
+    "id": 32000017,
+    "name": "Argentina",
+    "isCountry": true,
+    "countryCode": "AR"
+  },
+  {
+    "id": 32000018,
+    "name": "Armenia",
+    "isCountry": true,
+    "countryCode": "AM"
+  },
+  {
+    "id": 32000019,
+    "name": "Aruba",
+    "isCountry": true,
+    "countryCode": "AW"
+  },
+  {
+    "id": 32000020,
+    "name": "Ascension Island",
+    "isCountry": true,
+    "countryCode": "AC"
+  },
+  {
+    "id": 32000021,
+    "name": "Australia",
+    "isCountry": true,
+    "countryCode": "AU"
+  },
+  {
+    "id": 32000022,
+    "name": "Austria",
+    "isCountry": true,
+    "countryCode": "AT"
+  },
+  {
+    "id": 32000023,
+    "name": "Azerbaijan",
+    "isCountry": true,
+    "countryCode": "AZ"
+  },
+  {
+    "id": 32000024,
+    "name": "Bahamas",
+    "isCountry": true,
+    "countryCode": "BS"
+  },
+  {
+    "id": 32000025,
+    "name": "Bahrain",
+    "isCountry": true,
+    "countryCode": "BH"
+  },
+  {
+    "id": 32000026,
+    "name": "Bangladesh",
+    "isCountry": true,
+    "countryCode": "BD"
+  },
+  {
+    "id": 32000027,
+    "name": "Barbados",
+    "isCountry": true,
+    "countryCode": "BB"
+  },
+  {
+    "id": 32000028,
+    "name": "Belarus",
+    "isCountry": true,
+    "countryCode": "BY"
+  },
+  {
+    "id": 32000029,
+    "name": "Belgium",
+    "isCountry": true,
+    "countryCode": "BE"
+  },
+  {
+    "id": 32000030,
+    "name": "Belize",
+    "isCountry": true,
+    "countryCode": "BZ"
+  },
+  {
+    "id": 32000031,
+    "name": "Benin",
+    "isCountry": true,
+    "countryCode": "BJ"
+  },
+  {
+    "id": 32000032,
+    "name": "Bermuda",
+    "isCountry": true,
+    "countryCode": "BM"
+  },
+  {
+    "id": 32000033,
+    "name": "Bhutan",
+    "isCountry": true,
+    "countryCode": "BT"
+  },
+  {
+    "id": 32000034,
+    "name": "Bolivia",
+    "isCountry": true,
+    "countryCode": "BO"
+  },
+  {
+    "id": 32000035,
+    "name": "Bosnia and Herzegovina",
+    "isCountry": true,
+    "countryCode": "BA"
+  },
+  {
+    "id": 32000036,
+    "name": "Botswana",
+    "isCountry": true,
+    "countryCode": "BW"
+  },
+  {
+    "id": 32000037,
+    "name": "Bouvet Island",
+    "isCountry": true,
+    "countryCode": "BV"
+  },
+  {
+    "id": 32000038,
+    "name": "Brazil",
+    "isCountry": true,
+    "countryCode": "BR"
+  },
+  {
+    "id": 32000039,
+    "name": "British Indian Ocean Territory",
+    "isCountry": true,
+    "countryCode": "IO"
+  },
+  {
+    "id": 32000040,
+    "name": "British Virgin Islands",
+    "isCountry": true,
+    "countryCode": "VG"
+  },
+  {
+    "id": 32000041,
+    "name": "Brunei",
+    "isCountry": true,
+    "countryCode": "BN"
+  },
+  {
+    "id": 32000042,
+    "name": "Bulgaria",
+    "isCountry": true,
+    "countryCode": "BG"
+  },
+  {
+    "id": 32000043,
+    "name": "Burkina Faso",
+    "isCountry": true,
+    "countryCode": "BF"
+  },
+  {
+    "id": 32000044,
+    "name": "Burundi",
+    "isCountry": true,
+    "countryCode": "BI"
+  },
+  {
+    "id": 32000045,
+    "name": "Cambodia",
+    "isCountry": true,
+    "countryCode": "KH"
+  },
+  {
+    "id": 32000046,
+    "name": "Cameroon",
+    "isCountry": true,
+    "countryCode": "CM"
+  },
+  {
+    "id": 32000047,
+    "name": "Canada",
+    "isCountry": true,
+    "countryCode": "CA"
+  },
+  {
+    "id": 32000048,
+    "name": "Canary Islands",
+    "isCountry": true,
+    "countryCode": "IC"
+  },
+  {
+    "id": 32000049,
+    "name": "Cape Verde",
+    "isCountry": true,
+    "countryCode": "CV"
+  },
+  {
+    "id": 32000050,
+    "name": "Caribbean Netherlands",
+    "isCountry": true,
+    "countryCode": "BQ"
+  },
+  {
+    "id": 32000051,
+    "name": "Cayman Islands",
+    "isCountry": true,
+    "countryCode": "KY"
+  },
+  {
+    "id": 32000052,
+    "name": "Central African Republic",
+    "isCountry": true,
+    "countryCode": "CF"
+  },
+  {
+    "id": 32000053,
+    "name": "Ceuta and Melilla",
+    "isCountry": true,
+    "countryCode": "EA"
+  },
+  {
+    "id": 32000054,
+    "name": "Chad",
+    "isCountry": true,
+    "countryCode": "TD"
+  },
+  {
+    "id": 32000055,
+    "name": "Chile",
+    "isCountry": true,
+    "countryCode": "CL"
+  },
+  {
+    "id": 32000056,
+    "name": "China",
+    "isCountry": true,
+    "countryCode": "CN"
+  },
+  {
+    "id": 32000057,
+    "name": "Christmas Island",
+    "isCountry": true,
+    "countryCode": "CX"
+  },
+  {
+    "id": 32000058,
+    "name": "Cocos (Keeling) Islands",
+    "isCountry": true,
+    "countryCode": "CC"
+  },
+  {
+    "id": 32000059,
+    "name": "Colombia",
+    "isCountry": true,
+    "countryCode": "CO"
+  },
+  {
+    "id": 32000060,
+    "name": "Comoros",
+    "isCountry": true,
+    "countryCode": "KM"
+  },
+  {
+    "id": 32000061,
+    "name": "Congo (DRC)",
+    "isCountry": true,
+    "countryCode": "CG"
+  },
+  {
+    "id": 32000062,
+    "name": "Congo (Republic)",
+    "isCountry": true,
+    "countryCode": "CD"
+  },
+  {
+    "id": 32000063,
+    "name": "Cook Islands",
+    "isCountry": true,
+    "countryCode": "CK"
+  },
+  {
+    "id": 32000064,
+    "name": "Costa Rica",
+    "isCountry": true,
+    "countryCode": "CR"
+  },
+  {
+    "id": 32000065,
+    "name": "Côte d’Ivoire",
+    "isCountry": true,
+    "countryCode": "CI"
+  },
+  {
+    "id": 32000066,
+    "name": "Croatia",
+    "isCountry": true,
+    "countryCode": "HR"
+  },
+  {
+    "id": 32000067,
+    "name": "Cuba",
+    "isCountry": true,
+    "countryCode": "CU"
+  },
+  {
+    "id": 32000068,
+    "name": "Curaçao",
+    "isCountry": true,
+    "countryCode": "CW"
+  },
+  {
+    "id": 32000069,
+    "name": "Cyprus",
+    "isCountry": true,
+    "countryCode": "CY"
+  },
+  {
+    "id": 32000070,
+    "name": "Czech Republic",
+    "isCountry": true,
+    "countryCode": "CZ"
+  },
+  {
+    "id": 32000071,
+    "name": "Denmark",
+    "isCountry": true,
+    "countryCode": "DK"
+  },
+  {
+    "id": 32000072,
+    "name": "Diego Garcia",
+    "isCountry": true,
+    "countryCode": "DG"
+  },
+  {
+    "id": 32000073,
+    "name": "Djibouti",
+    "isCountry": true,
+    "countryCode": "DJ"
+  },
+  {
+    "id": 32000074,
+    "name": "Dominica",
+    "isCountry": true,
+    "countryCode": "DM"
+  },
+  {
+    "id": 32000075,
+    "name": "Dominican Republic",
+    "isCountry": true,
+    "countryCode": "DO"
+  },
+  {
+    "id": 32000076,
+    "name": "Ecuador",
+    "isCountry": true,
+    "countryCode": "EC"
+  },
+  {
+    "id": 32000077,
+    "name": "Egypt",
+    "isCountry": true,
+    "countryCode": "EG"
+  },
+  {
+    "id": 32000078,
+    "name": "El Salvador",
+    "isCountry": true,
+    "countryCode": "SV"
+  },
+  {
+    "id": 32000079,
+    "name": "Equatorial Guinea",
+    "isCountry": true,
+    "countryCode": "GQ"
+  },
+  {
+    "id": 32000080,
+    "name": "Eritrea",
+    "isCountry": true,
+    "countryCode": "ER"
+  },
+  {
+    "id": 32000081,
+    "name": "Estonia",
+    "isCountry": true,
+    "countryCode": "EE"
+  },
+  {
+    "id": 32000082,
+    "name": "Ethiopia",
+    "isCountry": true,
+    "countryCode": "ET"
+  },
+  {
+    "id": 32000083,
+    "name": "Falkland Islands",
+    "isCountry": true,
+    "countryCode": "FK"
+  },
+  {
+    "id": 32000084,
+    "name": "Faroe Islands",
+    "isCountry": true,
+    "countryCode": "FO"
+  },
+  {
+    "id": 32000085,
+    "name": "Fiji",
+    "isCountry": true,
+    "countryCode": "FJ"
+  },
+  {
+    "id": 32000086,
+    "name": "Finland",
+    "isCountry": true,
+    "countryCode": "FI"
+  },
+  {
+    "id": 32000087,
+    "name": "France",
+    "isCountry": true,
+    "countryCode": "FR"
+  },
+  {
+    "id": 32000088,
+    "name": "French Guiana",
+    "isCountry": true,
+    "countryCode": "GF"
+  },
+  {
+    "id": 32000089,
+    "name": "French Polynesia",
+    "isCountry": true,
+    "countryCode": "PF"
+  },
+  {
+    "id": 32000090,
+    "name": "French Southern Territories",
+    "isCountry": true,
+    "countryCode": "TF"
+  },
+  {
+    "id": 32000091,
+    "name": "Gabon",
+    "isCountry": true,
+    "countryCode": "GA"
+  },
+  {
+    "id": 32000092,
+    "name": "Gambia",
+    "isCountry": true,
+    "countryCode": "GM"
+  },
+  {
+    "id": 32000093,
+    "name": "Georgia",
+    "isCountry": true,
+    "countryCode": "GE"
+  },
+  {
+    "id": 32000094,
+    "name": "Germany",
+    "isCountry": true,
+    "countryCode": "DE"
+  },
+  {
+    "id": 32000095,
+    "name": "Ghana",
+    "isCountry": true,
+    "countryCode": "GH"
+  },
+  {
+    "id": 32000096,
+    "name": "Gibraltar",
+    "isCountry": true,
+    "countryCode": "GI"
+  },
+  {
+    "id": 32000097,
+    "name": "Greece",
+    "isCountry": true,
+    "countryCode": "GR"
+  },
+  {
+    "id": 32000098,
+    "name": "Greenland",
+    "isCountry": true,
+    "countryCode": "GL"
+  },
+  {
+    "id": 32000099,
+    "name": "Grenada",
+    "isCountry": true,
+    "countryCode": "GD"
+  },
+  {
+    "id": 32000100,
+    "name": "Guadeloupe",
+    "isCountry": true,
+    "countryCode": "GP"
+  },
+  {
+    "id": 32000101,
+    "name": "Guam",
+    "isCountry": true,
+    "countryCode": "GU"
+  },
+  {
+    "id": 32000102,
+    "name": "Guatemala",
+    "isCountry": true,
+    "countryCode": "GT"
+  },
+  {
+    "id": 32000103,
+    "name": "Guernsey",
+    "isCountry": true,
+    "countryCode": "GG"
+  },
+  {
+    "id": 32000104,
+    "name": "Guinea",
+    "isCountry": true,
+    "countryCode": "GN"
+  },
+  {
+    "id": 32000105,
+    "name": "Guinea-Bissau",
+    "isCountry": true,
+    "countryCode": "GW"
+  },
+  {
+    "id": 32000106,
+    "name": "Guyana",
+    "isCountry": true,
+    "countryCode": "GY"
+  },
+  {
+    "id": 32000107,
+    "name": "Haiti",
+    "isCountry": true,
+    "countryCode": "HT"
+  },
+  {
+    "id": 32000108,
+    "name": "Heard & McDonald Islands",
+    "isCountry": true,
+    "countryCode": "HM"
+  },
+  {
+    "id": 32000109,
+    "name": "Honduras",
+    "isCountry": true,
+    "countryCode": "HN"
+  },
+  {
+    "id": 32000110,
+    "name": "Hong Kong",
+    "isCountry": true,
+    "countryCode": "HK"
+  },
+  {
+    "id": 32000111,
+    "name": "Hungary",
+    "isCountry": true,
+    "countryCode": "HU"
+  },
+  {
+    "id": 32000112,
+    "name": "Iceland",
+    "isCountry": true,
+    "countryCode": "IS"
+  },
+  {
+    "id": 32000113,
+    "name": "India",
+    "isCountry": true,
+    "countryCode": "IN"
+  },
+  {
+    "id": 32000114,
+    "name": "Indonesia",
+    "isCountry": true,
+    "countryCode": "ID"
+  },
+  {
+    "id": 32000115,
+    "name": "Iran",
+    "isCountry": true,
+    "countryCode": "IR"
+  },
+  {
+    "id": 32000116,
+    "name": "Iraq",
+    "isCountry": true,
+    "countryCode": "IQ"
+  },
+  {
+    "id": 32000117,
+    "name": "Ireland",
+    "isCountry": true,
+    "countryCode": "IE"
+  },
+  {
+    "id": 32000118,
+    "name": "Isle of Man",
+    "isCountry": true,
+    "countryCode": "IM"
+  },
+  {
+    "id": 32000119,
+    "name": "Israel",
+    "isCountry": true,
+    "countryCode": "IL"
+  },
+  {
+    "id": 32000120,
+    "name": "Italy",
+    "isCountry": true,
+    "countryCode": "IT"
+  },
+  {
+    "id": 32000121,
+    "name": "Jamaica",
+    "isCountry": true,
+    "countryCode": "JM"
+  },
+  {
+    "id": 32000122,
+    "name": "Japan",
+    "isCountry": true,
+    "countryCode": "JP"
+  },
+  {
+    "id": 32000123,
+    "name": "Jersey",
+    "isCountry": true,
+    "countryCode": "JE"
+  },
+  {
+    "id": 32000124,
+    "name": "Jordan",
+    "isCountry": true,
+    "countryCode": "JO"
+  },
+  {
+    "id": 32000125,
+    "name": "Kazakhstan",
+    "isCountry": true,
+    "countryCode": "KZ"
+  },
+  {
+    "id": 32000126,
+    "name": "Kenya",
+    "isCountry": true,
+    "countryCode": "KE"
+  },
+  {
+    "id": 32000127,
+    "name": "Kiribati",
+    "isCountry": true,
+    "countryCode": "KI"
+  },
+  {
+    "id": 32000128,
+    "name": "Kosovo",
+    "isCountry": true,
+    "countryCode": "XK"
+  },
+  {
+    "id": 32000129,
+    "name": "Kuwait",
+    "isCountry": true,
+    "countryCode": "KW"
+  },
+  {
+    "id": 32000130,
+    "name": "Kyrgyzstan",
+    "isCountry": true,
+    "countryCode": "KG"
+  },
+  {
+    "id": 32000131,
+    "name": "Laos",
+    "isCountry": true,
+    "countryCode": "LA"
+  },
+  {
+    "id": 32000132,
+    "name": "Latvia",
+    "isCountry": true,
+    "countryCode": "LV"
+  },
+  {
+    "id": 32000133,
+    "name": "Lebanon",
+    "isCountry": true,
+    "countryCode": "LB"
+  },
+  {
+    "id": 32000134,
+    "name": "Lesotho",
+    "isCountry": true,
+    "countryCode": "LS"
+  },
+  {
+    "id": 32000135,
+    "name": "Liberia",
+    "isCountry": true,
+    "countryCode": "LR"
+  },
+  {
+    "id": 32000136,
+    "name": "Libya",
+    "isCountry": true,
+    "countryCode": "LY"
+  },
+  {
+    "id": 32000137,
+    "name": "Liechtenstein",
+    "isCountry": true,
+    "countryCode": "LI"
+  },
+  {
+    "id": 32000138,
+    "name": "Lithuania",
+    "isCountry": true,
+    "countryCode": "LT"
+  },
+  {
+    "id": 32000139,
+    "name": "Luxembourg",
+    "isCountry": true,
+    "countryCode": "LU"
+  },
+  {
+    "id": 32000140,
+    "name": "Macau",
+    "isCountry": true,
+    "countryCode": "MO"
+  },
+  {
+    "id": 32000141,
+    "name": "North Macedonia",
+    "isCountry": true,
+    "countryCode": "MK"
+  },
+  {
+    "id": 32000142,
+    "name": "Madagascar",
+    "isCountry": true,
+    "countryCode": "MG"
+  },
+  {
+    "id": 32000143,
+    "name": "Malawi",
+    "isCountry": true,
+    "countryCode": "MW"
+  },
+  {
+    "id": 32000144,
+    "name": "Malaysia",
+    "isCountry": true,
+    "countryCode": "MY"
+  },
+  {
+    "id": 32000145,
+    "name": "Maldives",
+    "isCountry": true,
+    "countryCode": "MV"
+  },
+  {
+    "id": 32000146,
+    "name": "Mali",
+    "isCountry": true,
+    "countryCode": "ML"
+  },
+  {
+    "id": 32000147,
+    "name": "Malta",
+    "isCountry": true,
+    "countryCode": "MT"
+  },
+  {
+    "id": 32000148,
+    "name": "Marshall Islands",
+    "isCountry": true,
+    "countryCode": "MH"
+  },
+  {
+    "id": 32000149,
+    "name": "Martinique",
+    "isCountry": true,
+    "countryCode": "MQ"
+  },
+  {
+    "id": 32000150,
+    "name": "Mauritania",
+    "isCountry": true,
+    "countryCode": "MR"
+  },
+  {
+    "id": 32000151,
+    "name": "Mauritius",
+    "isCountry": true,
+    "countryCode": "MU"
+  },
+  {
+    "id": 32000152,
+    "name": "Mayotte",
+    "isCountry": true,
+    "countryCode": "YT"
+  },
+  {
+    "id": 32000153,
+    "name": "Mexico",
+    "isCountry": true,
+    "countryCode": "MX"
+  },
+  {
+    "id": 32000154,
+    "name": "Micronesia",
+    "isCountry": true,
+    "countryCode": "FM"
+  },
+  {
+    "id": 32000155,
+    "name": "Moldova",
+    "isCountry": true,
+    "countryCode": "MD"
+  },
+  {
+    "id": 32000156,
+    "name": "Monaco",
+    "isCountry": true,
+    "countryCode": "MC"
+  },
+  {
+    "id": 32000157,
+    "name": "Mongolia",
+    "isCountry": true,
+    "countryCode": "MN"
+  },
+  {
+    "id": 32000158,
+    "name": "Montenegro",
+    "isCountry": true,
+    "countryCode": "ME"
+  },
+  {
+    "id": 32000159,
+    "name": "Montserrat",
+    "isCountry": true,
+    "countryCode": "MS"
+  },
+  {
+    "id": 32000160,
+    "name": "Morocco",
+    "isCountry": true,
+    "countryCode": "MA"
+  },
+  {
+    "id": 32000161,
+    "name": "Mozambique",
+    "isCountry": true,
+    "countryCode": "MZ"
+  },
+  {
+    "id": 32000162,
+    "name": "Myanmar (Burma)",
+    "isCountry": true,
+    "countryCode": "MM"
+  },
+  {
+    "id": 32000163,
+    "name": "Namibia",
+    "isCountry": true,
+    "countryCode": "NA"
+  },
+  {
+    "id": 32000164,
+    "name": "Nauru",
+    "isCountry": true,
+    "countryCode": "NR"
+  },
+  {
+    "id": 32000165,
+    "name": "Nepal",
+    "isCountry": true,
+    "countryCode": "NP"
+  },
+  {
+    "id": 32000166,
+    "name": "Netherlands",
+    "isCountry": true,
+    "countryCode": "NL"
+  },
+  {
+    "id": 32000167,
+    "name": "New Caledonia",
+    "isCountry": true,
+    "countryCode": "NC"
+  },
+  {
+    "id": 32000168,
+    "name": "New Zealand",
+    "isCountry": true,
+    "countryCode": "NZ"
+  },
+  {
+    "id": 32000169,
+    "name": "Nicaragua",
+    "isCountry": true,
+    "countryCode": "NI"
+  },
+  {
+    "id": 32000170,
+    "name": "Niger",
+    "isCountry": true,
+    "countryCode": "NE"
+  },
+  {
+    "id": 32000171,
+    "name": "Nigeria",
+    "isCountry": true,
+    "countryCode": "NG"
+  },
+  {
+    "id": 32000172,
+    "name": "Niue",
+    "isCountry": true,
+    "countryCode": "NU"
+  },
+  {
+    "id": 32000173,
+    "name": "Norfolk Island",
+    "isCountry": true,
+    "countryCode": "NF"
+  },
+  {
+    "id": 32000174,
+    "name": "North Korea",
+    "isCountry": true,
+    "countryCode": "KP"
+  },
+  {
+    "id": 32000175,
+    "name": "Northern Mariana Islands",
+    "isCountry": true,
+    "countryCode": "MP"
+  },
+  {
+    "id": 32000176,
+    "name": "Norway",
+    "isCountry": true,
+    "countryCode": "NO"
+  },
+  {
+    "id": 32000177,
+    "name": "Oman",
+    "isCountry": true,
+    "countryCode": "OM"
+  },
+  {
+    "id": 32000178,
+    "name": "Pakistan",
+    "isCountry": true,
+    "countryCode": "PK"
+  },
+  {
+    "id": 32000179,
+    "name": "Palau",
+    "isCountry": true,
+    "countryCode": "PW"
+  },
+  {
+    "id": 32000180,
+    "name": "Palestine",
+    "isCountry": true,
+    "countryCode": "PS"
+  },
+  {
+    "id": 32000181,
+    "name": "Panama",
+    "isCountry": true,
+    "countryCode": "PA"
+  },
+  {
+    "id": 32000182,
+    "name": "Papua New Guinea",
+    "isCountry": true,
+    "countryCode": "PG"
+  },
+  {
+    "id": 32000183,
+    "name": "Paraguay",
+    "isCountry": true,
+    "countryCode": "PY"
+  },
+  {
+    "id": 32000184,
+    "name": "Peru",
+    "isCountry": true,
+    "countryCode": "PE"
+  },
+  {
+    "id": 32000185,
+    "name": "Philippines",
+    "isCountry": true,
+    "countryCode": "PH"
+  },
+  {
+    "id": 32000186,
+    "name": "Pitcairn Islands",
+    "isCountry": true,
+    "countryCode": "PN"
+  },
+  {
+    "id": 32000187,
+    "name": "Poland",
+    "isCountry": true,
+    "countryCode": "PL"
+  },
+  {
+    "id": 32000188,
+    "name": "Portugal",
+    "isCountry": true,
+    "countryCode": "PT"
+  },
+  {
+    "id": 32000189,
+    "name": "Puerto Rico",
+    "isCountry": true,
+    "countryCode": "PR"
+  },
+  {
+    "id": 32000190,
+    "name": "Qatar",
+    "isCountry": true,
+    "countryCode": "QA"
+  },
+  {
+    "id": 32000191,
+    "name": "Réunion",
+    "isCountry": true,
+    "countryCode": "RE"
+  },
+  {
+    "id": 32000192,
+    "name": "Romania",
+    "isCountry": true,
+    "countryCode": "RO"
+  },
+  {
+    "id": 32000193,
+    "name": "Russia",
+    "isCountry": true,
+    "countryCode": "RU"
+  },
+  {
+    "id": 32000194,
+    "name": "Rwanda",
+    "isCountry": true,
+    "countryCode": "RW"
+  },
+  {
+    "id": 32000195,
+    "name": "Saint Barthélemy",
+    "isCountry": true,
+    "countryCode": "BL"
+  },
+  {
+    "id": 32000196,
+    "name": "Saint Helena",
+    "isCountry": true,
+    "countryCode": "SH"
+  },
+  {
+    "id": 32000197,
+    "name": "Saint Kitts and Nevis",
+    "isCountry": true,
+    "countryCode": "KN"
+  },
+  {
+    "id": 32000198,
+    "name": "Saint Lucia",
+    "isCountry": true,
+    "countryCode": "LC"
+  },
+  {
+    "id": 32000199,
+    "name": "Saint Martin",
+    "isCountry": true,
+    "countryCode": "MF"
+  },
+  {
+    "id": 32000200,
+    "name": "Saint Pierre and Miquelon",
+    "isCountry": true,
+    "countryCode": "PM"
+  },
+  {
+    "id": 32000201,
+    "name": "Samoa",
+    "isCountry": true,
+    "countryCode": "WS"
+  },
+  {
+    "id": 32000202,
+    "name": "San Marino",
+    "isCountry": true,
+    "countryCode": "SM"
+  },
+  {
+    "id": 32000203,
+    "name": "São Tomé and Príncipe",
+    "isCountry": true,
+    "countryCode": "ST"
+  },
+  {
+    "id": 32000204,
+    "name": "Saudi Arabia",
+    "isCountry": true,
+    "countryCode": "SA"
+  },
+  {
+    "id": 32000205,
+    "name": "Senegal",
+    "isCountry": true,
+    "countryCode": "SN"
+  },
+  {
+    "id": 32000206,
+    "name": "Serbia",
+    "isCountry": true,
+    "countryCode": "RS"
+  },
+  {
+    "id": 32000207,
+    "name": "Seychelles",
+    "isCountry": true,
+    "countryCode": "SC"
+  },
+  {
+    "id": 32000208,
+    "name": "Sierra Leone",
+    "isCountry": true,
+    "countryCode": "SL"
+  },
+  {
+    "id": 32000209,
+    "name": "Singapore",
+    "isCountry": true,
+    "countryCode": "SG"
+  },
+  {
+    "id": 32000210,
+    "name": "Sint Maarten",
+    "isCountry": true,
+    "countryCode": "SX"
+  },
+  {
+    "id": 32000211,
+    "name": "Slovakia",
+    "isCountry": true,
+    "countryCode": "SK"
+  },
+  {
+    "id": 32000212,
+    "name": "Slovenia",
+    "isCountry": true,
+    "countryCode": "SI"
+  },
+  {
+    "id": 32000213,
+    "name": "Solomon Islands",
+    "isCountry": true,
+    "countryCode": "SB"
+  },
+  {
+    "id": 32000214,
+    "name": "Somalia",
+    "isCountry": true,
+    "countryCode": "SO"
+  },
+  {
+    "id": 32000215,
+    "name": "South Africa",
+    "isCountry": true,
+    "countryCode": "ZA"
+  },
+  {
+    "id": 32000216,
+    "name": "South Korea",
+    "isCountry": true,
+    "countryCode": "KR"
+  },
+  {
+    "id": 32000217,
+    "name": "South Sudan",
+    "isCountry": true,
+    "countryCode": "SS"
+  },
+  {
+    "id": 32000218,
+    "name": "Spain",
+    "isCountry": true,
+    "countryCode": "ES"
+  },
+  {
+    "id": 32000219,
+    "name": "Sri Lanka",
+    "isCountry": true,
+    "countryCode": "LK"
+  },
+  {
+    "id": 32000220,
+    "name": "St. Vincent & Grenadines",
+    "isCountry": true,
+    "countryCode": "VC"
+  },
+  {
+    "id": 32000221,
+    "name": "Sudan",
+    "isCountry": true,
+    "countryCode": "SD"
+  },
+  {
+    "id": 32000222,
+    "name": "Suriname",
+    "isCountry": true,
+    "countryCode": "SR"
+  },
+  {
+    "id": 32000223,
+    "name": "Svalbard and Jan Mayen",
+    "isCountry": true,
+    "countryCode": "SJ"
+  },
+  {
+    "id": 32000224,
+    "name": "Swaziland",
+    "isCountry": true,
+    "countryCode": "SZ"
+  },
+  {
+    "id": 32000225,
+    "name": "Sweden",
+    "isCountry": true,
+    "countryCode": "SE"
+  },
+  {
+    "id": 32000226,
+    "name": "Switzerland",
+    "isCountry": true,
+    "countryCode": "CH"
+  },
+  {
+    "id": 32000227,
+    "name": "Syria",
+    "isCountry": true,
+    "countryCode": "SY"
+  },
+  {
+    "id": 32000228,
+    "name": "Taiwan",
+    "isCountry": true,
+    "countryCode": "TW"
+  },
+  {
+    "id": 32000229,
+    "name": "Tajikistan",
+    "isCountry": true,
+    "countryCode": "TJ"
+  },
+  {
+    "id": 32000230,
+    "name": "Tanzania",
+    "isCountry": true,
+    "countryCode": "TZ"
+  },
+  {
+    "id": 32000231,
+    "name": "Thailand",
+    "isCountry": true,
+    "countryCode": "TH"
+  },
+  {
+    "id": 32000232,
+    "name": "Timor-Leste",
+    "isCountry": true,
+    "countryCode": "TL"
+  },
+  {
+    "id": 32000233,
+    "name": "Togo",
+    "isCountry": true,
+    "countryCode": "TG"
+  },
+  {
+    "id": 32000234,
+    "name": "Tokelau",
+    "isCountry": true,
+    "countryCode": "TK"
+  },
+  {
+    "id": 32000235,
+    "name": "Tonga",
+    "isCountry": true,
+    "countryCode": "TO"
+  },
+  {
+    "id": 32000236,
+    "name": "Trinidad and Tobago",
+    "isCountry": true,
+    "countryCode": "TT"
+  },
+  {
+    "id": 32000237,
+    "name": "Tristan da Cunha",
+    "isCountry": true,
+    "countryCode": "TA"
+  },
+  {
+    "id": 32000238,
+    "name": "Tunisia",
+    "isCountry": true,
+    "countryCode": "TN"
+  },
+  {
+    "id": 32000239,
+    "name": "Türkiye",
+    "isCountry": true,
+    "countryCode": "TR"
+  },
+  {
+    "id": 32000240,
+    "name": "Turkmenistan",
+    "isCountry": true,
+    "countryCode": "TM"
+  },
+  {
+    "id": 32000241,
+    "name": "Turks and Caicos Islands",
+    "isCountry": true,
+    "countryCode": "TC"
+  },
+  {
+    "id": 32000242,
+    "name": "Tuvalu",
+    "isCountry": true,
+    "countryCode": "TV"
+  },
+  {
+    "id": 32000243,
+    "name": "U.S. Outlying Islands",
+    "isCountry": true,
+    "countryCode": "UM"
+  },
+  {
+    "id": 32000244,
+    "name": "U.S. Virgin Islands",
+    "isCountry": true,
+    "countryCode": "VI"
+  },
+  {
+    "id": 32000245,
+    "name": "Uganda",
+    "isCountry": true,
+    "countryCode": "UG"
+  },
+  {
+    "id": 32000246,
+    "name": "Ukraine",
+    "isCountry": true,
+    "countryCode": "UA"
+  },
+  {
+    "id": 32000247,
+    "name": "United Arab Emirates",
+    "isCountry": true,
+    "countryCode": "AE"
+  },
+  {
+    "id": 32000248,
+    "name": "United Kingdom",
+    "isCountry": true,
+    "countryCode": "GB"
+  },
+  {
+    "id": 32000249,
+    "name": "United States",
+    "isCountry": true,
+    "countryCode": "US"
+  },
+  {
+    "id": 32000250,
+    "name": "Uruguay",
+    "isCountry": true,
+    "countryCode": "UY"
+  },
+  {
+    "id": 32000251,
+    "name": "Uzbekistan",
+    "isCountry": true,
+    "countryCode": "UZ"
+  },
+  {
+    "id": 32000252,
+    "name": "Vanuatu",
+    "isCountry": true,
+    "countryCode": "VU"
+  },
+  {
+    "id": 32000253,
+    "name": "Vatican City",
+    "isCountry": true,
+    "countryCode": "VA"
+  },
+  {
+    "id": 32000254,
+    "name": "Venezuela",
+    "isCountry": true,
+    "countryCode": "VE"
+  },
+  {
+    "id": 32000255,
+    "name": "Vietnam",
+    "isCountry": true,
+    "countryCode": "VN"
+  },
+  {
+    "id": 32000256,
+    "name": "Wallis and Futuna",
+    "isCountry": true,
+    "countryCode": "WF"
+  },
+  {
+    "id": 32000257,
+    "name": "Western Sahara",
+    "isCountry": true,
+    "countryCode": "EH"
+  },
+  {
+    "id": 32000258,
+    "name": "Yemen",
+    "isCountry": true,
+    "countryCode": "YE"
+  },
+  {
+    "id": 32000259,
+    "name": "Zambia",
+    "isCountry": true,
+    "countryCode": "ZM"
+  },
+  {
+    "id": 32000260,
+    "name": "Zimbabwe",
+    "isCountry": true,
+    "countryCode": "ZW"
+  }
+]

--- a/internal/routes/search_test.go
+++ b/internal/routes/search_test.go
@@ -1,0 +1,310 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+const searchTestEncryptionKey = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+
+func TestNormalizePlayerSearchQueryUsesDiscreteTownhallsAndCapsLists(t *testing.T) {
+	request := modelsv2.SearchPlayerQuery{
+		Query: "  Magic  ",
+		Filters: modelsv2.SearchPlayerFilters{
+			ClanTags:       []string{"vy2j0ll", "#VY2J0LL"},
+			LeagueIDs:      []int{105000035, 105000034, 105000035},
+			TownhallLevels: []int{17, 1, 17, 100},
+		},
+	}
+	limit, err := normalizePlayerSearchQuery(&request)
+	if err != nil {
+		t.Fatalf("normalize player query: %v", err)
+	}
+	if limit != searchDefaultLimit || request.Query != "Magic" {
+		t.Fatalf("unexpected normalized request: %#v", request)
+	}
+	if got := strings.Join(request.Filters.ClanTags, ","); got != "#VY2J0LL" {
+		t.Fatalf("unexpected clan tags %q", got)
+	}
+	if got := request.Filters.LeagueIDs; len(got) != 2 || got[0] != 105000034 || got[1] != 105000035 {
+		t.Fatalf("unexpected league ids %#v", got)
+	}
+	if got := request.Filters.TownhallLevels; len(got) != 3 || got[0] != 1 || got[1] != 17 || got[2] != 100 {
+		t.Fatalf("unexpected townhall levels %#v", got)
+	}
+
+	for _, unsupported := range []int{0, 101} {
+		request.Filters.TownhallLevels = []int{unsupported}
+		if _, err := normalizePlayerSearchQuery(&request); err == nil {
+			t.Fatalf("expected townhall level %d to be rejected", unsupported)
+		}
+	}
+}
+
+func TestNormalizeSearchQueryEnforcesFilterCaps(t *testing.T) {
+	for name, filters := range map[string]modelsv2.SearchClanFilters{
+		"location ids":   {LocationIDs: []int{1, 2, 3, 4, 5, 6}},
+		"CWL league ids": {CWLLeagueIDs: []int{1, 2, 3, 4, 5, 6}},
+	} {
+		clan := modelsv2.SearchClanQuery{Query: "Clan", Filters: filters}
+		if _, err := normalizeClanSearchQuery(&clan); err == nil {
+			t.Fatalf("expected too many %s to be rejected", name)
+		}
+	}
+
+	for name, filters := range map[string]modelsv2.SearchPlayerFilters{
+		"clan tags":  {ClanTags: make([]string, 101)},
+		"league ids": {LeagueIDs: []int{1, 2, 3, 4, 5, 6}},
+	} {
+		player := modelsv2.SearchPlayerQuery{Query: "Player", Filters: filters}
+		if _, err := normalizePlayerSearchQuery(&player); err == nil {
+			t.Fatalf("expected too many %s to be rejected", name)
+		}
+	}
+}
+
+func TestSearchResultJSONUsesCompactBadgeAndRequestedFieldOrder(t *testing.T) {
+	clanRaw, err := json.Marshal(modelsv2.SearchClanResult{
+		Name: "Clan", Tag: "#VY2J0LL", Badge: "badge.png", ClanLevel: 25, Members: 50,
+	})
+	if err != nil {
+		t.Fatalf("marshal clan: %v", err)
+	}
+	assertJSONFieldOrder(t, string(clanRaw), []string{`"name"`, `"tag"`, `"badge"`, `"clanLevel"`, `"members"`})
+	if strings.Contains(string(clanRaw), "badgeUrls") {
+		t.Fatalf("unexpected expanded badge object: %s", clanRaw)
+	}
+
+	playerRaw, err := json.Marshal(modelsv2.SearchPlayerResult{
+		Name: "Player", Tag: "#2PP", Clan: &modelsv2.SearchPlayerClan{Name: "Clan", Tag: "#VY2J0LL", Badge: "badge.png"},
+		LeagueTier: &modelsv2.SearchLeagueReference{ID: 105000034, Name: "Legend League"},
+	})
+	if err != nil {
+		t.Fatalf("marshal player: %v", err)
+	}
+	assertJSONFieldOrder(t, string(playerRaw), []string{`"name"`, `"tag"`, `"leagueTier"`, `"clan"`})
+	clanStart := strings.Index(string(playerRaw), `"clan"`)
+	assertJSONFieldOrder(t, string(playerRaw)[clanStart:], []string{`"name"`, `"tag"`, `"badge"`})
+	if strings.Contains(string(playerRaw), `"leagueTier":{"id":105000034,"name":"Legend League","badge"`) {
+		t.Fatalf("league tier must not contain a badge: %s", playerRaw)
+	}
+}
+
+func TestPlayerSearchPaginatesWithEncryptedPITCursorAndEnrichesClan(t *testing.T) {
+	if err := apptypes.InitEncryption(searchTestEncryptionKey); err != nil {
+		t.Fatalf("initialize encryption: %v", err)
+	}
+	var mu sync.Mutex
+	searchCalls := 0
+	closedPIT := ""
+	elasticsearch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/players/_pit":
+			_, _ = io.WriteString(w, `{"id":"pit-1"}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/_search":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode search body: %v", err)
+			}
+			mu.Lock()
+			searchCalls++
+			call := searchCalls
+			mu.Unlock()
+			pit := body["pit"].(map[string]any)["id"]
+			if call == 1 {
+				if pit != "pit-1" || body["size"] != float64(2) {
+					t.Errorf("unexpected first page body: %#v", body)
+				}
+				_, _ = io.WriteString(w, `{"pit_id":"pit-2","hits":{"hits":[`+
+					`{"_source":{"tag":"#8GLYGGJQ","name":"Magic","league_id":105000034,"clan_tag":"#VY2J0LL","townhall_level":17},"sort":[9.5,"#8glyggjq"]},`+
+					`{"_source":{"tag":"#2PP","name":"Magic Two","townhall_level":16},"sort":[8.2,"#2pp"]}`+
+					`]}}`)
+				return
+			}
+			if pit != "pit-2" || body["search_after"] == nil {
+				t.Errorf("unexpected continuation body: %#v", body)
+			}
+			_, _ = io.WriteString(w, `{"pit_id":"pit-3","hits":{"hits":[`+
+				`{"_source":{"tag":"#2PP","name":"Magic Two","league_id":105000035,"townhall_level":16},"sort":[8.2,"#2pp"]}`+
+				`]}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/clans/_mget":
+			if got := r.URL.Query().Get("_source_includes"); got != "tag,name,clan_level,badge_token" {
+				t.Errorf("unexpected mget source filter %q", got)
+			}
+			_, _ = io.WriteString(w, `{"docs":[{"_id":"#VY2J0LL","found":true,"_source":{"tag":"#VY2J0LL","name":"Clash King","clan_level":27,"badge_token":"badge-token"}}]}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/_pit":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			closedPIT = body["id"]
+			_, _ = io.WriteString(w, `{"succeeded":true}`)
+		default:
+			t.Errorf("unexpected Elasticsearch request %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer elasticsearch.Close()
+
+	search, err := apptypes.NewElasticsearchAdapter(apptypes.Config{
+		ElasticsearchURL: elasticsearch.URL, ElasticsearchPlayersAlias: "players", ElasticsearchClansAlias: "clans",
+	})
+	if err != nil {
+		t.Fatalf("create search adapter: %v", err)
+	}
+	clash, err := apptypes.NewClashAdapter(context.Background(), elasticsearch.URL)
+	if err != nil {
+		t.Fatalf("create Clash adapter: %v", err)
+	}
+	defer clash.Close()
+
+	app := fiber.New(fiber.Config{RequestMethods: apptypes.APIRequestMethods(), ErrorHandler: apptypes.ErrorHandler})
+	app.Add(apptypes.MethodQuery, "/v2/search/player", searchPlayers(apptypes.Deps{Search: search, Clash: clash}))
+	first := searchTestRequest(t, app, "/v2/search/player", `{"query":"Magic","filters":{"clan_tags":["#VY2J0LL"],"league_ids":[105000034],"townhall_levels":[17]},"limit":1}`)
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first page status = %d, body = %s", first.StatusCode, first.Body)
+	}
+	if len(first.Response.Items) != 1 || first.Response.Items[0].Clan == nil || first.Response.Items[0].Clan.Name != "Clash King" {
+		t.Fatalf("unexpected first page: %#v", first.Response)
+	}
+	if first.Response.Items[0].LeagueTier == nil || first.Response.Items[0].LeagueTier.Name != "Legend League" {
+		t.Fatalf("expected fleshed league tier: %#v", first.Response.Items[0].LeagueTier)
+	}
+	if first.Response.Pagination.NextCursor == nil || !first.Response.Pagination.HasMore {
+		t.Fatalf("expected continuation cursor: %#v", first.Response.Pagination)
+	}
+
+	secondBody := `{"query":"Magic","filters":{"clan_tags":["#VY2J0LL"],"league_ids":[105000034],"townhall_levels":[17]},"limit":1,"cursor":` + mustJSON(t, *first.Response.Pagination.NextCursor) + `}`
+	second := searchTestRequest(t, app, "/v2/search/player", secondBody)
+	if second.StatusCode != http.StatusOK || second.Response.Pagination.HasMore || second.Response.Pagination.NextCursor != nil {
+		t.Fatalf("unexpected second page: status=%d body=%s", second.StatusCode, second.Body)
+	}
+	if closedPIT != "pit-3" {
+		t.Fatalf("closed PIT = %q, want pit-3", closedPIT)
+	}
+}
+
+func TestClanSearchUsesAliasFiltersAndOfficialReferenceShapes(t *testing.T) {
+	var searchBody map[string]any
+	closedPIT := ""
+	elasticsearch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/clans/_pit":
+			if got := r.URL.Query().Get("keep_alive"); got != searchPITKeepAlive {
+				t.Errorf("PIT keep_alive = %q", got)
+			}
+			_, _ = io.WriteString(w, `{"id":"clan-pit"}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/_search":
+			if err := json.NewDecoder(r.Body).Decode(&searchBody); err != nil {
+				t.Errorf("decode search body: %v", err)
+			}
+			_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{"tag":"#VY2J0LL","name":"Clash King","clan_level":27,"badge_token":"badge-token","location_id":32000249,"cwl_league_id":48000018,"member_count":49},"sort":[9.5,"#vy2j0ll"]}]}}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/_pit":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			closedPIT = body["id"]
+			_, _ = io.WriteString(w, `{"succeeded":true}`)
+		default:
+			t.Errorf("unexpected Elasticsearch request %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer elasticsearch.Close()
+
+	search, err := apptypes.NewElasticsearchAdapter(apptypes.Config{
+		ElasticsearchURL: elasticsearch.URL, ElasticsearchPlayersAlias: "players", ElasticsearchClansAlias: "clans",
+	})
+	if err != nil {
+		t.Fatalf("create search adapter: %v", err)
+	}
+	clash, err := apptypes.NewClashAdapter(context.Background(), elasticsearch.URL)
+	if err != nil {
+		t.Fatalf("create Clash adapter: %v", err)
+	}
+	defer clash.Close()
+
+	app := fiber.New(fiber.Config{RequestMethods: apptypes.APIRequestMethods(), ErrorHandler: apptypes.ErrorHandler})
+	app.Add(apptypes.MethodQuery, "/v2/search/clan", searchClans(apptypes.Deps{Search: search, Clash: clash}))
+	req := httptest.NewRequest(apptypes.MethodQuery, "/v2/search/clan", strings.NewReader(`{"query":"Clash","filters":{"location_ids":[32000249],"cwl_league_ids":[48000018],"clan_level":{"min":20},"members":{"min":40,"max":50}}}`))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("execute request: %v", err)
+	}
+	defer resp.Body.Close()
+	var result modelsv2.SearchClanResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK || len(result.Items) != 1 {
+		t.Fatalf("unexpected response status=%d body=%#v", resp.StatusCode, result)
+	}
+	item := result.Items[0]
+	if item.Location == nil || item.Location.Name != "United States" || item.Location.CountryCode != "US" || !item.Location.IsCountry {
+		t.Fatalf("location was not fleshed out: %#v", item.Location)
+	}
+	if item.WarLeague == nil || item.WarLeague.ID != 48000018 || item.WarLeague.Name != "Champion League I" {
+		t.Fatalf("war league was not fleshed out: %#v", item.WarLeague)
+	}
+	if item.Badge != badgeURL("badge-token", 512) {
+		t.Fatalf("badge = %q", item.Badge)
+	}
+	if result.Pagination.Limit != searchDefaultLimit || result.Pagination.HasMore || result.Pagination.NextCursor != nil {
+		t.Fatalf("unexpected pagination: %#v", result.Pagination)
+	}
+	if closedPIT != "clan-pit" {
+		t.Fatalf("closed PIT = %q", closedPIT)
+	}
+	query := searchBody["query"].(map[string]any)["bool"].(map[string]any)
+	filters, ok := query["filter"].([]any)
+	if !ok || len(filters) != 4 {
+		t.Fatalf("expected all clan filters in Elasticsearch query: %#v", query["filter"])
+	}
+}
+
+type searchPlayerTestResponse struct {
+	StatusCode int
+	Body       string
+	Response   modelsv2.SearchPlayerResponse
+}
+
+func searchTestRequest(t *testing.T, app *fiber.App, path, body string) searchPlayerTestResponse {
+	t.Helper()
+	req := httptest.NewRequest(apptypes.MethodQuery, path, strings.NewReader(body))
+	req.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("execute request: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	result := searchPlayerTestResponse{StatusCode: resp.StatusCode, Body: string(raw)}
+	if resp.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &result.Response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+	}
+	return result
+}
+
+func mustJSON(t *testing.T, value string) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	return string(raw)
+}

--- a/internal/routes/search_test.go
+++ b/internal/routes/search_test.go
@@ -176,7 +176,7 @@ func TestPlayerSearchPaginatesWithEncryptedPITCursorAndEnrichesClan(t *testing.T
 	if len(first.Response.Items) != 1 || first.Response.Items[0].Clan == nil || first.Response.Items[0].Clan.Name != "Clash King" {
 		t.Fatalf("unexpected first page: %#v", first.Response)
 	}
-	if first.Response.Items[0].LeagueTier == nil || first.Response.Items[0].LeagueTier.Name != "Legend League" {
+	if first.Response.Items[0].LeagueTier == nil || first.Response.Items[0].LeagueTier.ID != 105000034 || first.Response.Items[0].LeagueTier.Name == "" {
 		t.Fatalf("expected fleshed league tier: %#v", first.Response.Items[0].LeagueTier)
 	}
 	if first.Response.Pagination.NextCursor == nil || !first.Response.Pagination.HasMore {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	TimescaleURL                 string
 	ValkeyAddress                string
 	ValkeyPassword               string
+	ElasticsearchURL             string
+	ElasticsearchAPIKey          string
+	ElasticsearchPlayersAlias    string
+	ElasticsearchClansAlias      string
 	BunnyAccessKey               string
 	AIUsageSecret                string
 	Local                        bool
@@ -70,6 +74,10 @@ func Load() (Config, error) {
 		TimescaleURL:                 buildTimescaleURL(os.Getenv),
 		ValkeyAddress:                buildValkeyAddress(os.Getenv),
 		ValkeyPassword:               os.Getenv("VALKEY_PASSWORD"),
+		ElasticsearchURL:             normalizeOrigin(os.Getenv("ELASTICSEARCH_URL")),
+		ElasticsearchAPIKey:          strings.TrimSpace(os.Getenv("ELASTICSEARCH_API_KEY")),
+		ElasticsearchPlayersAlias:    firstNonEmpty(os.Getenv("ELASTICSEARCH_PLAYERS_ALIAS"), "clashking_players"),
+		ElasticsearchClansAlias:      firstNonEmpty(os.Getenv("ELASTICSEARCH_CLANS_ALIAS"), "clashking_clans"),
 		BunnyAccessKey:               os.Getenv("BUNNY_ACCESS_KEY"),
 		AIUsageSecret:                os.Getenv("AI_USAGE_SECRET"),
 		Local:                        strings.EqualFold(os.Getenv("LOCAL"), "TRUE"),
@@ -162,6 +170,12 @@ func (c Config) validate() error {
 		return errors.New("LOCAL=TRUE requires DEV_USER_ID")
 	}
 	if !c.Local {
+		if strings.TrimSpace(c.ElasticsearchURL) == "" {
+			return errors.New("ELASTICSEARCH_URL is required outside local mode")
+		}
+		if strings.TrimSpace(c.ElasticsearchAPIKey) == "" {
+			return errors.New("ELASTICSEARCH_API_KEY is required outside local mode")
+		}
 		if strings.TrimSpace(c.ValkeyAddress) == "" {
 			return errors.New("VALKEY_HOST is required outside local mode")
 		}
@@ -193,7 +207,29 @@ func (c Config) validate() error {
 	if c.SMTPStartTLS && c.SMTPSSLTLS {
 		return errors.New("SMTP_STARTTLS and SMTP_SSL_TLS cannot both be enabled")
 	}
+	for key, value := range map[string]string{
+		"ELASTICSEARCH_PLAYERS_ALIAS": c.ElasticsearchPlayersAlias,
+		"ELASTICSEARCH_CLANS_ALIAS":   c.ElasticsearchClansAlias,
+	} {
+		if !validElasticsearchName(value) {
+			return fmt.Errorf("%s contains unsupported characters", key)
+		}
+	}
 	return nil
+}
+
+func validElasticsearchName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 255 || value == "." || value == ".." || strings.ContainsRune("-_+", rune(value[0])) {
+		return false
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' || char == '-' || char == '_' || char == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -76,8 +76,8 @@ func Load() (Config, error) {
 		ValkeyPassword:               os.Getenv("VALKEY_PASSWORD"),
 		ElasticsearchURL:             normalizeOrigin(os.Getenv("ELASTICSEARCH_URL")),
 		ElasticsearchAPIKey:          strings.TrimSpace(os.Getenv("ELASTICSEARCH_API_KEY")),
-		ElasticsearchPlayersAlias:    firstNonEmpty(os.Getenv("ELASTICSEARCH_PLAYERS_ALIAS"), "clashking_players"),
-		ElasticsearchClansAlias:      firstNonEmpty(os.Getenv("ELASTICSEARCH_CLANS_ALIAS"), "clashking_clans"),
+		ElasticsearchPlayersAlias:    normalizeElasticsearchAlias(os.Getenv("ELASTICSEARCH_PLAYERS_ALIAS"), "clashking_players"),
+		ElasticsearchClansAlias:      normalizeElasticsearchAlias(os.Getenv("ELASTICSEARCH_CLANS_ALIAS"), "clashking_clans"),
 		BunnyAccessKey:               os.Getenv("BUNNY_ACCESS_KEY"),
 		AIUsageSecret:                os.Getenv("AI_USAGE_SECRET"),
 		Local:                        strings.EqualFold(os.Getenv("LOCAL"), "TRUE"),
@@ -230,6 +230,10 @@ func validElasticsearchName(value string) bool {
 		return false
 	}
 	return true
+}
+
+func normalizeElasticsearchAlias(value, fallback string) string {
+	return strings.TrimSpace(firstNonEmpty(value, fallback))
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/utils/cors.go
+++ b/internal/utils/cors.go
@@ -86,8 +86,8 @@ func isPublicCORSRequest(c *fiber.Ctx) bool {
 	switch method {
 	case fiber.MethodGet, fiber.MethodHead:
 		return !strings.HasPrefix(c.Path(), "/v2/auth/") && !strings.HasPrefix(c.Path(), "/v2/privacy/")
-	case "QUERY":
-		return strings.HasPrefix(c.Path(), "/v2/stats/")
+	case MethodQuery:
+		return strings.HasPrefix(c.Path(), "/v2/stats/") || strings.HasPrefix(c.Path(), "/v2/search/")
 	default:
 		return false
 	}

--- a/internal/utils/cors_test.go
+++ b/internal/utils/cors_test.go
@@ -8,14 +8,61 @@ import (
 )
 
 func newCORSTestApp(cfg Config) *fiber.App {
-	app := fiber.New(fiber.Config{ErrorHandler: ErrorHandler})
+	app := fiber.New(fiber.Config{ErrorHandler: ErrorHandler, RequestMethods: APIRequestMethods()})
 	app.Use(CORSMiddleware(cfg))
 	app.Get("/v2/stats/public", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusNoContent) })
 	app.Get("/v2/player/test", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusNoContent) })
+	app.Add(MethodQuery, "/v2/search/clan", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusNoContent) })
+	app.Add(MethodQuery, "/v2/search/player", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusNoContent) })
 	app.Post("/v2/auth/web/refresh", RequireWebOrigin(cfg), func(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 	return app
+}
+
+func TestCORSPublicSearchQueriesRemainWildcard(t *testing.T) {
+	app := newCORSTestApp(Config{WebAllowedOrigins: []string{"https://dash.clashk.ing"}})
+	for _, path := range []string{"/v2/search/clan", "/v2/search/player"} {
+		t.Run(path+" preflight", func(t *testing.T) {
+			request := httptest.NewRequest(fiber.MethodOptions, path, nil)
+			request.Header.Set(fiber.HeaderOrigin, "https://unrelated.example")
+			request.Header.Set(fiber.HeaderAccessControlRequestMethod, MethodQuery)
+			request.Header.Set(fiber.HeaderAccessControlRequestHeaders, "content-type")
+
+			response, err := app.Test(request)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if response.StatusCode != fiber.StatusNoContent {
+				t.Fatalf("status = %d, want %d", response.StatusCode, fiber.StatusNoContent)
+			}
+			if got := response.Header.Get(fiber.HeaderAccessControlAllowOrigin); got != "*" {
+				t.Fatalf("allow origin = %q, want wildcard", got)
+			}
+			if got := response.Header.Get(fiber.HeaderAccessControlAllowCredentials); got != "" {
+				t.Fatalf("public preflight unexpectedly allows credentials: %q", got)
+			}
+		})
+
+		t.Run(path+" request", func(t *testing.T) {
+			request := httptest.NewRequest(MethodQuery, path, nil)
+			request.Header.Set(fiber.HeaderOrigin, "https://unrelated.example")
+
+			response, err := app.Test(request)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			if response.StatusCode != fiber.StatusNoContent {
+				t.Fatalf("status = %d, want %d", response.StatusCode, fiber.StatusNoContent)
+			}
+			if got := response.Header.Get(fiber.HeaderAccessControlAllowOrigin); got != "*" {
+				t.Fatalf("allow origin = %q, want wildcard", got)
+			}
+			if got := response.Header.Get(fiber.HeaderAccessControlAllowCredentials); got != "" {
+				t.Fatalf("public response unexpectedly allows credentials: %q", got)
+			}
+		})
+	}
 }
 
 func TestCORSPublicReadsRemainWildcard(t *testing.T) {

--- a/internal/utils/elasticsearch.go
+++ b/internal/utils/elasticsearch.go
@@ -42,8 +42,8 @@ func NewElasticsearchAdapter(cfg Config) (*ElasticsearchAdapter, error) {
 		client: &http.Client{
 			Timeout: 15 * time.Second,
 		},
-		PlayersAlias: firstNonEmpty(cfg.ElasticsearchPlayersAlias, "clashking_players"),
-		ClansAlias:   firstNonEmpty(cfg.ElasticsearchClansAlias, "clashking_clans"),
+		PlayersAlias: normalizeElasticsearchAlias(cfg.ElasticsearchPlayersAlias, "clashking_players"),
+		ClansAlias:   normalizeElasticsearchAlias(cfg.ElasticsearchClansAlias, "clashking_clans"),
 	}, nil
 }
 

--- a/internal/utils/elasticsearch.go
+++ b/internal/utils/elasticsearch.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const elasticsearchMaximumResponseBytes = 16 << 20
+
+// ElasticsearchAdapter is the API's narrow, read-only Elasticsearch transport.
+// Search query construction remains in the route package so this adapter does
+// not leak product contracts into shared infrastructure.
+type ElasticsearchAdapter struct {
+	baseURL      *url.URL
+	apiKey       string
+	client       *http.Client
+	PlayersAlias string
+	ClansAlias   string
+}
+
+func NewElasticsearchAdapter(cfg Config) (*ElasticsearchAdapter, error) {
+	if strings.TrimSpace(cfg.ElasticsearchURL) == "" {
+		return nil, nil
+	}
+	parsed, err := url.Parse(cfg.ElasticsearchURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid ELASTICSEARCH_URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("ELASTICSEARCH_URL must use http or https")
+	}
+	return &ElasticsearchAdapter{
+		baseURL: parsed,
+		apiKey:  strings.TrimSpace(cfg.ElasticsearchAPIKey),
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		PlayersAlias: firstNonEmpty(cfg.ElasticsearchPlayersAlias, "clashking_players"),
+		ClansAlias:   firstNonEmpty(cfg.ElasticsearchClansAlias, "clashking_clans"),
+	}, nil
+}
+
+// DoJSON sends one Elasticsearch request and decodes its JSON response.
+func (a *ElasticsearchAdapter) DoJSON(ctx context.Context, method, requestPath string, query url.Values, body any, out any) error {
+	if a == nil || a.client == nil || a.baseURL == nil {
+		return fmt.Errorf("Elasticsearch is not configured")
+	}
+	var encoded io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		encoded = bytes.NewReader(raw)
+	}
+	endpoint := *a.baseURL
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/" + strings.TrimLeft(requestPath, "/")
+	endpoint.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), encoded)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if a.apiKey != "" {
+		req.Header.Set("Authorization", "ApiKey "+a.apiKey)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	limited := io.LimitReader(resp.Body, elasticsearchMaximumResponseBytes+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return err
+	}
+	if len(raw) > elasticsearchMaximumResponseBytes {
+		return fmt.Errorf("Elasticsearch response exceeded the supported size")
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("Elasticsearch request failed with status %d", resp.StatusCode)
+	}
+	if out == nil || len(raw) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode Elasticsearch response: %w", err)
+	}
+	return nil
+}
+
+func (a *ElasticsearchAdapter) Close() {
+	if a == nil || a.client == nil {
+		return
+	}
+	if transport, ok := a.client.Transport.(interface{ CloseIdleConnections() }); ok {
+		transport.CloseIdleConnections()
+		return
+	}
+	a.client.CloseIdleConnections()
+}

--- a/internal/utils/elasticsearch_test.go
+++ b/internal/utils/elasticsearch_test.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestElasticsearchAdapterUsesAPIKeyAndPreservesBasePath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/elastic/_search" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "ApiKey encoded-key" {
+			t.Errorf("authorization = %q", got)
+		}
+		if got := r.URL.Query().Get("keep_alive"); got != "2m" {
+			t.Errorf("keep_alive = %q", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if string(body) != `{"query":{"match_all":{}}}` {
+			t.Errorf("body = %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	adapter, err := NewElasticsearchAdapter(Config{
+		ElasticsearchURL: server.URL + "/elastic", ElasticsearchAPIKey: "encoded-key",
+	})
+	if err != nil {
+		t.Fatalf("create adapter: %v", err)
+	}
+	defer adapter.Close()
+	if adapter.PlayersAlias != "clashking_players" || adapter.ClansAlias != "clashking_clans" {
+		t.Fatalf("unexpected default aliases: players=%q clans=%q", adapter.PlayersAlias, adapter.ClansAlias)
+	}
+
+	var response map[string]bool
+	err = adapter.DoJSON(
+		context.Background(),
+		http.MethodPost,
+		"/_search",
+		url.Values{"keep_alive": {"2m"}},
+		map[string]any{"query": map[string]any{"match_all": map[string]any{}}},
+		&response,
+	)
+	if err != nil {
+		t.Fatalf("perform request: %v", err)
+	}
+	if !response["ok"] {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+}
+
+func TestElasticsearchAdapterRejectsInvalidURL(t *testing.T) {
+	for _, raw := range []string{"elastic:9200", "ftp://elastic.example"} {
+		if _, err := NewElasticsearchAdapter(Config{ElasticsearchURL: raw}); err == nil {
+			t.Fatalf("expected %q to be rejected", raw)
+		}
+	}
+}
+
+func TestElasticsearchNameValidation(t *testing.T) {
+	for _, valid := range []string{"clashking_players", "clans-v2", "search.alias"} {
+		if !validElasticsearchName(valid) {
+			t.Fatalf("expected %q to be valid", valid)
+		}
+	}
+	for _, invalid := range []string{"", "_hidden", "-clans", "Uppercase", "clans/*"} {
+		if validElasticsearchName(invalid) {
+			t.Fatalf("expected %q to be invalid", invalid)
+		}
+	}
+}
+
+func TestElasticsearchAdapterRejectsNonJSONResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "not-json")
+	}))
+	defer server.Close()
+	adapter, err := NewElasticsearchAdapter(Config{ElasticsearchURL: server.URL})
+	if err != nil {
+		t.Fatalf("create adapter: %v", err)
+	}
+	var response json.RawMessage
+	if err := adapter.DoJSON(context.Background(), http.MethodGet, "/", nil, nil, &response); err == nil {
+		t.Fatal("expected invalid JSON to fail")
+	}
+}

--- a/internal/utils/elasticsearch_test.go
+++ b/internal/utils/elasticsearch_test.go
@@ -35,13 +35,14 @@ func TestElasticsearchAdapterUsesAPIKeyAndPreservesBasePath(t *testing.T) {
 
 	adapter, err := NewElasticsearchAdapter(Config{
 		ElasticsearchURL: server.URL + "/elastic", ElasticsearchAPIKey: "encoded-key",
+		ElasticsearchPlayersAlias: "  players  ", ElasticsearchClansAlias: "  clans  ",
 	})
 	if err != nil {
 		t.Fatalf("create adapter: %v", err)
 	}
 	defer adapter.Close()
-	if adapter.PlayersAlias != "clashking_players" || adapter.ClansAlias != "clashking_clans" {
-		t.Fatalf("unexpected default aliases: players=%q clans=%q", adapter.PlayersAlias, adapter.ClansAlias)
+	if adapter.PlayersAlias != "players" || adapter.ClansAlias != "clans" {
+		t.Fatalf("unexpected normalized aliases: players=%q clans=%q", adapter.PlayersAlias, adapter.ClansAlias)
 	}
 
 	var response map[string]bool
@@ -79,6 +80,15 @@ func TestElasticsearchNameValidation(t *testing.T) {
 		if validElasticsearchName(invalid) {
 			t.Fatalf("expected %q to be invalid", invalid)
 		}
+	}
+}
+
+func TestNormalizeElasticsearchAliasUsesTrimmedOverrideOrDefault(t *testing.T) {
+	if got := normalizeElasticsearchAlias("  clans-v2  ", "clashking_clans"); got != "clans-v2" {
+		t.Fatalf("normalized override = %q", got)
+	}
+	if got := normalizeElasticsearchAlias("  ", "clashking_clans"); got != "clashking_clans" {
+		t.Fatalf("normalized default = %q", got)
 	}
 }
 

--- a/internal/utils/runtime.go
+++ b/internal/utils/runtime.go
@@ -11,6 +11,7 @@ type Deps struct {
 	Discord   *DiscordAdapter
 	Auth      *Authenticator
 	Cache     *CacheAdapter
+	Search    *ElasticsearchAdapter
 	Mailer    *Mailer
 	StartedAt time.Time
 }

--- a/main.go
+++ b/main.go
@@ -64,14 +64,21 @@ func New(ctx context.Context) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	searchAdapter, err := utils.NewElasticsearchAdapter(cfg)
+	if err != nil {
+		_ = stores.Close(ctx)
+		return nil, err
+	}
 	clashAdapter, err := utils.NewClashAdapter(ctx, cfg.ProxyOrigin)
 	if err != nil {
+		searchAdapter.Close()
 		_ = stores.Close(ctx)
 		return nil, err
 	}
 	discordAdapter, err := utils.NewDiscordAdapter(cfg)
 	if err != nil {
 		_ = clashAdapter.Close()
+		searchAdapter.Close()
 		_ = stores.Close(ctx)
 		return nil, err
 	}
@@ -83,6 +90,7 @@ func New(ctx context.Context) (*App, error) {
 			Discord:   discordAdapter,
 			Auth:      utils.NewAuthenticator(cfg, stores),
 			Cache:     utils.NewCacheAdapter(cfg),
+			Search:    searchAdapter,
 			Mailer:    utils.NewMailer(cfg),
 			StartedAt: time.Now().UTC(),
 		},
@@ -90,6 +98,7 @@ func New(ctx context.Context) (*App, error) {
 	}
 	server, err := application.buildFiber()
 	if err != nil {
+		_ = application.Shutdown(ctx)
 		return nil, err
 	}
 	application.Server = server
@@ -186,6 +195,9 @@ func (a *App) Shutdown(ctx context.Context) error {
 	}
 	if a.Cache != nil {
 		a.Cache.Close()
+	}
+	if a.Search != nil {
+		a.Search.Close()
 	}
 	utils.FlushSentry(2 * time.Second)
 	if a.Store != nil {

--- a/test/api/swagger_test.go
+++ b/test/api/swagger_test.go
@@ -1196,7 +1196,7 @@ func TestBuildDocIncludesPublicStatsSectionsFirst(t *testing.T) {
 
 func TestBuildDocRepresentsQueryOperationsWithoutAdvertisingPost(t *testing.T) {
 	paths := swaggerPaths(t, buildSwaggerDoc(t))
-	for _, path := range []string{"/v2/home/activity", "/v2/stats/armies", "/v2/stats/items", "/v2/stats/ranked", "/v2/stats/war", "/v2/stats/cwl"} {
+	for _, path := range []string{"/v2/home/activity", "/v2/stats/armies", "/v2/stats/items", "/v2/stats/ranked", "/v2/stats/war", "/v2/stats/cwl", "/v2/search/clan", "/v2/search/player"} {
 		operation, ok := paths[path].(map[string]any)
 		if !ok {
 			t.Fatalf("expected path object for %s", path)
@@ -1213,6 +1213,43 @@ func TestBuildDocRepresentsQueryOperationsWithoutAdvertisingPost(t *testing.T) {
 			t.Fatalf("expected %s QUERY operation to consume application/json, got %v", path, consumes)
 		}
 	}
+}
+
+func TestSearchOpenAPIUsesCompactTypedContracts(t *testing.T) {
+	doc := buildSwaggerDoc(t)
+	definitions := swaggerDefinitions(t, doc)
+
+	clan := swaggerDefinitionProperties(t, definitions, "modelsv2.SearchClanResult")
+	for _, field := range []string{"name", "tag", "badge", "clanLevel", "location", "warLeague", "members"} {
+		if _, ok := clan[field]; !ok {
+			t.Fatalf("clan search result omits %s", field)
+		}
+	}
+	if _, ok := clan["badgeUrls"]; ok {
+		t.Fatal("clan search result exposes badgeUrls instead of compact badge")
+	}
+	assertRef(t, clan["location"], "#/definitions/modelsv2.SearchLocation")
+	assertRef(t, clan["warLeague"], "#/definitions/modelsv2.SearchLeagueReference")
+
+	player := swaggerDefinitionProperties(t, definitions, "modelsv2.SearchPlayerResult")
+	assertRef(t, player["leagueTier"], "#/definitions/modelsv2.SearchLeagueReference")
+	assertRef(t, player["clan"], "#/definitions/modelsv2.SearchPlayerClan")
+	league := swaggerDefinitionProperties(t, definitions, "modelsv2.SearchLeagueReference")
+	if _, ok := league["badge"]; ok {
+		t.Fatal("search league tier exposes an unwanted badge")
+	}
+	playerClan := swaggerDefinitionProperties(t, definitions, "modelsv2.SearchPlayerClan")
+	if _, ok := playerClan["badge"]; !ok {
+		t.Fatal("player clan omits compact badge")
+	}
+
+	clanFilters := swaggerDefinitionProperties(t, definitions, "modelsv2.SearchClanFilters")
+	assertSwaggerMaxItems(t, clanFilters["location_ids"], 5)
+	assertSwaggerMaxItems(t, clanFilters["cwl_league_ids"], 5)
+	playerFilters := swaggerDefinitionProperties(t, definitions, "modelsv2.SearchPlayerFilters")
+	assertSwaggerMaxItems(t, playerFilters["clan_tags"], 100)
+	assertSwaggerMaxItems(t, playerFilters["league_ids"], 5)
+	assertSwaggerMaxItems(t, playerFilters["townhall_levels"], 100)
 }
 
 func TestServerLogAndReminderDestinationOpenAPIContract(t *testing.T) {
@@ -1307,6 +1344,14 @@ func assertRef(t *testing.T, value any, want string) {
 	ref, _ := value.(map[string]any)
 	if ref["$ref"] != want {
 		t.Fatalf("expected ref %s, got %v", want, value)
+	}
+}
+
+func assertSwaggerMaxItems(t *testing.T, value any, want float64) {
+	t.Helper()
+	field, _ := value.(map[string]any)
+	if field["maxItems"] != want {
+		t.Fatalf("expected maxItems %.0f, got %v", want, value)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the legacy `GET /v2/search/clan` flow with QUERY-only Elasticsearch searches for clans and players
- add opaque PIT + `search_after` cursor pagination with a default page size of 25 and a maximum of 200
- add the requested clan and player filters, compact 512px badges, official-shaped location/league references, and batched player clan enrichment through the clan alias
- remove Clash API and Valkey dependencies from search pagination, add Elasticsearch configuration, and regenerate the API contract

## Deployment

Configure `ELASTICSEARCH_URL` and a read-only `ELASTICSEARCH_API_KEY`. The stable aliases default to `clashking_players` and `clashking_clans` and can be overridden with the documented environment variables.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/routes ./internal/utils`