### PR TITLE
fix(embeds): preserve full message payload

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -16714,91 +16714,6 @@ const docTemplate = `{
                 }
             }
         },
-        "modelsv2.DiscordEmbed": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "$ref": "#/definitions/modelsv2.DiscordEmbedAuthor"
-                },
-                "color": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "fields": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/modelsv2.DiscordEmbedField"
-                    }
-                },
-                "footer": {
-                    "$ref": "#/definitions/modelsv2.DiscordEmbedFooter"
-                },
-                "image": {
-                    "$ref": "#/definitions/modelsv2.DiscordEmbedMedia"
-                },
-                "thumbnail": {
-                    "$ref": "#/definitions/modelsv2.DiscordEmbedMedia"
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.DiscordEmbedAuthor": {
-            "type": "object",
-            "properties": {
-                "icon_url": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.DiscordEmbedField": {
-            "type": "object",
-            "properties": {
-                "inline": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.DiscordEmbedFooter": {
-            "type": "object",
-            "properties": {
-                "icon_url": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.DiscordEmbedMedia": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
         "modelsv2.DiscordEmoji": {
             "type": "object",
             "properties": {
@@ -21076,7 +20991,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "data": {
-                    "$ref": "#/definitions/modelsv2.DiscordEmbed"
+                    "type": "object",
+                    "additionalProperties": {}
                 },
                 "name": {
                     "type": "string"
@@ -22762,7 +22678,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "data": {
-                    "$ref": "#/definitions/modelsv2.DiscordEmbed"
+                    "type": "object",
+                    "additionalProperties": {}
                 },
                 "name": {
                     "type": "string"

--- a/internal/models/v2/tickets.go
+++ b/internal/models/v2/tickets.go
@@ -88,8 +88,8 @@ type UpdateApproveMessagesRequest struct {
 }
 
 type ServerEmbed struct {
-	Name string       `json:"name"`
-	Data DiscordEmbed `json:"data"`
+	Name string         `json:"name"`
+	Data map[string]any `json:"data"`
 }
 
 type ServerEmbedsResponse struct {
@@ -98,8 +98,8 @@ type ServerEmbedsResponse struct {
 }
 
 type UpsertEmbedRequest struct {
-	Name string       `json:"name"`
-	Data DiscordEmbed `json:"data"`
+	Name string         `json:"name"`
+	Data map[string]any `json:"data"`
 }
 
 type CreatePanelRequest struct {

--- a/internal/models/v2/tickets.go
+++ b/internal/models/v2/tickets.go
@@ -1,5 +1,10 @@
 package modelsv2
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 type TicketButton struct {
 	CustomID string        `json:"custom_id"`
 	Label    string        `json:"label"`
@@ -100,6 +105,13 @@ type ServerEmbedsResponse struct {
 type UpsertEmbedRequest struct {
 	Name string         `json:"name"`
 	Data map[string]any `json:"data"`
+}
+
+func (r *UpsertEmbedRequest) UnmarshalJSON(data []byte) error {
+	type requestAlias UpsertEmbedRequest
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	return decoder.Decode((*requestAlias)(r))
 }
 
 type CreatePanelRequest struct {

--- a/internal/models/v2/tickets_test.go
+++ b/internal/models/v2/tickets_test.go
@@ -1,0 +1,39 @@
+package modelsv2
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUpsertEmbedRequestPreservesFullMessagePayload(t *testing.T) {
+	input := []byte(`{
+		"name":"Bienvenue",
+		"data":{
+			"username":"ClashKing",
+			"messages":[{
+				"data":{
+					"content":"Welcome to the server",
+					"embeds":[{"title":"Bienvenue","description":"Choose your roles"}]
+				}
+			}]
+		}
+	}`)
+
+	var request UpsertEmbedRequest
+	if err := json.Unmarshal(input, &request); err != nil {
+		t.Fatalf("decode embed request: %v", err)
+	}
+
+	messages, ok := request.Data["messages"].([]any)
+	if !ok || len(messages) != 1 {
+		t.Fatalf("expected the messages wrapper to be preserved, got %#v", request.Data["messages"])
+	}
+	message, ok := messages[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a message object, got %#v", messages[0])
+	}
+	data, ok := message["data"].(map[string]any)
+	if !ok || data["content"] != "Welcome to the server" {
+		t.Fatalf("expected nested message data to be preserved, got %#v", message["data"])
+	}
+}

--- a/internal/models/v2/tickets_test.go
+++ b/internal/models/v2/tickets_test.go
@@ -1,6 +1,7 @@
 package modelsv2
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -9,6 +10,7 @@ func TestUpsertEmbedRequestPreservesFullMessagePayload(t *testing.T) {
 	input := []byte(`{
 		"name":"Bienvenue",
 		"data":{
+			"application_id":9007199254740993,
 			"username":"ClashKing",
 			"messages":[{
 				"data":{
@@ -35,5 +37,17 @@ func TestUpsertEmbedRequestPreservesFullMessagePayload(t *testing.T) {
 	data, ok := message["data"].(map[string]any)
 	if !ok || data["content"] != "Welcome to the server" {
 		t.Fatalf("expected nested message data to be preserved, got %#v", message["data"])
+	}
+
+	applicationID, ok := request.Data["application_id"].(json.Number)
+	if !ok || applicationID.String() != "9007199254740993" {
+		t.Fatalf("expected the large integer to remain exact, got %#v", request.Data["application_id"])
+	}
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("encode embed request: %v", err)
+	}
+	if !bytes.Contains(encoded, []byte(`"application_id":9007199254740993`)) {
+		t.Fatalf("expected encoded payload to preserve the large integer, got %s", encoded)
 	}
 }

--- a/internal/routes/server/tickets.go
+++ b/internal/routes/server/tickets.go
@@ -115,7 +115,7 @@ func ticketEmbedList(c *fiber.Ctx, a apptypes.Deps, serverID int64) ([]map[strin
 		if err := rows.Scan(&name, &dataRaw, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
-		item := map[string]any{"name": name, "data": mapMaybe(decodeEmbedJSON(dataRaw)), "created_at": createdAt, "updated_at": updatedAt}
+		item := map[string]any{"name": name, "data": decodeEmbedJSON(dataRaw), "created_at": createdAt, "updated_at": updatedAt}
 		items = append(items, item)
 	}
 	return items, rows.Err()
@@ -603,7 +603,7 @@ func getServerEmbeds(a apptypes.Deps) fiber.Handler {
 		items := make([]modelsv2.ServerEmbed, 0, len(docs))
 		for _, d := range docs {
 			if _, ok := d["name"].(string); ok {
-				items = append(items, modelsv2.ServerEmbed{Name: serverAsString(d["name"]), Data: ticketEmbedFromMap(mapMaybe(d["data"]))})
+				items = append(items, modelsv2.ServerEmbed{Name: serverAsString(d["name"]), Data: ticketEmbedPayload(d["data"])})
 			}
 		}
 		sort.Slice(items, func(i, j int) bool {
@@ -799,8 +799,12 @@ func decodeEmbedJSON(raw []byte) any {
 	return out
 }
 
-func ticketEmbedFromMap(value map[string]any) map[string]any {
-	return value
+func ticketEmbedPayload(value any) map[string]any {
+	payload, ok := value.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return payload
 }
 
 func ticketApproveMessages(value any) []modelsv2.ApproveMessage {

--- a/internal/routes/server/tickets.go
+++ b/internal/routes/server/tickets.go
@@ -119,7 +119,7 @@ func ticketEmbedList(c *fiber.Ctx, a apptypes.Deps, serverID int64) ([]map[strin
 	return items, rows.Err()
 }
 
-func ticketEmbedSave(c *fiber.Ctx, a apptypes.Deps, serverID int64, name string, data modelsv2.DiscordEmbed) error {
+func ticketEmbedSave(c *fiber.Ctx, a apptypes.Deps, serverID int64, name string, data map[string]any) error {
 	_, err := a.Store.SQL.Exec(c.UserContext(), `
 		INSERT INTO server_custom_embeds (server_id, name, data, created_at, updated_at)
 		VALUES ($1, $2, $3::jsonb, now(), now())
@@ -601,7 +601,7 @@ func getServerEmbeds(a apptypes.Deps) fiber.Handler {
 		items := make([]modelsv2.ServerEmbed, 0, len(docs))
 		for _, d := range docs {
 			if _, ok := d["name"].(string); ok {
-				items = append(items, modelsv2.ServerEmbed{Name: serverAsString(d["name"]), Data: ticketEmbedFromMap(mapMaybe(d["data"]))})
+				items = append(items, modelsv2.ServerEmbed{Name: serverAsString(d["name"]), Data: mapMaybe(d["data"])})
 			}
 		}
 		sort.Slice(items, func(i, j int) bool {
@@ -782,33 +782,6 @@ func ticketIntMap(value any) map[string]int {
 		out[key] = asIntWithDefault(item, 0)
 	}
 	return out
-}
-
-func ticketEmbedFromMap(value map[string]any) modelsv2.DiscordEmbed {
-	embed := modelsv2.DiscordEmbed{
-		Title:       stringPtrMaybe(value["title"]),
-		Description: stringPtrMaybe(value["description"]),
-		URL:         stringPtrMaybe(value["url"]),
-		Timestamp:   stringPtrMaybe(value["timestamp"]),
-		Color:       intPtrMaybe(value["color"]),
-	}
-	if footer := mapMaybe(value["footer"]); len(footer) > 0 {
-		embed.Footer = &modelsv2.DiscordEmbedFooter{Text: serverAsString(footer["text"]), IconURL: stringPtrMaybe(footer["icon_url"])}
-	}
-	if image := mapMaybe(value["image"]); len(image) > 0 {
-		embed.Image = &modelsv2.DiscordEmbedMedia{URL: serverAsString(image["url"])}
-	}
-	if thumbnail := mapMaybe(value["thumbnail"]); len(thumbnail) > 0 {
-		embed.Thumbnail = &modelsv2.DiscordEmbedMedia{URL: serverAsString(thumbnail["url"])}
-	}
-	if author := mapMaybe(value["author"]); len(author) > 0 {
-		embed.Author = &modelsv2.DiscordEmbedAuthor{Name: serverAsString(author["name"]), URL: stringPtrMaybe(author["url"]), IconURL: stringPtrMaybe(author["icon_url"])}
-	}
-	for _, raw := range anySlice(value["fields"]) {
-		field := mapMaybe(raw)
-		embed.Fields = append(embed.Fields, modelsv2.DiscordEmbedField{Name: serverAsString(field["name"]), Value: serverAsString(field["value"]), Inline: asBool(field["inline"])})
-	}
-	return embed
 }
 
 func ticketApproveMessages(value any) []modelsv2.ApproveMessage {

--- a/internal/routes/server/tickets.go
+++ b/internal/routes/server/tickets.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -113,7 +115,7 @@ func ticketEmbedList(c *fiber.Ctx, a apptypes.Deps, serverID int64) ([]map[strin
 		if err := rows.Scan(&name, &dataRaw, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
-		item := map[string]any{"name": name, "data": mapMaybe(decodeJSONAny(dataRaw)), "created_at": createdAt, "updated_at": updatedAt}
+		item := map[string]any{"name": name, "data": mapMaybe(decodeEmbedJSON(dataRaw)), "created_at": createdAt, "updated_at": updatedAt}
 		items = append(items, item)
 	}
 	return items, rows.Err()
@@ -601,7 +603,7 @@ func getServerEmbeds(a apptypes.Deps) fiber.Handler {
 		items := make([]modelsv2.ServerEmbed, 0, len(docs))
 		for _, d := range docs {
 			if _, ok := d["name"].(string); ok {
-				items = append(items, modelsv2.ServerEmbed{Name: serverAsString(d["name"]), Data: mapMaybe(d["data"])})
+				items = append(items, modelsv2.ServerEmbed{Name: serverAsString(d["name"]), Data: ticketEmbedFromMap(mapMaybe(d["data"]))})
 			}
 		}
 		sort.Slice(items, func(i, j int) bool {
@@ -782,6 +784,23 @@ func ticketIntMap(value any) map[string]int {
 		out[key] = asIntWithDefault(item, 0)
 	}
 	return out
+}
+
+func decodeEmbedJSON(raw []byte) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var out any
+	if err := decoder.Decode(&out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func ticketEmbedFromMap(value map[string]any) map[string]any {
+	return value
 }
 
 func ticketApproveMessages(value any) []modelsv2.ApproveMessage {

--- a/internal/routes/server/tickets_test.go
+++ b/internal/routes/server/tickets_test.go
@@ -1,10 +1,37 @@
 package server
 
 import (
+	"encoding/json"
 	"testing"
 
 	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
 )
+
+func TestDecodeEmbedJSONPreservesLargeIntegers(t *testing.T) {
+	decoded, ok := decodeEmbedJSON([]byte(`{"application_id":9007199254740993}`)).(map[string]any)
+	if !ok {
+		t.Fatalf("expected an object, got %#v", decoded)
+	}
+	applicationID, ok := decoded["application_id"].(json.Number)
+	if !ok || applicationID.String() != "9007199254740993" {
+		t.Fatalf("expected the large integer to remain exact, got %#v", decoded["application_id"])
+	}
+
+	if got := decodeEmbedJSON(nil); got != nil {
+		t.Fatalf("expected empty JSON to return nil, got %#v", got)
+	}
+	if got := decodeEmbedJSON([]byte(`{"invalid"`)); got != nil {
+		t.Fatalf("expected invalid JSON to return nil, got %#v", got)
+	}
+}
+
+func TestTicketEmbedFromMapPreservesPayload(t *testing.T) {
+	payload := map[string]any{"content": "welcome", "application_id": json.Number("9007199254740993")}
+	got := ticketEmbedFromMap(payload)
+	if got["content"] != "welcome" || got["application_id"] != json.Number("9007199254740993") {
+		t.Fatalf("expected payload to be returned unchanged, got %#v", got)
+	}
+}
 
 func TestNormalizeApproveMessagesKeepsOnlyFirstNamedMessage(t *testing.T) {
 	got := normalizeApproveMessages([]modelsv2.ApproveMessage{

--- a/internal/routes/server/tickets_test.go
+++ b/internal/routes/server/tickets_test.go
@@ -8,13 +8,17 @@ import (
 )
 
 func TestDecodeEmbedJSONPreservesLargeIntegers(t *testing.T) {
-	decoded, ok := decodeEmbedJSON([]byte(`{"application_id":9007199254740993}`)).(map[string]any)
+	decoded, ok := decodeEmbedJSON([]byte(`{"application_id":9007199254740993,"data":{"_id":"nested"}}`)).(map[string]any)
 	if !ok {
 		t.Fatalf("expected an object, got %#v", decoded)
 	}
 	applicationID, ok := decoded["application_id"].(json.Number)
 	if !ok || applicationID.String() != "9007199254740993" {
 		t.Fatalf("expected the large integer to remain exact, got %#v", decoded["application_id"])
+	}
+	nested, ok := decoded["data"].(map[string]any)
+	if !ok || nested["_id"] != "nested" {
+		t.Fatalf("expected nested _id to be preserved, got %#v", decoded["data"])
 	}
 
 	if got := decodeEmbedJSON(nil); got != nil {
@@ -25,11 +29,15 @@ func TestDecodeEmbedJSONPreservesLargeIntegers(t *testing.T) {
 	}
 }
 
-func TestTicketEmbedFromMapPreservesPayload(t *testing.T) {
-	payload := map[string]any{"content": "welcome", "application_id": json.Number("9007199254740993")}
-	got := ticketEmbedFromMap(payload)
-	if got["content"] != "welcome" || got["application_id"] != json.Number("9007199254740993") {
+func TestTicketEmbedPayloadPreservesPayload(t *testing.T) {
+	payload := map[string]any{"_id": "top-level", "data": map[string]any{"_id": "nested"}}
+	got := ticketEmbedPayload(payload)
+	nested, ok := got["data"].(map[string]any)
+	if got["_id"] != "top-level" || !ok || nested["_id"] != "nested" {
 		t.Fatalf("expected payload to be returned unchanged, got %#v", got)
+	}
+	if got := ticketEmbedPayload("invalid"); len(got) != 0 {
+		t.Fatalf("expected a non-object payload to return an empty object, got %#v", got)
 	}
 }
 

--- a/internal/swaggerdocs/openapi.json
+++ b/internal/swaggerdocs/openapi.json
@@ -2929,91 +2929,6 @@
         },
         "type": "object"
       },
-      "modelsv2.DiscordEmbed": {
-        "properties": {
-          "author": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedAuthor"
-          },
-          "color": {
-            "type": "integer"
-          },
-          "description": {
-            "type": "string"
-          },
-          "fields": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.DiscordEmbedField"
-            },
-            "type": "array"
-          },
-          "footer": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedFooter"
-          },
-          "image": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedMedia"
-          },
-          "thumbnail": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedMedia"
-          },
-          "timestamp": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedAuthor": {
-        "properties": {
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedField": {
-        "properties": {
-          "inline": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedFooter": {
-        "properties": {
-          "icon_url": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedMedia": {
-        "properties": {
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "modelsv2.DiscordEmoji": {
         "properties": {
           "animated": {
@@ -7314,7 +7229,8 @@
       "modelsv2.ServerEmbed": {
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbed"
+            "additionalProperties": {},
+            "type": "object"
           },
           "name": {
             "type": "string"
@@ -9006,7 +8922,8 @@
       "modelsv2.UpsertEmbedRequest": {
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbed"
+            "additionalProperties": {},
+            "type": "object"
           },
           "name": {
             "type": "string"

--- a/internal/swaggerdocs/openapi.scalar.json
+++ b/internal/swaggerdocs/openapi.scalar.json
@@ -2929,91 +2929,6 @@
         },
         "type": "object"
       },
-      "modelsv2.DiscordEmbed": {
-        "properties": {
-          "author": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedAuthor"
-          },
-          "color": {
-            "type": "integer"
-          },
-          "description": {
-            "type": "string"
-          },
-          "fields": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.DiscordEmbedField"
-            },
-            "type": "array"
-          },
-          "footer": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedFooter"
-          },
-          "image": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedMedia"
-          },
-          "thumbnail": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbedMedia"
-          },
-          "timestamp": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedAuthor": {
-        "properties": {
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedField": {
-        "properties": {
-          "inline": {
-            "type": "boolean"
-          },
-          "name": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedFooter": {
-        "properties": {
-          "icon_url": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.DiscordEmbedMedia": {
-        "properties": {
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "modelsv2.DiscordEmoji": {
         "properties": {
           "animated": {
@@ -7314,7 +7229,8 @@
       "modelsv2.ServerEmbed": {
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbed"
+            "additionalProperties": {},
+            "type": "object"
           },
           "name": {
             "type": "string"
@@ -9006,7 +8922,8 @@
       "modelsv2.UpsertEmbedRequest": {
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/modelsv2.DiscordEmbed"
+            "additionalProperties": {},
+            "type": "object"
           },
           "name": {
             "type": "string"

--- a/internal/swaggerdocs/openapi.yaml
+++ b/internal/swaggerdocs/openapi.yaml
@@ -1907,61 +1907,6 @@ components:
                         - forum
                     type: string
             type: object
-        modelsv2.DiscordEmbed:
-            properties:
-                author:
-                    $ref: '#/components/schemas/modelsv2.DiscordEmbedAuthor'
-                color:
-                    type: integer
-                description:
-                    type: string
-                fields:
-                    items:
-                        $ref: '#/components/schemas/modelsv2.DiscordEmbedField'
-                    type: array
-                footer:
-                    $ref: '#/components/schemas/modelsv2.DiscordEmbedFooter'
-                image:
-                    $ref: '#/components/schemas/modelsv2.DiscordEmbedMedia'
-                thumbnail:
-                    $ref: '#/components/schemas/modelsv2.DiscordEmbedMedia'
-                timestamp:
-                    type: string
-                title:
-                    type: string
-                url:
-                    type: string
-            type: object
-        modelsv2.DiscordEmbedAuthor:
-            properties:
-                icon_url:
-                    type: string
-                name:
-                    type: string
-                url:
-                    type: string
-            type: object
-        modelsv2.DiscordEmbedField:
-            properties:
-                inline:
-                    type: boolean
-                name:
-                    type: string
-                value:
-                    type: string
-            type: object
-        modelsv2.DiscordEmbedFooter:
-            properties:
-                icon_url:
-                    type: string
-                text:
-                    type: string
-            type: object
-        modelsv2.DiscordEmbedMedia:
-            properties:
-                url:
-                    type: string
-            type: object
         modelsv2.DiscordEmoji:
             properties:
                 animated:
@@ -4805,7 +4750,8 @@ components:
         modelsv2.ServerEmbed:
             properties:
                 data:
-                    $ref: '#/components/schemas/modelsv2.DiscordEmbed'
+                    additionalProperties: {}
+                    type: object
                 name:
                     type: string
             type: object
@@ -5927,7 +5873,8 @@ components:
         modelsv2.UpsertEmbedRequest:
             properties:
                 data:
-                    $ref: '#/components/schemas/modelsv2.DiscordEmbed'
+                    additionalProperties: {}
+                    type: object
                 name:
                     type: string
             type: object


### PR DESCRIPTION
## Summary
- preserve complete custom embed JSON payloads when decoding create and update requests
- return stored embed payloads unchanged instead of flattening them to a single Discord embed
- update the generated OpenAPI contract and add a nested message payload regression test

## Validation
- `go test ./...`
- `go vet ./...`
- verified the local API returns the stored Bienvenue payload with nested messages and embed description