### PR TITLE
fix(players): support normalized change history

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -4919,7 +4919,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Change type",
+                        "description": "Change type name or ID (1-12)",
                         "name": "type",
                         "in": "query"
                     }
@@ -18122,43 +18122,47 @@ const docTemplate = `{
         "modelsv2.PlayerChangeRecord": {
             "type": "object",
             "properties": {
-                "clan_tag": {
+                "current": {
                     "type": "string"
                 },
-                "current": {
-                    "$ref": "#/definitions/modelsv2.PlayerChangeValue"
+                "item_id": {
+                    "type": "integer",
+                    "x-nullable": true
                 },
                 "player_tag": {
                     "type": "string"
                 },
                 "previous": {
-                    "$ref": "#/definitions/modelsv2.PlayerChangeValue"
+                    "type": "string"
                 },
                 "time": {
                     "type": "string"
                 },
                 "townhall_level": {
-                    "type": "integer"
+                    "type": "integer",
+                    "x-nullable": true
                 },
                 "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.PlayerChangeValue": {
-            "type": "object",
-            "properties": {
-                "level": {
-                    "type": "integer"
+                    "type": "string",
+                    "enum": [
+                        "troop_level",
+                        "super_troop_boost",
+                        "hero_level",
+                        "spell_level",
+                        "pet_level",
+                        "equipment_level",
+                        "town_hall_level",
+                        "best_trophies",
+                        "best_builder_base_trophies",
+                        "exp_level",
+                        "war_preference",
+                        "name"
+                    ]
                 },
-                "name": {
-                    "type": "string"
-                },
-                "tag": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
+                "type_id": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1
                 }
             }
         },

--- a/internal/models/v2/public_stats.go
+++ b/internal/models/v2/public_stats.go
@@ -141,21 +141,15 @@ type PlayerRankedGroupResponse struct {
 	Count        int            `json:"count,omitempty"`
 }
 
-type PlayerChangeValue struct {
-	Name  string `json:"name,omitempty"`
-	Level int    `json:"level,omitempty"`
-	Value string `json:"value,omitempty"`
-	Tag   string `json:"tag,omitempty"`
-}
-
 type PlayerChangeRecord struct {
-	Time          time.Time         `json:"time"`
-	PlayerTag     string            `json:"player_tag"`
-	ClanTag       string            `json:"clan_tag"`
-	TownhallLevel int               `json:"townhall_level"`
-	Type          string            `json:"type"`
-	Previous      PlayerChangeValue `json:"previous"`
-	Current       PlayerChangeValue `json:"current"`
+	Time          time.Time `json:"time"`
+	PlayerTag     string    `json:"player_tag"`
+	TownhallLevel *int16    `json:"townhall_level" extensions:"x-nullable"`
+	TypeID        int16     `json:"type_id" minimum:"1" maximum:"12"`
+	Type          string    `json:"type" enums:"troop_level,super_troop_boost,hero_level,spell_level,pet_level,equipment_level,town_hall_level,best_trophies,best_builder_base_trophies,exp_level,war_preference,name"`
+	ItemID        *int16    `json:"item_id" extensions:"x-nullable"`
+	Previous      string    `json:"previous"`
+	Current       string    `json:"current"`
 }
 
 type PlayerChangesResponse struct {

--- a/internal/routes/player_changes_test.go
+++ b/internal/routes/player_changes_test.go
@@ -1,0 +1,164 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+type playerChangesTestDB struct {
+	query string
+	args  []any
+	rows  pgx.Rows
+}
+
+func (db *playerChangesTestDB) Query(_ context.Context, query string, args ...any) (pgx.Rows, error) {
+	db.query = query
+	db.args = args
+	return db.rows, nil
+}
+
+type playerChangesTestRow struct {
+	eventTime     time.Time
+	playerTag     string
+	townhallLevel *int16
+	typeID        int16
+	itemID        *int16
+	previous      string
+	current       string
+}
+
+type playerChangesTestRows struct {
+	pgx.Rows
+	items  []playerChangesTestRow
+	cursor int
+}
+
+func (rows *playerChangesTestRows) Close()     {}
+func (rows *playerChangesTestRows) Err() error { return nil }
+func (rows *playerChangesTestRows) Next() bool {
+	if rows.cursor >= len(rows.items) {
+		return false
+	}
+	rows.cursor++
+	return true
+}
+
+func (rows *playerChangesTestRows) Scan(dest ...any) error {
+	row := rows.items[rows.cursor-1]
+	*dest[0].(*time.Time) = row.eventTime
+	*dest[1].(*string) = row.playerTag
+	*dest[2].(**int16) = row.townhallLevel
+	*dest[3].(*int16) = row.typeID
+	*dest[4].(**int16) = row.itemID
+	*dest[5].(*string) = row.previous
+	*dest[6].(*string) = row.current
+	return nil
+}
+
+func TestPlayerChangesQueriesUseNormalizedSchema(t *testing.T) {
+	for _, query := range []string{playerChangesQuery, playerChangesByTypeQuery} {
+		for _, required := range []string{
+			"event_time, player_tag, townhall_level, change_type, item_id, previous_value, current_value",
+			"FROM player_change_history",
+			"WHERE player_tag = $1",
+			"ORDER BY event_time DESC",
+		} {
+			if !strings.Contains(query, required) {
+				t.Fatalf("player changes query missing %q", required)
+			}
+		}
+		for _, obsolete := range []string{"clan_tag", "jsonb"} {
+			if strings.Contains(query, obsolete) {
+				t.Fatalf("player changes query contains obsolete field %q", obsolete)
+			}
+		}
+	}
+	if !strings.Contains(playerChangesByTypeQuery, "change_type = ANY($2::smallint[])") {
+		t.Fatal("filtered player changes query does not use numeric change types")
+	}
+}
+
+func TestParsePlayerChangeTypeFilter(t *testing.T) {
+	tests := map[string][]int16{
+		"":                           nil,
+		"1":                          {1},
+		"troop_level":                {1},
+		"troops":                     {1, 2},
+		"heroEquipment":              {6},
+		"bestVersusTrophies":         {9},
+		"best_builder_base_trophies": {9},
+		"warPreference":              {11},
+	}
+	for input, expected := range tests {
+		actual, err := parsePlayerChangeTypeFilter(input)
+		if err != nil {
+			t.Fatalf("parse %q: %v", input, err)
+		}
+		if len(actual) != len(expected) {
+			t.Fatalf("parse %q = %v, want %v", input, actual, expected)
+		}
+		for index := range expected {
+			if actual[index] != expected[index] {
+				t.Fatalf("parse %q = %v, want %v", input, actual, expected)
+			}
+		}
+	}
+	for _, input := range []string{"0", "13", "unknown"} {
+		if _, err := parsePlayerChangeTypeFilter(input); err == nil {
+			t.Fatalf("parse %q unexpectedly succeeded", input)
+		}
+	}
+}
+
+func TestPlayerChangesReturnsNormalizedValuesAndUsesTypeFilter(t *testing.T) {
+	townhall := int16(17)
+	itemID := int16(19)
+	eventTime := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	db := &playerChangesTestDB{rows: &playerChangesTestRows{items: []playerChangesTestRow{
+		{eventTime: eventTime, playerTag: "#8GLYGGJQ", townhallLevel: &townhall, typeID: 1, itemID: &itemID, previous: "11", current: "12"},
+		{eventTime: eventTime.Add(-time.Minute), playerTag: "#8GLYGGJQ", typeID: 12, previous: "Old Name", current: "New Name"},
+	}}}
+
+	response, err := queryPlayerChanges(context.Background(), db, "#8GLYGGJQ", []int16{1, 2}, 5)
+	if err != nil {
+		t.Fatalf("query player changes: %v", err)
+	}
+	if db.query != playerChangesByTypeQuery || len(db.args) != 3 {
+		t.Fatalf("unexpected filtered query: %q %#v", db.query, db.args)
+	}
+	if response.Count != 2 || len(response.Items) != 2 {
+		t.Fatalf("unexpected response count: %#v", response)
+	}
+	if response.Items[0].Type != "troop_level" || response.Items[0].TypeID != 1 || response.Items[0].Previous != "11" || response.Items[0].Current != "12" {
+		t.Fatalf("unexpected troop change: %#v", response.Items[0])
+	}
+	if response.Items[1].Type != "name" || response.Items[1].TownhallLevel != nil || response.Items[1].ItemID != nil {
+		t.Fatalf("unexpected nullable name change: %#v", response.Items[1])
+	}
+}
+
+func TestPlayerChangesRejectsInvalidTypeBeforeDatabaseAccess(t *testing.T) {
+	app := fiber.New(fiber.Config{ErrorHandler: apptypes.ErrorHandler})
+	app.Get("/v2/player/:player_tag/changes", playerChanges(apptypes.Deps{}))
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/v2/player/%23ABC/changes?type=unknown", nil))
+	if err != nil {
+		t.Fatalf("player changes request: %v", err)
+	}
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", response.StatusCode)
+	}
+	var body modelsv2.ErrorResponse
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+}

--- a/internal/routes/public_stats.go
+++ b/internal/routes/public_stats.go
@@ -308,7 +308,7 @@ func playerRankedGroup(a apptypes.Deps) fiber.Handler {
 // @Produce json
 // @Param player_tag path string true "Player tag"
 // @Param limit query int false "Result limit, max 500"
-// @Param type query string false "Change type"
+// @Param type query string false "Change type name or ID (1-12)"
 // @Success 200 {object} modelsv2.PlayerChangesResponse
 // @Failure 400 {object} modelsv2.ErrorResponse
 // @Failure 500 {object} modelsv2.ErrorResponse
@@ -319,39 +319,104 @@ func playerChanges(a apptypes.Deps) fiber.Handler {
 		if tag == "" {
 			return apptypes.Error(fiber.StatusBadRequest, "player_tag is required")
 		}
-		limit := clamp(queryInt(c, "limit", 100), 1, 500)
-		rows, err := a.Store.SQL.Query(c.UserContext(), `
-			SELECT event_time, player_tag, clan_tag, townhall_level, change_type, previous_value, current_value
-			FROM player_change_history
-			WHERE player_tag = $1 AND ($2 = '' OR change_type = $2)
-			ORDER BY event_time DESC
-			LIMIT $3
-		`, tag, c.Query("type"), limit)
+		changeTypes, err := parsePlayerChangeTypeFilter(c.Query("type"))
+		if err != nil {
+			return apptypes.Error(fiber.StatusBadRequest, err.Error())
+		}
+		response, err := queryPlayerChanges(c.UserContext(), a.Store.SQL, tag, changeTypes, clamp(queryInt(c, "limit", 100), 1, 500))
 		if err != nil {
 			return err
 		}
-		defer rows.Close()
-		items := []map[string]any{}
-		for rows.Next() {
-			var eventTime time.Time
-			var playerTag, clanTag, changeType string
-			var townhall int
-			var previousRaw, currentRaw []byte
-			if err := rows.Scan(&eventTime, &playerTag, &clanTag, &townhall, &changeType, &previousRaw, &currentRaw); err != nil {
-				return err
-			}
-			items = append(items, map[string]any{
-				"time":           eventTime,
-				"player_tag":     playerTag,
-				"clan_tag":       clanTag,
-				"townhall_level": townhall,
-				"type":           changeType,
-				"previous":       jsonValue(previousRaw, nil),
-				"current":        jsonValue(currentRaw, nil),
-			})
-		}
-		return apptypes.JSON(c, fiber.StatusOK, map[string]any{"tag": tag, "items": items, "count": len(items)})
+		return apptypes.JSON(c, fiber.StatusOK, response)
 	}
+}
+
+type playerChangesDB interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+const playerChangesQuery = `
+	SELECT event_time, player_tag, townhall_level, change_type, item_id, previous_value, current_value
+	FROM player_change_history
+	WHERE player_tag = $1
+	ORDER BY event_time DESC
+	LIMIT $2
+`
+
+const playerChangesByTypeQuery = `
+	SELECT event_time, player_tag, townhall_level, change_type, item_id, previous_value, current_value
+	FROM player_change_history
+	WHERE player_tag = $1 AND change_type = ANY($2::smallint[])
+	ORDER BY event_time DESC
+	LIMIT $3
+`
+
+var playerChangeTypeNames = map[int16]string{
+	1: "troop_level", 2: "super_troop_boost", 3: "hero_level", 4: "spell_level",
+	5: "pet_level", 6: "equipment_level", 7: "town_hall_level", 8: "best_trophies",
+	9: "best_builder_base_trophies", 10: "exp_level", 11: "war_preference", 12: "name",
+}
+
+var playerChangeTypeFilters = map[string][]int16{
+	"troop_level": {1}, "trooplevel": {1}, "troops": {1, 2},
+	"super_troop_boost": {2}, "supertroopboost": {2},
+	"hero_level": {3}, "herolevel": {3}, "heroes": {3},
+	"spell_level": {4}, "spelllevel": {4}, "spells": {4},
+	"pet_level": {5}, "petlevel": {5}, "pets": {5},
+	"equipment_level": {6}, "equipmentlevel": {6}, "heroequipment": {6},
+	"town_hall_level": {7}, "townhalllevel": {7},
+	"best_trophies": {8}, "besttrophies": {8},
+	"best_builder_base_trophies": {9}, "bestbuilderbasetrophies": {9}, "bestversustrophies": {9},
+	"exp_level": {10}, "explevel": {10},
+	"war_preference": {11}, "warpreference": {11},
+	"name": {12},
+}
+
+func parsePlayerChangeTypeFilter(value string) ([]int16, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	if id, err := strconv.ParseInt(value, 10, 16); err == nil {
+		if _, ok := playerChangeTypeNames[int16(id)]; ok {
+			return []int16{int16(id)}, nil
+		}
+		return nil, errors.New("type must be a change type name or ID from 1 to 12")
+	}
+	normalized := strings.ToLower(strings.ReplaceAll(value, "-", "_"))
+	if ids, ok := playerChangeTypeFilters[normalized]; ok {
+		return ids, nil
+	}
+	return nil, errors.New("type must be a change type name or ID from 1 to 12")
+}
+
+func queryPlayerChanges(ctx context.Context, db playerChangesDB, tag string, changeTypes []int16, limit int) (modelsv2.PlayerChangesResponse, error) {
+	query := playerChangesQuery
+	args := []any{tag, limit}
+	if len(changeTypes) != 0 {
+		query = playerChangesByTypeQuery
+		args = []any{tag, changeTypes, limit}
+	}
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return modelsv2.PlayerChangesResponse{}, err
+	}
+	defer rows.Close()
+
+	response := modelsv2.PlayerChangesResponse{Tag: tag, Items: []modelsv2.PlayerChangeRecord{}}
+	for rows.Next() {
+		var item modelsv2.PlayerChangeRecord
+		if err := rows.Scan(&item.Time, &item.PlayerTag, &item.TownhallLevel, &item.TypeID, &item.ItemID, &item.Previous, &item.Current); err != nil {
+			return modelsv2.PlayerChangesResponse{}, err
+		}
+		item.Type = playerChangeTypeNames[item.TypeID]
+		response.Items = append(response.Items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return modelsv2.PlayerChangesResponse{}, err
+	}
+	response.Count = len(response.Items)
+	return response, nil
 }
 
 // leaderboardLeague godoc

--- a/internal/swaggerdocs/openapi.json
+++ b/internal/swaggerdocs/openapi.json
@@ -4441,43 +4441,51 @@
       },
       "modelsv2.PlayerChangeRecord": {
         "properties": {
-          "clan_tag": {
+          "current": {
             "type": "string"
           },
-          "current": {
-            "$ref": "#/components/schemas/modelsv2.PlayerChangeValue"
+          "item_id": {
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "player_tag": {
             "type": "string"
           },
           "previous": {
-            "$ref": "#/components/schemas/modelsv2.PlayerChangeValue"
+            "type": "string"
           },
           "time": {
             "type": "string"
           },
           "townhall_level": {
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "type": {
+            "enum": [
+              "troop_level",
+              "super_troop_boost",
+              "hero_level",
+              "spell_level",
+              "pet_level",
+              "equipment_level",
+              "town_hall_level",
+              "best_trophies",
+              "best_builder_base_trophies",
+              "exp_level",
+              "war_preference",
+              "name"
+            ],
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.PlayerChangeValue": {
-        "properties": {
-          "level": {
+          },
+          "type_id": {
+            "maximum": 12,
+            "minimum": 1,
             "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "tag": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
           }
         },
         "type": "object"
@@ -15316,7 +15324,7 @@
             }
           },
           {
-            "description": "Change type",
+            "description": "Change type name or ID (1-12)",
             "in": "query",
             "name": "type",
             "schema": {

--- a/internal/swaggerdocs/openapi.scalar.json
+++ b/internal/swaggerdocs/openapi.scalar.json
@@ -4441,43 +4441,51 @@
       },
       "modelsv2.PlayerChangeRecord": {
         "properties": {
-          "clan_tag": {
+          "current": {
             "type": "string"
           },
-          "current": {
-            "$ref": "#/components/schemas/modelsv2.PlayerChangeValue"
+          "item_id": {
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "player_tag": {
             "type": "string"
           },
           "previous": {
-            "$ref": "#/components/schemas/modelsv2.PlayerChangeValue"
+            "type": "string"
           },
           "time": {
             "type": "string"
           },
           "townhall_level": {
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "type": {
+            "enum": [
+              "troop_level",
+              "super_troop_boost",
+              "hero_level",
+              "spell_level",
+              "pet_level",
+              "equipment_level",
+              "town_hall_level",
+              "best_trophies",
+              "best_builder_base_trophies",
+              "exp_level",
+              "war_preference",
+              "name"
+            ],
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.PlayerChangeValue": {
-        "properties": {
-          "level": {
+          },
+          "type_id": {
+            "maximum": 12,
+            "minimum": 1,
             "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "tag": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
           }
         },
         "type": "object"
@@ -15317,7 +15325,7 @@
             }
           },
           {
-            "description": "Change type",
+            "description": "Change type name or ID (1-12)",
             "in": "query",
             "name": "type",
             "schema": {

--- a/internal/swaggerdocs/openapi.yaml
+++ b/internal/swaggerdocs/openapi.yaml
@@ -2905,31 +2905,41 @@ components:
             type: object
         modelsv2.PlayerChangeRecord:
             properties:
-                clan_tag:
-                    type: string
                 current:
-                    $ref: '#/components/schemas/modelsv2.PlayerChangeValue'
+                    type: string
+                item_id:
+                    type:
+                        - integer
+                        - "null"
                 player_tag:
                     type: string
                 previous:
-                    $ref: '#/components/schemas/modelsv2.PlayerChangeValue'
+                    type: string
                 time:
                     type: string
                 townhall_level:
-                    type: integer
+                    type:
+                        - integer
+                        - "null"
                 type:
+                    enum:
+                        - troop_level
+                        - super_troop_boost
+                        - hero_level
+                        - spell_level
+                        - pet_level
+                        - equipment_level
+                        - town_hall_level
+                        - best_trophies
+                        - best_builder_base_trophies
+                        - exp_level
+                        - war_preference
+                        - name
                     type: string
-            type: object
-        modelsv2.PlayerChangeValue:
-            properties:
-                level:
+                type_id:
+                    maximum: 12
+                    minimum: 1
                     type: integer
-                name:
-                    type: string
-                tag:
-                    type: string
-                value:
-                    type: string
             type: object
         modelsv2.PlayerChangesResponse:
             properties:
@@ -9794,7 +9804,7 @@ paths:
                   name: limit
                   schema:
                     type: integer
-                - description: Change type
+                - description: Change type name or ID (1-12)
                   in: query
                   name: type
                   schema:


### PR DESCRIPTION
## Summary
- query the normalized player change-history hypertable schema
- expose numeric type and item IDs while retaining stable readable type names
- support numeric, canonical, and legacy change-type filters
- update generated OpenAPI documents and add focused route tests

## Testing
- `go test ./...`