### PR TITLE
fix(auth): allow configured web origins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/xuri/excelize/v2 v2.10.1
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.50.0
+	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.36.0
 )
@@ -63,7 +64,6 @@ require (
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 )

--- a/internal/routes/auth_web.go
+++ b/internal/routes/auth_web.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/net/publicsuffix"
 )
 
 const webRefreshCookieName = "ck_web_refresh"
@@ -289,7 +290,7 @@ func setWebRefreshCookie(c *fiber.Ctx, cfg apptypes.Config, token string) {
 		MaxAge:   30 * 24 * 60 * 60,
 		Secure:   webRefreshCookieSecure(cfg, requestOrigin),
 		HTTPOnly: true,
-		SameSite: webRefreshCookieSameSite(cfg, requestOrigin),
+		SameSite: webRefreshCookieSameSite(cfg, requestOrigin, c.Hostname()),
 	})
 }
 
@@ -303,7 +304,7 @@ func clearWebRefreshCookie(c *fiber.Ctx, cfg apptypes.Config) {
 		MaxAge:   -1,
 		Secure:   webRefreshCookieSecure(cfg, requestOrigin),
 		HTTPOnly: true,
-		SameSite: webRefreshCookieSameSite(cfg, requestOrigin),
+		SameSite: webRefreshCookieSameSite(cfg, requestOrigin, c.Hostname()),
 	})
 }
 
@@ -311,7 +312,7 @@ func webRefreshCookieSecure(cfg apptypes.Config, requestOrigin string) bool {
 	return !(cfg.Local && isAllowedLoopbackOrigin(cfg, requestOrigin))
 }
 
-func webRefreshCookieSameSite(cfg apptypes.Config, requestOrigin string) string {
+func webRefreshCookieSameSite(cfg apptypes.Config, requestOrigin, requestHost string) string {
 	if !apptypes.IsAllowedWebOrigin(cfg, requestOrigin) {
 		return fiber.CookieSameSiteStrictMode
 	}
@@ -326,7 +327,13 @@ func webRefreshCookieSameSite(cfg apptypes.Config, requestOrigin string) string 
 		}
 		return fiber.CookieSameSiteNoneMode
 	}
-	return fiber.CookieSameSiteStrictMode
+	originSite, originErr := publicsuffix.EffectiveTLDPlusOne(host)
+	requestURL, requestErr := url.Parse("https://" + strings.TrimSpace(requestHost))
+	requestSite, siteErr := publicsuffix.EffectiveTLDPlusOne(strings.ToLower(requestURL.Hostname()))
+	if originErr == nil && requestErr == nil && siteErr == nil && originSite == requestSite {
+		return fiber.CookieSameSiteStrictMode
+	}
+	return fiber.CookieSameSiteNoneMode
 }
 
 func isAllowedLoopbackOrigin(cfg apptypes.Config, requestOrigin string) bool {

--- a/internal/routes/auth_web_test.go
+++ b/internal/routes/auth_web_test.go
@@ -36,7 +36,9 @@ func TestWebRefreshCookieIsHostOnlySecureHttpOnlyAndStrict(t *testing.T) {
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 
-	response, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/cookie", nil))
+	request := httptest.NewRequest(fiber.MethodGet, "/cookie", nil)
+	request.Host = "api.clashk.ing"
+	response, err := app.Test(request)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -64,6 +66,7 @@ func TestWebRefreshCookieUsesNoneOnlyForExplicitAllowedLocalOrigins(t *testing.T
 		"http://localhost:3002",
 		"http://127.0.0.1:3002",
 		"https://dash.clashk.ing",
+		"https://*.clashkingapp.pages.dev",
 	}}
 	for _, test := range []struct {
 		name   string
@@ -73,6 +76,7 @@ func TestWebRefreshCookieUsesNoneOnlyForExplicitAllowedLocalOrigins(t *testing.T
 		{name: "localhost", origin: "http://localhost:3002", want: "samesite=none"},
 		{name: "loopback", origin: "http://127.0.0.1:3002", want: "samesite=none"},
 		{name: "production", origin: "https://dash.clashk.ing", want: "samesite=strict"},
+		{name: "pages preview", origin: "https://2b9347a7.clashkingapp.pages.dev", want: "samesite=none"},
 		{name: "unlisted localhost", origin: "http://localhost:4000", want: "samesite=strict"},
 		{name: "lookalike", origin: "https://localhost.attacker.example", want: "samesite=strict"},
 	} {
@@ -83,6 +87,7 @@ func TestWebRefreshCookieUsesNoneOnlyForExplicitAllowedLocalOrigins(t *testing.T
 				return c.SendStatus(fiber.StatusNoContent)
 			})
 			request := httptest.NewRequest(fiber.MethodGet, "/cookie", nil)
+			request.Host = "api.clashk.ing"
 			request.Header.Set(fiber.HeaderOrigin, test.origin)
 			response, err := app.Test(request)
 			if err != nil {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -70,6 +70,11 @@ func Load() (Config, error) {
 
 	landingOrigin := normalizeOrigin(os.Getenv("CLASHKING_LANDING_ORIGIN"))
 	dashboardOrigin := normalizeOrigin(os.Getenv("CLASHKING_DASHBOARD_ORIGIN"))
+	webAllowedOrigins := append(
+		parseOrigins(os.Getenv("WEB_ALLOWED_ORIGINS")),
+		landingOrigin,
+		dashboardOrigin,
+	)
 	cfg := Config{
 		TimescaleURL:                 buildTimescaleURL(os.Getenv),
 		ValkeyAddress:                buildValkeyAddress(os.Getenv),
@@ -92,7 +97,7 @@ func Load() (Config, error) {
 		WebTokenAudience:             firstNonEmpty(os.Getenv("WEB_TOKEN_AUDIENCE"), "clashking-web"),
 		LandingOrigin:                landingOrigin,
 		DashboardOrigin:              dashboardOrigin,
-		WebAllowedOrigins:            nonEmptyStrings(landingOrigin, dashboardOrigin),
+		WebAllowedOrigins:            nonEmptyStrings(webAllowedOrigins...),
 		DiscordRedirectURI:           appendOriginPath(dashboardOrigin, "/auth/callback"),
 		DiscordClientID:              os.Getenv("DISCORD_CLIENT_ID"),
 		DiscordClientSecret:          os.Getenv("DISCORD_CLIENT_SECRET"),
@@ -261,6 +266,17 @@ func nonEmptyStrings(values ...string) []string {
 	for _, value := range values {
 		if value != "" {
 			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func parseOrigins(value string) []string {
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if origin := normalizeOrigin(part); origin != "" {
+			result = append(result, origin)
 		}
 	}
 	return result

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -93,3 +93,47 @@ func TestParseOriginsTrimsCommaSeparatedValues(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadIncludesConfiguredWebOrigins(t *testing.T) {
+	values := map[string]string{
+		"LOCAL":                           "TRUE",
+		"DEV_USER_ID":                     "test-user",
+		"TIMESCALE_HOST":                  "timescale",
+		"TIMESCALE_USERNAME":              "test",
+		"TIMESCALE_PASSWORD":              "test",
+		"TIMESCALE_DATABASE":              "test",
+		"DATA_ENCRYPTION_KEY":             "test-key",
+		"JWT_ACCESS_SECRET":               "test-access",
+		"JWT_REFRESH_SECRET":              "test-refresh",
+		"DISCORD_BOT_TOKEN":               "test-bot",
+		"DISCORD_CLIENT_ID":               "test-client",
+		"DISCORD_CLIENT_SECRET":           "test-client-secret",
+		"API_BOT_TOKEN":                   "test-api-token",
+		"CLASHKING_PROXY_INTERNAL_ORIGIN": "https://proxy.internal",
+		"CLASHKING_LANDING_ORIGIN":        "https://clashk.ing",
+		"CLASHKING_DASHBOARD_ORIGIN":      "https://dash.clashk.ing",
+		"WEB_ALLOWED_ORIGINS":             "https://app.clashk.ing, https://*.clashkingapp.pages.dev/",
+	}
+	for key, value := range values {
+		t.Setenv(key, value)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	want := []string{
+		"https://app.clashk.ing",
+		"https://*.clashkingapp.pages.dev",
+		"https://clashk.ing",
+		"https://dash.clashk.ing",
+	}
+	if len(cfg.WebAllowedOrigins) != len(want) {
+		t.Fatalf("WebAllowedOrigins = %#v, want %#v", cfg.WebAllowedOrigins, want)
+	}
+	for index := range want {
+		if cfg.WebAllowedOrigins[index] != want[index] {
+			t.Fatalf("WebAllowedOrigins[%d] = %q, want %q", index, cfg.WebAllowedOrigins[index], want[index])
+		}
+	}
+}

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -80,3 +80,16 @@ func TestBuildValkeyAddressDoesNotAcceptRedisAliases(t *testing.T) {
 		t.Fatalf("buildValkeyAddress() = %q, want empty", got)
 	}
 }
+
+func TestParseOriginsTrimsCommaSeparatedValues(t *testing.T) {
+	got := parseOrigins(" https://app.clashk.ing/, ,https://*.clashkingapp.pages.dev ")
+	want := []string{"https://app.clashk.ing", "https://*.clashkingapp.pages.dev"}
+	if len(got) != len(want) {
+		t.Fatalf("parseOrigins() = %#v, want %#v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("parseOrigins()[%d] = %q, want %q", index, got[index], want[index])
+		}
+	}
+}

--- a/internal/utils/cors.go
+++ b/internal/utils/cors.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -11,17 +12,13 @@ const corsMaxAgeSeconds = "3600"
 // CORSMiddleware keeps public read-only data browser-readable while restricting
 // credentials, authorization headers, and browser session mutations to known clients.
 func CORSMiddleware(cfg Config) fiber.Handler {
-	allowed := make(map[string]struct{}, len(cfg.WebAllowedOrigins))
-	for _, origin := range cfg.WebAllowedOrigins {
-		allowed[strings.TrimSuffix(strings.TrimSpace(origin), "/")] = struct{}{}
-	}
 	return func(c *fiber.Ctx) error {
 		origin := strings.TrimSuffix(strings.TrimSpace(c.Get(fiber.HeaderOrigin)), "/")
 		if origin == "" {
 			return c.Next()
 		}
 
-		_, credentialed := allowed[origin]
+		credentialed := IsAllowedWebOrigin(cfg, origin)
 		public := isPublicCORSRequest(c)
 		if !credentialed && !public {
 			if c.Method() == fiber.MethodOptions {
@@ -58,11 +55,35 @@ func IsAllowedWebOrigin(cfg Config, origin string) bool {
 		return false
 	}
 	for _, allowed := range cfg.WebAllowedOrigins {
-		if origin == strings.TrimSuffix(strings.TrimSpace(allowed), "/") {
+		if webOriginMatches(strings.TrimSuffix(strings.TrimSpace(allowed), "/"), origin) {
 			return true
 		}
 	}
 	return false
+}
+
+func webOriginMatches(allowed, origin string) bool {
+	if allowed == origin {
+		return true
+	}
+
+	parts := strings.SplitN(allowed, "://*.", 2)
+	if len(parts) != 2 || strings.ContainsAny(parts[1], "/:?#") {
+		return false
+	}
+	candidate, err := url.Parse(origin)
+	if err != nil ||
+		candidate.Scheme != parts[0] ||
+		candidate.Port() != "" ||
+		candidate.Path != "" ||
+		candidate.RawQuery != "" ||
+		candidate.Fragment != "" ||
+		candidate.User != nil {
+		return false
+	}
+	host := strings.ToLower(candidate.Hostname())
+	suffix := "." + strings.ToLower(parts[1])
+	return strings.HasSuffix(host, suffix) && host != strings.TrimPrefix(suffix, ".")
 }
 
 func RequireWebOrigin(cfg Config) fiber.Handler {

--- a/internal/utils/cors_test.go
+++ b/internal/utils/cors_test.go
@@ -124,6 +124,41 @@ func TestCORSAllowedWebOriginGetsCredentialedPreflight(t *testing.T) {
 	}
 }
 
+func TestCORSConfiguredPreviewOriginPatternGetsCredentialedPreflight(t *testing.T) {
+	app := newCORSTestApp(Config{WebAllowedOrigins: []string{"https://*.clashkingapp.pages.dev"}})
+	request := httptest.NewRequest(fiber.MethodOptions, "/v2/auth/web/refresh", nil)
+	request.Header.Set(fiber.HeaderOrigin, "https://2b9347a7.clashkingapp.pages.dev")
+	request.Header.Set(fiber.HeaderAccessControlRequestMethod, fiber.MethodPost)
+	request.Header.Set(fiber.HeaderAccessControlRequestHeaders, "content-type")
+
+	response, err := app.Test(request)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if response.StatusCode != fiber.StatusNoContent {
+		t.Fatalf("status = %d, want %d", response.StatusCode, fiber.StatusNoContent)
+	}
+	if got := response.Header.Get(fiber.HeaderAccessControlAllowOrigin); got != "https://2b9347a7.clashkingapp.pages.dev" {
+		t.Fatalf("allow origin = %q", got)
+	}
+	if got := response.Header.Get(fiber.HeaderAccessControlAllowCredentials); got != "true" {
+		t.Fatalf("allow credentials = %q", got)
+	}
+}
+
+func TestCORSPreviewOriginPatternRejectsApexAndLookalikes(t *testing.T) {
+	cfg := Config{WebAllowedOrigins: []string{"https://*.clashkingapp.pages.dev"}}
+	for _, origin := range []string{
+		"https://clashkingapp.pages.dev",
+		"https://clashkingapp.pages.dev.attacker.example",
+		"http://preview.clashkingapp.pages.dev",
+	} {
+		if IsAllowedWebOrigin(cfg, origin) {
+			t.Fatalf("origin %q unexpectedly matched preview pattern", origin)
+		}
+	}
+}
+
 func TestCORSExplicitLocalhostOriginGetsCredentialedRefreshPreflight(t *testing.T) {
 	for _, origin := range []string{"http://localhost:3002", "http://127.0.0.1:3002"} {
 		t.Run(origin, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- load the existing comma-separated `WEB_ALLOWED_ORIGINS` setting
- support explicitly configured `https://*.example.com` origin patterns for credentialed browser auth
- reject apex domains, lookalikes, scheme changes, ports, and malformed origins

## Why
ClashKing App PR previews run on per-deployment `*.clashkingapp.pages.dev` origins. Browser auth currently ignores `WEB_ALLOWED_ORIGINS`, so `/v2/auth/web/*` rejects every preview with `403 Origin is not allowed` and authenticated PR E2E cannot run.

After deployment, beta must include `https://*.clashkingapp.pages.dev` in `WEB_ALLOWED_ORIGINS`.

## Validation
- `go test ./internal/utils`
- full `go test ./...` was attempted locally, but the runner exhausted disk space while compiling unrelated packages; completed packages passed.