### PR TITLE
feat(api): refine war and CWL history contracts

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -43,14 +43,14 @@ const docTemplate = `{
         },
         "/cwl/{clanTag}/group": {
             "get": {
-                "description": "Returns the current season CWL group for a clan.",
+                "description": "Returns the clan's current CWL group through the legacy response shape used by older clients.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "War"
+                    "CWL"
                 ],
-                "summary": "Get current CWL group",
+                "summary": "View a clan's current CWL group",
                 "parameters": [
                     {
                         "type": "string",
@@ -72,14 +72,14 @@ const docTemplate = `{
         },
         "/cwl/{clanTag}/{season}": {
             "get": {
-                "description": "Returns the CWL group for a clan and season.",
+                "description": "Returns the clan's CWL group for a selected season through the legacy response shape used by older clients.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "War"
+                    "CWL"
                 ],
-                "summary": "Get CWL group by season",
+                "summary": "View a clan's CWL group by season",
                 "parameters": [
                     {
                         "type": "string",
@@ -1552,14 +1552,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/cached": {
             "get": {
-                "description": "Returns ClashKing's cached version of the clan response. The data may be several hours old.",
+                "description": "Returns a stored clan profile when live data is unnecessary. Values may be several hours behind the official API.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get a cached clan profile",
+                "summary": "Read a recently cached clan profile",
                 "parameters": [
                     {
                         "type": "string",
@@ -1587,14 +1587,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/history/changes": {
             "get": {
-                "description": "Returns description or clan-level changes. Values are strings or integers according to type.",
+                "description": "Returns stored description or clan-level changes with optional inclusive time bounds. Each value keeps its natural string or integer type.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get clan change history",
+                "summary": "Review changes to a clan's profile",
                 "parameters": [
                     {
                         "type": "string",
@@ -1659,14 +1659,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/join-leave": {
             "get": {
-                "description": "Returns join and leave history for a single clan tag. available and uniquePlayers are all-time totals; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.",
+                "description": "Returns stored joins and leaves for one clan. Time filters affect returned events, while available and uniquePlayers remain all-time totals.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get clan join-leave history",
+                "summary": "Review a clan's membership changes",
                 "parameters": [
                     {
                         "type": "string",
@@ -1836,14 +1836,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/rankings": {
             "get": {
-                "description": "Returns Home Village, Builder Base, and Clan Capital current points with every stored global/location placement.",
+                "description": "Returns current Home Village, Builder Base, and Clan Capital scores with every available global and local leaderboard position.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get rankings of a clan",
+                "summary": "View a clan's current leaderboard positions",
                 "parameters": [
                     {
                         "type": "string",
@@ -1871,14 +1871,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/records": {
             "get": {
-                "description": "Returns the highest tracked clan-points and war-win-streak records for a clan.",
+                "description": "Returns the clan's highest tracked points and longest war win streak, including when each record was reached.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get clan records",
+                "summary": "View a clan's tracked records",
                 "parameters": [
                     {
                         "type": "string",
@@ -1906,14 +1906,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/warlog": {
             "get": {
-                "description": "Returns wars stored in ClashKing's history.",
+                "description": "Returns stored wars in the official clan war-log shape, with optional type and end-time filters for paging historical results.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get a clan war log",
+                "summary": "Official API-compatible war log from stored war history",
                 "parameters": [
                     {
                         "type": "string",
@@ -1979,14 +1979,14 @@ const docTemplate = `{
         },
         "/v2/clan/{clan_tag}/wars": {
             "get": {
-                "description": "Returns previous wars for a clan rebuilt from SQL war rows, attacks, and missed attacks.",
+                "description": "Returns complete stored war details, including members and attacks, filtered by war type and inclusive end-time boundaries.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Clan"
                 ],
-                "summary": "Get stored clan wars",
+                "summary": "Complete stored wars for a clan",
                 "parameters": [
                     {
                         "type": "string",
@@ -1996,33 +1996,35 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "type": "integer",
-                        "description": "Start Unix timestamp. Defaults to all history.",
-                        "name": "timestamp_start",
+                        "enum": [
+                            "cwl",
+                            "random",
+                            "friendly"
+                        ],
+                        "type": "string",
+                        "description": "War type",
+                        "name": "type",
                         "in": "query"
                     },
                     {
-                        "type": "integer",
-                        "description": "End Unix timestamp",
-                        "name": "timestamp_end",
+                        "type": "string",
+                        "description": "Only include wars ending at or after this ISO-8601 time",
+                        "name": "time[after]",
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Only include wars ending at or before this ISO-8601 time",
+                        "name": "time[before]",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 500,
+                        "minimum": 1,
                         "type": "integer",
-                        "description": "Maximum number of wars. Max 250.",
+                        "default": 15,
+                        "description": "Maximum wars to return",
                         "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "War type filter. Repeatable. Values: random, friendly, cwl, all.",
-                        "name": "war_type",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Comma-separated war type filter. Values: random,friendly,cwl.",
-                        "name": "war_types",
                         "in": "query"
                     }
                 ],
@@ -2031,6 +2033,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/modelsv2.WarListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
                         }
                     },
                     "500": {
@@ -2233,91 +2241,16 @@ const docTemplate = `{
                 }
             }
         },
-        "/v2/cwl/league-thresholds": {
-            "get": {
-                "description": "Returns the static CWL promotion and demotion thresholds list.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "War"
-                ],
-                "summary": "Promo and demotion thresholds for CWL leagues",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.CWLThresholdResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/v2/cwl/leagues/{league_id}/rankings": {
-            "get": {
-                "description": "Returns only persisted standings for one season, league, and war size. Empty standings are a successful empty result until Tracking has computed them.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "War"
-                ],
-                "summary": "Persisted CWL league rankings",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "CWL league ID",
-                        "name": "league_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "CWL season (YYYY-MM)",
-                        "name": "season",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "CWL war size",
-                        "name": "war_size",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.CWLLeagueRankingsResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/v2/cwl/{clan_tag}": {
             "get": {
-                "description": "Returns the requested season, or the most recent stored season when season is omitted.",
+                "description": "Returns the requested CWL group with its roster, rounds, and wars, or the clan's most recent stored season when omitted.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "CWL"
                 ],
-                "summary": "Get a stored CWL group",
+                "summary": "View a clan's stored CWL group",
                 "parameters": [
                     {
                         "type": "string",
@@ -2351,14 +2284,14 @@ const docTemplate = `{
         },
         "/v2/cwl/{clan_tag}/ranking-history": {
             "get": {
-                "description": "Returns typed CWL group snapshots for a clan. A group without persisted standings returns its roster and lifecycle data with no synthetic ranking.",
+                "description": "Returns every stored CWL group containing the clan. Rosters and rounds are historical snapshots; rankings appear only when separately saved.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "War"
+                    "CWL"
                 ],
-                "summary": "CWL group history for a clan",
+                "summary": "Browse a clan's stored CWL groups",
                 "parameters": [
                     {
                         "type": "string",
@@ -2386,13 +2319,14 @@ const docTemplate = `{
         },
         "/v2/cwl/{clan_tag}/seasons": {
             "get": {
+                "description": "Lists every stored CWL season containing the clan, with its league, team size, state, and available group standing.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "CWL"
                 ],
-                "summary": "List stored CWL seasons for a clan",
+                "summary": "List a clan's stored CWL seasons",
                 "parameters": [
                     {
                         "type": "string",
@@ -3152,6 +3086,61 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/modelsv2.PublicClanLeaderboardResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/leaderboard/cwl/{league_id}": {
+            "get": {
+                "description": "Returns the saved leaderboard for one CWL season, league, and team size, ordered by global rank and then group rank.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Leaderboard"
+                ],
+                "summary": "Rank CWL clans within a league",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "CWL league ID",
+                        "name": "league_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "CWL season (YYYY-MM)",
+                        "name": "season",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "CWL team size",
+                        "name": "team_size",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.CWLLeagueRankingsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/modelsv2.ErrorResponse"
                         }
                     },
                     "500": {
@@ -4906,14 +4895,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/battlelog/history": {
             "get": {
-                "description": "Returns historical returned battlelogs for a player, including farming hits when present.",
+                "description": "Returns previously observed battle logs for the player, including farming attacks when those results were available during tracking.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player battlelog history",
+                "summary": "Browse a player's saved battle history",
                 "parameters": [
                     {
                         "type": "string",
@@ -4971,14 +4960,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/cwl/history": {
             "get": {
-                "description": "Returns player-centric CWL seasons from normalized roster, completed war lineup, and attack facts. Clan totals and placements are returned only when persisted standings or complete war facts support them.",
+                "description": "Returns each season containing the player, with their clan, league, team size, attacks, missed attacks, results, stars, and placements.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "War"
+                    "Player"
                 ],
-                "summary": "CWL group history for a player",
+                "summary": "Review a player's CWL season history",
                 "parameters": [
                     {
                         "type": "string",
@@ -5006,14 +4995,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/history/changes": {
             "get": {
-                "description": "Returns stored player profile changes of the requested type.",
+                "description": "Returns stored changes of one required type, such as upgrades or trophies, with optional inclusive time bounds.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player change history",
+                "summary": "Review changes to a player's profile",
                 "parameters": [
                     {
                         "type": "string",
@@ -5089,14 +5078,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/history/stats": {
             "get": {
-                "description": "Returns stored typed positive stat changes for a player over an inclusive ISO-8601 time range, newest first.",
+                "description": "Returns positive changes for one required activity type over an inclusive time range, newest first and limited to stored observations.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player stat changes",
+                "summary": "Track a player's activity gains",
                 "parameters": [
                     {
                         "type": "string",
@@ -5170,14 +5159,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/join-leave": {
             "get": {
-                "description": "Returns join and leave history for a single player tag. available is the all-time event total; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.",
+                "description": "Returns stored clan joins and leaves for one player. Time filters affect returned events, while available remains the all-time total.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player join-leave history",
+                "summary": "Review a player's clan movements",
                 "parameters": [
                     {
                         "type": "string",
@@ -5232,14 +5221,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/join-leave/shared": {
             "get": {
-                "description": "Returns clans two players shared, total shared minutes per clan, and each shared time range.",
+                "description": "Returns every clan the two players shared, including their total overlap and the exact stored time ranges together.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get shared player join-leave clan totals",
+                "summary": "Find clans shared by two players",
                 "parameters": [
                     {
                         "type": "string",
@@ -5280,14 +5269,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/join-leave/totals": {
             "get": {
-                "description": "Returns total minutes and join visit counts for each clan a player spent time in across all stored join-leave history.",
+                "description": "Totals the player's stored time and visits for every clan, making long-term clan membership easy to compare.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player join-leave clan totals",
+                "summary": "Measure a player's time in each clan",
                 "parameters": [
                     {
                         "type": "string",
@@ -5426,14 +5415,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/ranked/{season}/battlelog": {
             "get": {
-                "description": "Returns player ranked season placement plus recent ranked battlelog rows.",
+                "description": "Returns the player's placement for one ranked season together with the recent battles saved for that season.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player ranked battlelog",
+                "summary": "Review a player's ranked season battles",
                 "parameters": [
                     {
                         "type": "string",
@@ -5480,14 +5469,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/ranked/{season}/group": {
             "get": {
-                "description": "Returns ranked group data for the group containing the requested player.",
+                "description": "Returns the complete ranked group containing the player for one season, including every stored member and placement.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player ranked group",
+                "summary": "View a player's ranked season group",
                 "parameters": [
                     {
                         "type": "string",
@@ -5528,14 +5517,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/rankings": {
             "get": {
-                "description": "Returns current Home Village and Builder Base trophy rankings plus the player's retained official ranking location.",
+                "description": "Returns current Home Village and Builder Base trophy positions plus the player's official ranking location when it is known.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get current player rankings",
+                "summary": "View a player's current leaderboard positions",
                 "parameters": [
                     {
                         "type": "string",
@@ -5575,14 +5564,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/war/attacks": {
             "get": {
-                "description": "Returns stored attacks and defenses involving a player, most recent first.",
+                "description": "Returns stored attacks made by or against the player, with optional war type and inclusive time filters, newest first.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player war attacks",
+                "summary": "Browse a player's war attacks and defenses",
                 "parameters": [
                     {
                         "type": "string",
@@ -5648,14 +5637,14 @@ const docTemplate = `{
         },
         "/v2/player/{player_tag}/war/stats": {
             "get": {
-                "description": "Returns wars in which the player was rostered, with their attacks and defenses. Empty attack and defense arrays are retained so missed attacks can be derived from attacksPerMember.",
+                "description": "Returns wars where the player appeared, including both sides and every attack involving them. Empty attack lists reveal missed opportunities.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Player"
                 ],
-                "summary": "Get player war history",
+                "summary": "Review a player's complete war history",
                 "parameters": [
                     {
                         "type": "string",
@@ -9833,13 +9822,14 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
+                "description": "Returns the saved bonus-medal recipients for one server, clan, and CWL season so an existing award plan can be reviewed.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "CWL"
                 ],
-                "summary": "Get stored CWL bonus recipients",
+                "summary": "View saved CWL bonus recipients",
                 "parameters": [
                     {
                         "type": "integer",
@@ -9878,6 +9868,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
+                "description": "Replaces the saved bonus-medal recipients for one server, clan, and CWL season with the submitted player list.",
                 "consumes": [
                     "application/json"
                 ],
@@ -9887,7 +9878,7 @@ const docTemplate = `{
                 "tags": [
                     "CWL"
                 ],
-                "summary": "Replace stored CWL bonus recipients",
+                "summary": "Replace saved CWL bonus recipients",
                 "parameters": [
                     {
                         "type": "integer",
@@ -13478,14 +13469,14 @@ const docTemplate = `{
         },
         "/v2/war/clan/stats": {
             "get": {
-                "description": "Returns the number of wars for the requested clan tags.",
+                "description": "Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Clan war stats",
+                "summary": "Count stored wars for selected clans",
                 "parameters": [
                     {
                         "type": "array",
@@ -13522,14 +13513,14 @@ const docTemplate = `{
         },
         "/v2/war/clans/warhits": {
             "post": {
-                "description": "Returns war hit rows for the requested clan tags.",
+                "description": "Returns stored attack performance for the requested clans, with filters for dates, war types, town halls, and attack freshness.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Clan warhits stats",
+                "summary": "Compare war performance for selected clans",
                 "parameters": [
                     {
                         "description": "Clan tags",
@@ -13565,14 +13556,14 @@ const docTemplate = `{
         },
         "/v2/war/players/warhits": {
             "post": {
-                "description": "Returns war hit rows for the requested player tags.",
+                "description": "Returns stored attack performance for the requested players, with filters for dates, war types, town halls, and attack freshness.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Player warhits stats",
+                "summary": "Compare war performance for selected players",
                 "parameters": [
                     {
                         "description": "Player tags",
@@ -13608,14 +13599,14 @@ const docTemplate = `{
         },
         "/v2/war/stats": {
             "get": {
-                "description": "Returns the number of wars for the requested clan tags.",
+                "description": "Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Clan war stats",
+                "summary": "Count stored wars for selected clans",
                 "parameters": [
                     {
                         "type": "array",
@@ -13652,14 +13643,14 @@ const docTemplate = `{
         },
         "/v2/war/war-summary": {
             "post": {
-                "description": "Returns current war summary data for multiple clan tags.",
+                "description": "Returns a compact current-war summary for each submitted clan tag so multiple wars can be displayed or compared together.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Get full war summary for multiple clans",
+                "summary": "Compare current wars across several clans",
                 "parameters": [
                     {
                         "description": "Clan tags",
@@ -13693,75 +13684,16 @@ const docTemplate = `{
                 }
             }
         },
-        "/v2/war/{clan_tag}/previous": {
-            "get": {
-                "description": "Returns previous wars for a clan tag, optionally filtered to CWL.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "War"
-                ],
-                "summary": "Previous wars for a clan",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Clan tag",
-                        "name": "clan_tag",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Start timestamp",
-                        "name": "timestamp_start",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "End timestamp",
-                        "name": "timestamp_end",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "description": "Include CWL wars",
-                        "name": "include_cwl",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum number of results",
-                        "name": "limit",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.WarListResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/v2/war/{clan_tag}/war-summary": {
             "get": {
-                "description": "Returns current war summary data for a single clan tag.",
+                "description": "Returns a compact summary of the clan's current war, including state, opponent, scores, attacks, timing, and team size.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Get war summary for a clan",
+                "summary": "View a clan's current war summary",
                 "parameters": [
                     {
                         "type": "string",
@@ -13789,14 +13721,14 @@ const docTemplate = `{
         },
         "/war/{clanTag}/basic": {
             "get": {
-                "description": "Returns the current or most recent non-CWL war for a clan.",
+                "description": "Returns the clan's current or most recent non-CWL war through the legacy response shape used by older clients.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Get current or recent war",
+                "summary": "View a clan's latest regular war",
                 "parameters": [
                     {
                         "type": "string",
@@ -13824,14 +13756,14 @@ const docTemplate = `{
         },
         "/war/{clanTag}/previous": {
             "get": {
-                "description": "Returns the stored previous war near the supplied Clash API end time.",
+                "description": "Returns the stored clan war nearest the supplied official end time through the legacy response shape.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "War"
                 ],
-                "summary": "Get previous war by end time",
+                "summary": "Find a stored war by end time",
                 "parameters": [
                     {
                         "type": "string",
@@ -15663,6 +15595,9 @@ const docTemplate = `{
                     "type": "integer",
                     "x-nullable": true
                 },
+                "warLeague": {
+                    "$ref": "#/definitions/modelsv2.LeagueReference"
+                },
                 "wars": {
                     "allOf": [
                         {
@@ -15685,10 +15620,6 @@ const docTemplate = `{
                 "clan": {
                     "$ref": "#/definitions/modelsv2.CWLPlayerHistoryClan"
                 },
-                "cwlLeagueId": {
-                    "type": "integer",
-                    "x-nullable": true
-                },
                 "missedAttacks": {
                     "type": "integer"
                 },
@@ -15703,12 +15634,12 @@ const docTemplate = `{
                 "season": {
                     "type": "string"
                 },
-                "townHallLevel": {
-                    "type": "integer"
-                },
-                "warSize": {
+                "teamSize": {
                     "type": "integer",
                     "x-nullable": true
+                },
+                "townHallLevel": {
+                    "type": "integer"
                 }
             }
         },
@@ -15895,34 +15826,6 @@ const docTemplate = `{
                 },
                 "tag": {
                     "type": "string"
-                }
-            }
-        },
-        "modelsv2.CWLThresholdItem": {
-            "type": "object",
-            "properties": {
-                "demote": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "promo": {
-                    "type": "integer"
-                }
-            }
-        },
-        "modelsv2.CWLThresholdResponse": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/modelsv2.CWLThresholdItem"
-                    }
                 }
             }
         },

--- a/internal/models/v2/war_responses.go
+++ b/internal/models/v2/war_responses.go
@@ -1,13 +1,5 @@
 package modelsv2
 
-// CWLThresholdItem is one league row returned by GET /v2/cwl/league-thresholds.
-type CWLThresholdItem struct {
-	ID     int    `json:"id"`
-	Name   string `json:"name"`
-	Promo  int    `json:"promo"`
-	Demote int    `json:"demote"`
-}
-
 // CWLStanding is a stored CWL standing. Rankings are absent until Tracking
 // persists them; API readers never derive them from wars.
 type CWLStanding struct {
@@ -61,8 +53,7 @@ type CWLPlayerHistoryResponse struct {
 type CWLPlayerHistoryItem struct {
 	Season        string                    `json:"season"`
 	TownHallLevel int                       `json:"townHallLevel"`
-	CWLLeagueID   *int                      `json:"cwlLeagueId" extensions:"x-nullable"`
-	WarSize       *int                      `json:"warSize" extensions:"x-nullable"`
+	TeamSize      *int                      `json:"teamSize" extensions:"x-nullable"`
 	Clan          CWLPlayerHistoryClan      `json:"clan"`
 	Attacks       []CWLPlayerHistoryAttack  `json:"attacks"`
 	Placement     *CWLPlayerAttackPlacement `json:"placement" extensions:"x-nullable"`
@@ -73,6 +64,7 @@ type CWLPlayerHistoryClan struct {
 	Tag        string                     `json:"tag"`
 	Name       string                     `json:"name"`
 	BadgeURLs  WarBadgeURLs               `json:"badgeUrls"`
+	WarLeague  *LeagueReference           `json:"warLeague,omitempty"`
 	Wars       *CWLPlayerHistoryWarRecord `json:"wars" extensions:"x-nullable"`
 	TotalStars *int                       `json:"totalStars" extensions:"x-nullable"`
 	Placement  *CWLPlayerClanPlacement    `json:"placement" extensions:"x-nullable"`
@@ -207,10 +199,6 @@ type WarCompletedDailyItem struct {
 
 type WarCompletedDailyResponse struct {
 	Items []WarCompletedDailyItem `json:"items"`
-}
-
-type CWLThresholdResponse struct {
-	Items []CWLThresholdItem `json:"items"`
 }
 
 type WarStatsResponse struct {

--- a/internal/routes/clan.go
+++ b/internal/routes/clan.go
@@ -39,8 +39,8 @@ type clanWarLogClanSide struct {
 }
 
 // clanWarLog godoc
-// @Summary Get a clan war log
-// @Description Returns wars stored in ClashKing's history.
+// @Summary Official API-compatible war log from stored war history
+// @Description Returns stored wars in the official clan war-log shape, with optional type and end-time filters for paging historical results.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
@@ -64,22 +64,9 @@ func clanWarLogHandler(a apptypes.Deps, load clanWarLogLoader) fiber.Handler {
 		if clanTag == "" {
 			return apptypes.Error(fiber.StatusBadRequest, "clan_tag cannot be empty")
 		}
-		warType := strings.ToLower(strings.TrimSpace(c.Query("type")))
-		if warType != "" && warType != "cwl" && warType != "random" && warType != "friendly" {
-			return apptypes.Error(fiber.StatusBadRequest, "invalid type")
-		}
-		after, before, err := v2TimeWindowFromQuery(c, time.Unix(0, 0).UTC(), time.Unix(9999999999, 0).UTC())
+		after, before, types, limit, err := clanWarHistoryOptions(c, 50)
 		if err != nil {
 			return err
-		}
-		limit, err := v2QueryInt(c, "limit", 50)
-		if err != nil || limit < 1 {
-			return apptypes.Error(fiber.StatusBadRequest, "invalid limit")
-		}
-		limit = clamp(limit, 1, 500)
-		types := []string{"random", "friendly", "cwl"}
-		if warType != "" {
-			types = []string{warType}
 		}
 		wars, err := load(c, a, clanTag, after, before, types, limit)
 		if err != nil {
@@ -94,6 +81,26 @@ func clanWarLogHandler(a apptypes.Deps, load clanWarLogLoader) fiber.Handler {
 
 		return apptypes.JSON(c, fiber.StatusOK, clanWarLogResponse{Items: items})
 	}
+}
+
+func clanWarHistoryOptions(c *fiber.Ctx, defaultLimit int) (time.Time, time.Time, []string, int, error) {
+	warType := strings.ToLower(strings.TrimSpace(c.Query("type")))
+	if warType != "" && warType != "cwl" && warType != "random" && warType != "friendly" {
+		return time.Time{}, time.Time{}, nil, 0, apptypes.Error(fiber.StatusBadRequest, "invalid type")
+	}
+	after, before, err := v2TimeWindowFromQuery(c, time.Unix(0, 0).UTC(), time.Unix(9999999999, 0).UTC())
+	if err != nil {
+		return time.Time{}, time.Time{}, nil, 0, err
+	}
+	limit, err := v2QueryInt(c, "limit", defaultLimit)
+	if err != nil || limit < 1 {
+		return time.Time{}, time.Time{}, nil, 0, apptypes.Error(fiber.StatusBadRequest, "invalid limit")
+	}
+	types := []string{"random", "friendly", "cwl"}
+	if warType != "" {
+		types = []string{warType}
+	}
+	return after, before, types, clamp(limit, 1, 500), nil
 }
 
 func buildClanWarLogItem(war officialWarResponse) clanWarLogItem {
@@ -133,26 +140,29 @@ func valueOrDefault(value *int, fallback int) int {
 }
 
 // clanWars godoc
-// @Summary Get stored clan wars
-// @Description Returns previous wars for a clan rebuilt from SQL war rows, attacks, and missed attacks.
+// @Summary Complete stored wars for a clan
+// @Description Returns complete stored war details, including members and attacks, filtered by war type and inclusive end-time boundaries.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
-// @Param timestamp_start query int false "Start Unix timestamp. Defaults to all history."
-// @Param timestamp_end query int false "End Unix timestamp"
-// @Param limit query int false "Maximum number of wars. Max 250."
-// @Param war_type query string false "War type filter. Repeatable. Values: random, friendly, cwl, all."
-// @Param war_types query string false "Comma-separated war type filter. Values: random,friendly,cwl."
+// @Param type query string false "War type" Enums(cwl,random,friendly)
+// @Param time[after] query string false "Only include wars ending at or after this ISO-8601 time"
+// @Param time[before] query string false "Only include wars ending at or before this ISO-8601 time"
+// @Param limit query int false "Maximum wars to return" default(15) minimum(1) maximum(500)
 // @Success 200 {object} modelsv2.WarListResponse
+// @Failure 400 {object} modelsv2.ErrorResponse
 // @Failure 500 {object} modelsv2.ErrorResponse
 // @Router /v2/clan/{clan_tag}/wars [get]
 func clanWars(a apptypes.Deps) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		clanTag := warFixTag(c.Params("clan_tag"))
-		start := time.Unix(queryInt64(c, "timestamp_start", 0), 0).UTC()
-		end := time.Unix(queryInt64(c, "timestamp_end", 9999999999), 0).UTC()
-		limit := clamp(warParseIntDefault(c.Query("limit"), 50), 1, 250)
-		types := warTypesFromQuery(c, true)
+		if clanTag == "" {
+			return apptypes.Error(fiber.StatusBadRequest, "clan_tag cannot be empty")
+		}
+		start, end, types, limit, err := clanWarHistoryOptions(c, 15)
+		if err != nil {
+			return err
+		}
 		wars, err := sqlClanWars(c, a, clanTag, start, end, types, limit)
 		if err != nil {
 			return err
@@ -162,8 +172,8 @@ func clanWars(a apptypes.Deps) fiber.Handler {
 }
 
 // clanRanking godoc
-// @Summary Get rankings of a clan
-// @Description Returns Home Village, Builder Base, and Clan Capital current points with every stored global/location placement.
+// @Summary View a clan's current leaderboard positions
+// @Description Returns current Home Village, Builder Base, and Clan Capital scores with every available global and local leaderboard position.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
@@ -267,8 +277,8 @@ func emptyClanRankingCategory() modelsv2.ClanRankingCategory {
 }
 
 // clanComposition godoc
-// @Summary Get composition of a clan or clans
-// @Description Returns town hall, role, and league composition for the requested clan tags.
+// @Summary Compare member composition across clans
+// @Description Breaks each requested clan down by member town hall, role, and league so roster composition can be compared quickly.
 // @Tags Clan
 // @Produce json
 // @Param clan_tags query []string false "Clan tags"
@@ -314,8 +324,8 @@ func clanComposition(a apptypes.Deps) fiber.Handler {
 }
 
 // clansDetails godoc
-// @Summary Get full stats for a list of clans
-// @Description Returns detailed clan objects for the requested clan tags.
+// @Summary Load live profiles for several clans
+// @Description Returns complete live clan profiles for every requested tag, preserving the familiar official API structure for each result.
 // @Tags Clan
 // @Produce json
 // @Param body body modelsv2.ClanTagsBody true "Clan tags"
@@ -346,8 +356,8 @@ func clansDetails(a apptypes.Deps) fiber.Handler {
 }
 
 // clanDetails godoc
-// @Summary Get full stats for a single clan
-// @Description Returns the live clan object for a clan tag.
+// @Summary Load a clan's live profile
+// @Description Returns the clan's current official profile, including members, leagues, location, labels, capital details, and war settings.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"

--- a/internal/routes/clan_history_contract_test.go
+++ b/internal/routes/clan_history_contract_test.go
@@ -339,6 +339,35 @@ func TestClanWarLogHandlerUsesStoredWarsWithoutAuthentication(t *testing.T) {
 	}
 }
 
+func TestClanWarHistoryOptionsUseSharedFiltersAndEndpointDefaults(t *testing.T) {
+	var gotTypes []string
+	var gotLimit int
+	app := fiber.New(fiber.Config{ErrorHandler: apptypes.ErrorHandler})
+	app.Get("/wars", func(c *fiber.Ctx) error {
+		_, _, types, limit, err := clanWarHistoryOptions(c, 15)
+		if err != nil {
+			return err
+		}
+		gotTypes, gotLimit = types, limit
+		return c.SendStatus(http.StatusNoContent)
+	})
+
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, "/wars?type=cwl&time%5Bafter%5D=2026-08-01T00%3A00%3A00Z&time%5Bbefore%5D=2026-08-31T00%3A00%3A00Z", nil))
+	if err != nil || response.StatusCode != http.StatusNoContent || gotLimit != 15 || len(gotTypes) != 1 || gotTypes[0] != "cwl" {
+		t.Fatalf("shared clan war filters: status=%d types=%v limit=%d err=%v", response.StatusCode, gotTypes, gotLimit, err)
+	}
+	response, err = app.Test(httptest.NewRequest(http.MethodGet, "/wars?limit=501", nil))
+	if err != nil || response.StatusCode != http.StatusNoContent || gotLimit != 500 {
+		t.Fatalf("clamped clan war limit: status=%d limit=%d err=%v", response.StatusCode, gotLimit, err)
+	}
+	for _, path := range []string{"/wars?type=league", "/wars?limit=0", "/wars?time%5Bbefore%5D=bad"} {
+		response, err := app.Test(httptest.NewRequest(http.MethodGet, path, nil))
+		if err != nil || response.StatusCode != http.StatusBadRequest {
+			t.Fatalf("invalid shared clan war filters %s: status=%d err=%v", path, response.StatusCode, err)
+		}
+	}
+}
+
 func TestStoredArchiveWarUsesNormalizedSQLWarType(t *testing.T) {
 	war := wararchive.War{State: "warEnded", Clan: wararchive.Clan{Tag: "#CLAN"}, Opponent: wararchive.Clan{Tag: "#OTHER"}}
 	if item := buildStoredArchiveWar(sqlWarRow{WarType: "cwl"}, war, "#CLAN"); item.WarType != "cwl" {

--- a/internal/routes/cwl.go
+++ b/internal/routes/cwl.go
@@ -14,7 +14,8 @@ import (
 )
 
 // cwlSeasons godoc
-// @Summary List stored CWL seasons for a clan
+// @Summary List a clan's stored CWL seasons
+// @Description Lists every stored CWL season containing the clan, with its league, team size, state, and available group standing.
 // @Tags CWL
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
@@ -72,8 +73,8 @@ func cwlSeasons(a apptypes.Deps) fiber.Handler {
 }
 
 // storedCWL godoc
-// @Summary Get a stored CWL group
-// @Description Returns the requested season, or the most recent stored season when season is omitted.
+// @Summary View a clan's stored CWL group
+// @Description Returns the requested CWL group with its roster, rounds, and wars, or the clan's most recent stored season when omitted.
 // @Tags CWL
 // @Produce json
 // @Param clan_tag path string true "Clan tag"

--- a/internal/routes/cwl_bonus_awards.go
+++ b/internal/routes/cwl_bonus_awards.go
@@ -14,7 +14,8 @@ import (
 )
 
 // getCWLBonusRecipients godoc
-// @Summary Get stored CWL bonus recipients
+// @Summary View saved CWL bonus recipients
+// @Description Returns the saved bonus-medal recipients for one server, clan, and CWL season so an existing award plan can be reviewed.
 // @Tags CWL
 // @Produce json
 // @Security ApiKeyAuth
@@ -60,7 +61,8 @@ func getCWLBonusRecipients(a apptypes.Deps) fiber.Handler {
 }
 
 // replaceCWLBonusRecipients godoc
-// @Summary Replace stored CWL bonus recipients
+// @Summary Replace saved CWL bonus recipients
+// @Description Replaces the saved bonus-medal recipients for one server, clan, and CWL season with the submitted player list.
 // @Tags CWL
 // @Accept json
 // @Produce json

--- a/internal/routes/cwl_history_test.go
+++ b/internal/routes/cwl_history_test.go
@@ -38,9 +38,8 @@ func TestScanCWLPlayerHistorySeedBuildsBadgeAndPersistedStandingFacts(t *testing
 	if seed.CWLID != "internal-cwl" {
 		t.Fatalf("internal cwl id = %q", seed.CWLID)
 	}
-	if seed.Item.CWLLeagueID == nil || *seed.Item.CWLLeagueID != 48000017 ||
-		seed.Item.WarSize == nil || *seed.Item.WarSize != 15 {
-		t.Fatalf("unexpected league/war size: %#v", seed.Item)
+	if seed.LeagueID != 48000017 || seed.Item.TeamSize == nil || *seed.Item.TeamSize != 15 {
+		t.Fatalf("unexpected league/team size: %#v", seed.Item)
 	}
 	if seed.Item.Clan.BadgeURLs.Medium != "https://api-assets.clashofclans.com/badges/200/badge-token.png" {
 		t.Fatalf("badgeUrls = %#v", seed.Item.Clan.BadgeURLs)
@@ -55,6 +54,20 @@ func TestScanCWLPlayerHistorySeedBuildsBadgeAndPersistedStandingFacts(t *testing
 	}
 }
 
+func TestDecodeCWLRoundTagsAcceptsStoredAndOfficialShapes(t *testing.T) {
+	for name, raw := range map[string]string{
+		"stored":   `[["#WAR1"],["#WAR2","#0"]]`,
+		"official": `[{"warTags":["#WAR1"]},{"warTags":["#WAR2","#0"]}]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := decodeCWLRoundTags([]byte(raw))
+			if len(got) != 2 || len(got[0]) != 1 || got[0][0] != "#WAR1" || len(got[1]) != 2 || got[1][0] != "#WAR2" {
+				t.Fatalf("decoded rounds = %#v", got)
+			}
+		})
+	}
+}
+
 func TestCWLPlayerHistoryResponseUsesDedicatedCamelCaseShape(t *testing.T) {
 	response := modelsv2.CWLPlayerHistoryResponse{
 		Items: []modelsv2.CWLPlayerHistoryItem{{
@@ -62,6 +75,7 @@ func TestCWLPlayerHistoryResponseUsesDedicatedCamelCaseShape(t *testing.T) {
 			Clan: modelsv2.CWLPlayerHistoryClan{
 				Tag: "#CLAN", Name: "Clan",
 				BadgeURLs: modelsv2.WarBadgeURLs{Small: "small", Medium: "medium", Large: "large"},
+				WarLeague: &modelsv2.LeagueReference{ID: 48000017, Name: "Champion League II"},
 			},
 			Attacks: []modelsv2.CWLPlayerHistoryAttack{},
 		}},
@@ -78,7 +92,7 @@ func TestCWLPlayerHistoryResponseUsesDedicatedCamelCaseShape(t *testing.T) {
 		t.Fatalf("outer response must contain only items, got %s", raw)
 	}
 	item := decoded["items"].([]any)[0].(map[string]any)
-	for _, field := range []string{"season", "townHallLevel", "cwlLeagueId", "warSize", "clan", "attacks", "placement", "missedAttacks"} {
+	for _, field := range []string{"season", "townHallLevel", "teamSize", "clan", "attacks", "placement", "missedAttacks"} {
 		if _, found := item[field]; !found {
 			t.Errorf("history item missing %q", field)
 		}
@@ -88,11 +102,16 @@ func TestCWLPlayerHistoryResponseUsesDedicatedCamelCaseShape(t *testing.T) {
 			t.Errorf("player history retained obsolete generic field %q", obsolete)
 		}
 	}
-	if item["cwlLeagueId"] != nil || item["warSize"] != nil || item["placement"] != nil {
-		t.Fatalf("unknown league, war size, and placement must be explicit nulls, got %s", raw)
+	for _, retired := range []string{"cwlLeagueId", "warSize"} {
+		if _, found := item[retired]; found {
+			t.Errorf("history item retained retired field %q", retired)
+		}
+	}
+	if item["teamSize"] != nil || item["placement"] != nil {
+		t.Fatalf("unknown team size and placement must be explicit nulls, got %s", raw)
 	}
 	clan := item["clan"].(map[string]any)
-	for _, field := range []string{"tag", "name", "badgeUrls", "wars", "totalStars", "placement"} {
+	for _, field := range []string{"tag", "name", "badgeUrls", "warLeague", "wars", "totalStars", "placement"} {
 		if _, found := clan[field]; !found {
 			t.Errorf("player history clan missing %q", field)
 		}
@@ -161,10 +180,12 @@ func TestCWLQueriesUseFinalTypedSchema(t *testing.T) {
 		"'townHallLevel', member.town_hall",
 		"LEFT JOIN cwl_standings AS s ON s.cwl_id = gc.cwl_id AND s.clan_tag = gc.clan_tag",
 		"FROM cwl_standings", "ORDER BY global_rank NULLS LAST, group_rank NULLS LAST, clan_tag",
-		"JOIN wars AS w ON w.war_tag = round_tags.war_tag",
+		"roundTags := decodeCWLRoundTags(roundsJSON)",
+		"war_tag = ANY($1)",
 		"sqlArchiveWarsContext(c.UserContext(), a, warIDs)",
 		"for _, attack := range member.Attacks",
 		"strings.ToLower(state) != \"ended\"",
+		"calculateCWLSeasonSummary",
 	} {
 		if !strings.Contains(string(warSource), required) {
 			t.Errorf("typed CWL reader missing %q", required)

--- a/internal/routes/join_leave.go
+++ b/internal/routes/join_leave.go
@@ -14,8 +14,8 @@ import (
 )
 
 // clanJoinLeave godoc
-// @Summary Get clan join-leave history
-// @Description Returns join and leave history for a single clan tag. available and uniquePlayers are all-time totals; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.
+// @Summary Review a clan's membership changes
+// @Description Returns stored joins and leaves for one clan. Time filters affect returned events, while available and uniquePlayers remain all-time totals.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
@@ -37,8 +37,8 @@ func clanJoinLeave(a apptypes.Deps) fiber.Handler {
 }
 
 // playerJoinLeave godoc
-// @Summary Get player join-leave history
-// @Description Returns join and leave history for a single player tag. available is the all-time event total; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.
+// @Summary Review a player's clan movements
+// @Description Returns stored clan joins and leaves for one player. Time filters affect returned events, while available remains the all-time total.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -60,8 +60,8 @@ func playerJoinLeave(a apptypes.Deps) fiber.Handler {
 }
 
 // playerJoinLeaveTotals godoc
-// @Summary Get player join-leave clan totals
-// @Description Returns total minutes and join visit counts for each clan a player spent time in across all stored join-leave history.
+// @Summary Measure a player's time in each clan
+// @Description Totals the player's stored time and visits for every clan, making long-term clan membership easy to compare.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -88,8 +88,8 @@ func playerJoinLeaveTotals(a apptypes.Deps) fiber.Handler {
 }
 
 // playerJoinLeaveShared godoc
-// @Summary Get shared player join-leave clan totals
-// @Description Returns clans two players shared, total shared minutes per clan, and each shared time range.
+// @Summary Find clans shared by two players
+// @Description Returns every clan the two players shared, including their total overlap and the exact stored time ranges together.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"

--- a/internal/routes/legacy_clan.go
+++ b/internal/routes/legacy_clan.go
@@ -14,8 +14,8 @@ import (
 )
 
 // clanCached godoc
-// @Summary Get a cached clan profile
-// @Description Returns ClashKing's cached version of the clan response. The data may be several hours old.
+// @Summary Read a recently cached clan profile
+// @Description Returns a stored clan profile when live data is unnecessary. Values may be several hours behind the official API.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
@@ -42,8 +42,8 @@ func clanCachedHandler(a apptypes.Deps, load clanCachedLoader) fiber.Handler {
 }
 
 // clanRecords godoc
-// @Summary Get clan records
-// @Description Returns the highest tracked clan-points and war-win-streak records for a clan.
+// @Summary View a clan's tracked records
+// @Description Returns the clan's highest tracked points and longest war win streak, including when each record was reached.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"

--- a/internal/routes/legacy_war.go
+++ b/internal/routes/legacy_war.go
@@ -11,8 +11,8 @@ import (
 )
 
 // warPrevious godoc
-// @Summary Get previous wars
-// @Description Returns stored previous wars for a clan.
+// @Summary Browse a clan's older stored wars
+// @Description Returns older wars stored for the clan through the legacy response shape. New integrations should use the versioned clan wars endpoint.
 // @Tags War
 // @Produce json
 // @Param clanTag path string true "Clan tag"
@@ -36,8 +36,8 @@ func warPrevious(a apptypes.Deps) fiber.Handler {
 }
 
 // warPreviousAtTime godoc
-// @Summary Get previous war by end time
-// @Description Returns the stored previous war near the supplied Clash API end time.
+// @Summary Find a stored war by end time
+// @Description Returns the stored clan war nearest the supplied official end time through the legacy response shape.
 // @Tags War
 // @Produce json
 // @Param clanTag path string true "Clan tag"
@@ -62,8 +62,8 @@ func warPreviousAtTime(a apptypes.Deps) fiber.Handler {
 }
 
 // warBasic godoc
-// @Summary Get current or recent war
-// @Description Returns the current or most recent non-CWL war for a clan.
+// @Summary View a clan's latest regular war
+// @Description Returns the clan's current or most recent non-CWL war through the legacy response shape used by older clients.
 // @Tags War
 // @Produce json
 // @Param clanTag path string true "Clan tag"
@@ -85,9 +85,9 @@ func warBasic(a apptypes.Deps) fiber.Handler {
 }
 
 // cwlGroup godoc
-// @Summary Get current CWL group
-// @Description Returns the current season CWL group for a clan.
-// @Tags War
+// @Summary View a clan's current CWL group
+// @Description Returns the clan's current CWL group through the legacy response shape used by older clients.
+// @Tags CWL
 // @Produce json
 // @Param clanTag path string true "Clan tag"
 // @Success 200 {object} modelsv2.CWLGroupResponse
@@ -104,9 +104,9 @@ func cwlGroup(a apptypes.Deps) fiber.Handler {
 }
 
 // cwlSeason godoc
-// @Summary Get CWL group by season
-// @Description Returns the CWL group for a clan and season.
-// @Tags War
+// @Summary View a clan's CWL group by season
+// @Description Returns the clan's CWL group for a selected season through the legacy response shape used by older clients.
+// @Tags CWL
 // @Produce json
 // @Param clanTag path string true "Clan tag"
 // @Param season path string true "Season YYYY-MM"

--- a/internal/routes/player.go
+++ b/internal/routes/player.go
@@ -16,8 +16,8 @@ import (
 )
 
 // playerWarAttacks godoc
-// @Summary Get player war attacks
-// @Description Returns stored attacks and defenses involving a player, most recent first.
+// @Summary Browse a player's war attacks and defenses
+// @Description Returns stored attacks made by or against the player, with optional war type and inclusive time filters, newest first.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"

--- a/internal/routes/player_stat_history.go
+++ b/internal/routes/player_stat_history.go
@@ -46,8 +46,8 @@ type playerStatHistoryDB interface {
 }
 
 // playerStatHistory godoc
-// @Summary Get player stat changes
-// @Description Returns stored typed positive stat changes for a player over an inclusive ISO-8601 time range, newest first.
+// @Summary Track a player's activity gains
+// @Description Returns positive changes for one required activity type over an inclusive time range, newest first and limited to stored observations.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"

--- a/internal/routes/player_war_stats.go
+++ b/internal/routes/player_war_stats.go
@@ -42,8 +42,8 @@ type playerWarStatsDB interface {
 }
 
 // playerWarStats godoc
-// @Summary Get player war history
-// @Description Returns wars in which the player was rostered, with their attacks and defenses. Empty attack and defense arrays are retained so missed attacks can be derived from attacksPerMember.
+// @Summary Review a player's complete war history
+// @Description Returns wars where the player appeared, including both sides and every attack involving them. Empty attack lists reveal missed opportunities.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"

--- a/internal/routes/public_stats.go
+++ b/internal/routes/public_stats.go
@@ -17,8 +17,8 @@ import (
 )
 
 // playerRankings godoc
-// @Summary Get current player rankings
-// @Description Returns current Home Village and Builder Base trophy rankings plus the player's retained official ranking location.
+// @Summary View a player's current leaderboard positions
+// @Description Returns current Home Village and Builder Base trophy positions plus the player's official ranking location when it is known.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -136,8 +136,8 @@ func resolvePlayerRankingLocations(
 }
 
 // playerBattlelogHistory godoc
-// @Summary Get player battlelog history
-// @Description Returns historical returned battlelogs for a player, including farming hits when present.
+// @Summary Browse a player's saved battle history
+// @Description Returns previously observed battle logs for the player, including farming attacks when those results were available during tracking.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -196,8 +196,8 @@ func playerBattlelogHistory(a apptypes.Deps) fiber.Handler {
 }
 
 // playerRankedBattlelog godoc
-// @Summary Get player ranked battlelog
-// @Description Returns player ranked season placement plus recent ranked battlelog rows.
+// @Summary Review a player's ranked season battles
+// @Description Returns the player's placement for one ranked season together with the recent battles saved for that season.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -249,8 +249,8 @@ func playerRankedBattlelog(a apptypes.Deps) fiber.Handler {
 }
 
 // playerRankedGroup godoc
-// @Summary Get player ranked group
-// @Description Returns ranked group data for the group containing the requested player.
+// @Summary View a player's ranked season group
+// @Description Returns the complete ranked group containing the player for one season, including every stored member and placement.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -304,8 +304,8 @@ func playerRankedGroup(a apptypes.Deps) fiber.Handler {
 }
 
 // playerChanges godoc
-// @Summary Get player change history
-// @Description Returns stored player profile changes of the requested type.
+// @Summary Review changes to a player's profile
+// @Description Returns stored changes of one required type, such as upgrades or trophies, with optional inclusive time bounds.
 // @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
@@ -789,8 +789,8 @@ func globalLeagueTiers(a apptypes.Deps) fiber.Handler {
 }
 
 // clanChanges godoc
-// @Summary Get clan change history
-// @Description Returns description or clan-level changes. Values are strings or integers according to type.
+// @Summary Review changes to a clan's profile
+// @Description Returns stored description or clan-level changes with optional inclusive time bounds. Each value keeps its natural string or integer type.
 // @Tags Clan
 // @Produce json
 // @Param clan_tag path string true "Clan tag"

--- a/internal/routes/register.go
+++ b/internal/routes/register.go
@@ -333,12 +333,10 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 	app.Post("/v2/server/:server_id/countdowns", serverWrite(serverroutes.EnableCountdown(a)))
 	app.Delete("/v2/server/:server_id/countdowns", serverWrite(serverroutes.DisableCountdown(a)))
 
-	app.Get("/v2/war/:clan_tag/previous", previousWars(a))
 	app.Get("/v2/clan/:clan_tag/wars", clanWars(a))
 	app.Get("/v2/clan/:clan_tag/warlog", clanWarLog(a))
 	app.Get("/v2/cwl/:clan_tag/ranking-history", cwlClanHistory(a))
-	app.Get("/v2/cwl/leagues/:league_id/rankings", cwlLeagueRankings(a))
-	app.Get("/v2/cwl/league-thresholds", cwlThresholds)
+	app.Get("/v2/leaderboard/cwl/:league_id", cwlLeagueRankings(a))
 	app.Get("/v2/cwl/:clan_tag/seasons", cwlSeasons(a))
 	app.Get("/v2/cwl/:clan_tag", storedCWL(a))
 	app.Get("/v2/war/clan/stats", clanStats(a))

--- a/internal/routes/register_test.go
+++ b/internal/routes/register_test.go
@@ -140,6 +140,9 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 		"/global/war/completed/daily",
 		"/war/:clan_tag/previous",
 		"/war/:clan_tag/previous/:end_time",
+		"/v2/war/:clan_tag/previous",
+		"/v2/cwl/leagues/:league_id/rankings",
+		"/v2/cwl/league-thresholds",
 	} {
 		if paths[path] {
 			t.Fatalf("expected %s to be absent from registered routes", path)
@@ -165,7 +168,7 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 		"/v2/cwl/:clan_tag/seasons",
 		"/v2/cwl/:clan_tag",
 		"/v2/cwl/:clan_tag/ranking-history",
-		"/v2/cwl/leagues/:league_id/rankings",
+		"/v2/leaderboard/cwl/:league_id",
 		"/v2/links/:id",
 		"/v2/links/:id/:playerTag",
 		"/v2/links/:id/order",

--- a/internal/routes/war.go
+++ b/internal/routes/war.go
@@ -206,45 +206,10 @@ func warCompletedDaily(a apptypes.Deps) fiber.Handler {
 	}
 }
 
-// previousWars godoc
-// @Summary Previous wars for a clan
-// @Description Returns previous wars for a clan tag, optionally filtered to CWL.
-// @Tags War
-// @Produce json
-// @Param clan_tag path string true "Clan tag"
-// @Param timestamp_start query int false "Start timestamp"
-// @Param timestamp_end query int false "End timestamp"
-// @Param include_cwl query bool false "Include CWL wars"
-// @Param limit query int false "Maximum number of results"
-// @Success 200 {object} modelsv2.WarListResponse
-// @Failure 500 {object} modelsv2.ErrorResponse
-// @Router /v2/war/{clan_tag}/previous [get]
-func previousWars(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		clanTag := warFixTag(c.Params("clan_tag"))
-		start := timestampString(c.Query("timestamp_start"), 0)
-		end := timestampString(c.Query("timestamp_end"), 9999999999)
-		includeCWL, err := apptypes.QueryBool(c, "include_cwl", false)
-		if err != nil {
-			return err
-		}
-		limit := warParseIntDefault(c.Query("limit"), 50)
-		types := []string{"random", "friendly"}
-		if includeCWL {
-			types = []string{"random", "friendly", "cwl"}
-		}
-		rows, err := sqlClanWars(c, a, clanTag, warTimestampToTime(start), warTimestampToTime(end), types, limit)
-		if err != nil {
-			return err
-		}
-		return apptypes.JSON(c, fiber.StatusOK, map[string]any{"items": rows})
-	}
-}
-
 // cwlClanHistory godoc
-// @Summary CWL group history for a clan
-// @Description Returns typed CWL group snapshots for a clan. A group without persisted standings returns its roster and lifecycle data with no synthetic ranking.
-// @Tags War
+// @Summary Browse a clan's stored CWL groups
+// @Description Returns every stored CWL group containing the clan. Rosters and rounds are historical snapshots; rankings appear only when separately saved.
+// @Tags CWL
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
 // @Success 200 {object} modelsv2.CWLClanHistoryResponse
@@ -262,9 +227,9 @@ func cwlClanHistory(a apptypes.Deps) fiber.Handler {
 }
 
 // cwlPlayerHistory godoc
-// @Summary CWL group history for a player
-// @Description Returns player-centric CWL seasons from normalized roster, completed war lineup, and attack facts. Clan totals and placements are returned only when persisted standings or complete war facts support them.
-// @Tags War
+// @Summary Review a player's CWL season history
+// @Description Returns each season containing the player, with their clan, league, team size, attacks, missed attacks, results, stars, and placements.
+// @Tags Player
 // @Produce json
 // @Param player_tag path string true "Player tag"
 // @Success 200 {object} modelsv2.CWLPlayerHistoryResponse
@@ -282,17 +247,17 @@ func cwlPlayerHistory(a apptypes.Deps) fiber.Handler {
 }
 
 // cwlLeagueRankings godoc
-// @Summary Persisted CWL league rankings
-// @Description Returns only persisted standings for one season, league, and war size. Empty standings are a successful empty result until Tracking has computed them.
-// @Tags War
+// @Summary Rank CWL clans within a league
+// @Description Returns the saved leaderboard for one CWL season, league, and team size, ordered by global rank and then group rank.
+// @Tags Leaderboard
 // @Produce json
 // @Param league_id path int true "CWL league ID"
 // @Param season query string true "CWL season (YYYY-MM)"
-// @Param war_size query int true "CWL war size"
+// @Param team_size query int true "CWL team size"
 // @Success 200 {object} modelsv2.CWLLeagueRankingsResponse
 // @Failure 400 {object} modelsv2.ErrorResponse
 // @Failure 500 {object} modelsv2.ErrorResponse
-// @Router /v2/cwl/leagues/{league_id}/rankings [get]
+// @Router /v2/leaderboard/cwl/{league_id} [get]
 func cwlLeagueRankings(a apptypes.Deps) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		leagueID, err := strconv.Atoi(c.Params("league_id"))
@@ -303,9 +268,9 @@ func cwlLeagueRankings(a apptypes.Deps) fiber.Handler {
 		if season == "" {
 			return apptypes.Error(fiber.StatusBadRequest, "season is required")
 		}
-		warSize, err := strconv.Atoi(c.Query("war_size"))
+		warSize, err := strconv.Atoi(c.Query("team_size"))
 		if err != nil || warSize <= 0 {
-			return apptypes.Error(fiber.StatusBadRequest, "war_size must be a positive integer")
+			return apptypes.Error(fiber.StatusBadRequest, "team_size must be a positive integer")
 		}
 		items, err := cwlStandingsForLeague(c, a, season, leagueID, warSize)
 		if err != nil {
@@ -315,29 +280,9 @@ func cwlLeagueRankings(a apptypes.Deps) fiber.Handler {
 	}
 }
 
-// cwlThresholds godoc
-// @Summary Promo and demotion thresholds for CWL leagues
-// @Description Returns the static CWL promotion and demotion thresholds list.
-// @Tags War
-// @Produce json
-// @Success 200 {object} modelsv2.CWLThresholdResponse
-// @Router /v2/cwl/league-thresholds [get]
-func cwlThresholds(c *fiber.Ctx) error {
-	return apptypes.JSON(c, fiber.StatusOK, map[string]any{"items": []modelsv2.CWLThresholdItem{
-		{ID: 48000001, Name: "Bronze League III", Promo: 3, Demote: 9},
-		{ID: 48000004, Name: "Silver League III", Promo: 2, Demote: 8},
-		{ID: 48000007, Name: "Gold League III", Promo: 2, Demote: 7},
-		{ID: 48000010, Name: "Crystal League III", Promo: 2, Demote: 7},
-		{ID: 48000013, Name: "Master League III", Promo: 2, Demote: 6},
-		{ID: 48000016, Name: "Champion League III", Promo: 2, Demote: 6},
-		{ID: 48000019, Name: "Titan League III", Promo: 2, Demote: 5},
-		{ID: 48000022, Name: "Legend League", Promo: 0, Demote: 5},
-	}})
-}
-
 // clanStats godoc
-// @Summary Clan war stats
-// @Description Returns the number of wars for the requested clan tags.
+// @Summary Count stored wars for selected clans
+// @Description Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.
 // @Tags War
 // @Produce json
 // @Param clan_tags query []string false "Clan tags"
@@ -358,8 +303,8 @@ func clanStats(a apptypes.Deps) fiber.Handler {
 }
 
 // warSummaryBulk godoc
-// @Summary Get full war summary for multiple clans
-// @Description Returns current war summary data for multiple clan tags.
+// @Summary Compare current wars across several clans
+// @Description Returns a compact current-war summary for each submitted clan tag so multiple wars can be displayed or compared together.
 // @Tags War
 // @Produce json
 // @Param body body modelsv2.WarClanTagsBody true "Clan tags"
@@ -416,8 +361,8 @@ func warSummaryBulk(a apptypes.Deps) fiber.Handler {
 }
 
 // warSummarySingle godoc
-// @Summary Get war summary for a clan
-// @Description Returns current war summary data for a single clan tag.
+// @Summary View a clan's current war summary
+// @Description Returns a compact summary of the clan's current war, including state, opponent, scores, attacks, timing, and team size.
 // @Tags War
 // @Produce json
 // @Param clan_tag path string true "Clan tag"
@@ -431,8 +376,8 @@ func warSummarySingle(a apptypes.Deps) fiber.Handler {
 }
 
 // playerWarhits godoc
-// @Summary Player warhits stats
-// @Description Returns war hit rows for the requested player tags.
+// @Summary Compare war performance for selected players
+// @Description Returns stored attack performance for the requested players, with filters for dates, war types, town halls, and attack freshness.
 // @Tags War
 // @Produce json
 // @Param body body modelsv2.WarPlayersBody true "Player tags"
@@ -454,8 +399,8 @@ func playerWarhits(a apptypes.Deps) fiber.Handler {
 }
 
 // clanWarhits godoc
-// @Summary Clan warhits stats
-// @Description Returns war hit rows for the requested clan tags.
+// @Summary Compare war performance for selected clans
+// @Description Returns stored attack performance for the requested clans, with filters for dates, war types, town halls, and attack freshness.
 // @Tags War
 // @Produce json
 // @Param body body modelsv2.WarClanTagsBody true "Clan tags"
@@ -538,8 +483,9 @@ const cwlPlayerHistorySelect = `
 `
 
 type cwlPlayerHistorySeed struct {
-	CWLID string
-	Item  modelsv2.CWLPlayerHistoryItem
+	CWLID    string
+	LeagueID int
+	Item     modelsv2.CWLPlayerHistoryItem
 }
 
 func cwlHistoryForPlayer(c *fiber.Ctx, a apptypes.Deps, playerTag string) ([]modelsv2.CWLPlayerHistoryItem, error) {
@@ -562,15 +508,32 @@ func cwlHistoryForPlayer(c *fiber.Ctx, a apptypes.Deps, playerTag string) ([]mod
 	}
 
 	items := make([]modelsv2.CWLPlayerHistoryItem, 0, len(seeds))
+	catalog := newReferenceCatalog(a)
 	for _, seed := range seeds {
-		attacks, missedAttacks, actualWarSize, err := cwlPlayerWarFacts(c, a, seed.CWLID, playerTag, seed.Item.Clan.Tag)
+		if seed.LeagueID > 0 {
+			seed.Item.Clan.WarLeague = catalog.warLeague(seed.LeagueID)
+			if seed.Item.Clan.WarLeague == nil {
+				seed.Item.Clan.WarLeague = &modelsv2.LeagueReference{ID: seed.LeagueID}
+			}
+		}
+		attacks, missedAttacks, actualTeamSize, summary, err := cwlPlayerWarFacts(c, a, seed.CWLID, playerTag, seed.Item.Clan.Tag)
 		if err != nil {
 			return nil, err
 		}
 		seed.Item.Attacks = attacks
 		seed.Item.MissedAttacks = missedAttacks
-		if seed.Item.WarSize == nil {
-			seed.Item.WarSize = actualWarSize
+		if seed.Item.TeamSize == nil {
+			seed.Item.TeamSize = actualTeamSize
+		}
+		if summary != nil {
+			totalStars := summary.stars
+			seed.Item.Clan.TotalStars = &totalStars
+			seed.Item.Clan.Wars = &modelsv2.CWLPlayerHistoryWarRecord{Won: summary.wins, Lost: summary.losses, Tied: summary.ties}
+			if seed.Item.Clan.Placement == nil {
+				seed.Item.Clan.Placement = &modelsv2.CWLPlayerClanPlacement{}
+			}
+			groupRank := summary.rank
+			seed.Item.Clan.Placement.Group = &groupRank
 		}
 		placement, err := cwlPlayerEarnedStarsPlacement(c, a, seed.CWLID, playerTag, seed.Item.Clan.Tag)
 		if err != nil {
@@ -599,12 +562,11 @@ func scanCWLPlayerHistorySeed(row cwlHistoryScanner) (cwlPlayerHistorySeed, erro
 		Small: badgeURL(badgeToken, 70), Medium: badgeURL(badgeToken, 200), Large: badgeURL(badgeToken, 512),
 	}
 	if leagueID.Valid {
-		value := int(leagueID.Int32)
-		seed.Item.CWLLeagueID = &value
+		seed.LeagueID = int(leagueID.Int32)
 	}
 	if warSize.Valid {
 		value := int(warSize.Int16)
-		seed.Item.WarSize = &value
+		seed.Item.TeamSize = &value
 	}
 	if totalStars.Valid && wins.Valid && losses.Valid && ties.Valid {
 		value := int(totalStars.Int32)
@@ -627,46 +589,80 @@ func scanCWLPlayerHistorySeed(row cwlHistoryScanner) (cwlPlayerHistorySeed, erro
 	return seed, nil
 }
 
-func cwlPlayerWarFacts(c *fiber.Ctx, a apptypes.Deps, cwlID, playerTag, clanTag string) ([]modelsv2.CWLPlayerHistoryAttack, int, *int, error) {
-	rows, err := a.Store.SQL.Query(c.UserContext(), `
-		WITH round_tags AS (
-			SELECT round_data.round_number::integer AS round_number, war_tag.value AS war_tag
-			FROM cwl_groups AS g
-			CROSS JOIN LATERAL jsonb_array_elements(g.rounds) WITH ORDINALITY AS round_data(value, round_number)
-			CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(round_data.value -> 'warTags', '[]'::jsonb)) AS war_tag(value)
-			WHERE g.cwl_id = $1 AND war_tag.value <> '' AND war_tag.value <> '#0'
-		)
-		SELECT DISTINCT ON (w.war_id) round_tags.round_number, w.war_id::text
-		FROM round_tags JOIN wars AS w ON w.war_tag = round_tags.war_tag
-		WHERE w.war_type = 'cwl' AND lower(w.state) IN ('warended', 'ended')
-		ORDER BY w.war_id, round_tags.round_number
-	`, cwlID)
+func cwlPlayerWarFacts(c *fiber.Ctx, a apptypes.Deps, cwlID, playerTag, clanTag string) ([]modelsv2.CWLPlayerHistoryAttack, int, *int, *cwlSeasonSummary, error) {
+	var state string
+	var roundsJSON []byte
+	var clanTags []string
+	err := a.Store.SQL.QueryRow(c.UserContext(), `
+		SELECT g.state, g.rounds, array_agg(clan.clan_tag ORDER BY clan.clan_tag)
+		FROM cwl_groups AS g
+		JOIN cwl_group_clans AS clan ON clan.cwl_id = g.cwl_id
+		WHERE g.cwl_id = $1
+		GROUP BY g.cwl_id, g.state, g.rounds
+	`, cwlID).Scan(&state, &roundsJSON, &clanTags)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
+	}
+	roundTags := decodeCWLRoundTags(roundsJSON)
+	roundByTag := make(map[string]int)
+	warTags := make([]string, 0)
+	for roundIndex, tags := range roundTags {
+		for _, tag := range tags {
+			if tag == "" || tag == "#0" {
+				continue
+			}
+			roundByTag[tag] = roundIndex + 1
+			warTags = append(warTags, tag)
+		}
+	}
+	if len(warTags) == 0 {
+		return []modelsv2.CWLPlayerHistoryAttack{}, 0, nil, nil, nil
+	}
+	rows, err := a.Store.SQL.Query(c.UserContext(), `
+		SELECT war_id::text, war_tag, state, size, clan_tag, opponent_tag,
+		       clan_stars, opponent_stars,
+		       clan_destruction_percentage::float8, opponent_destruction_percentage::float8
+		FROM wars
+		WHERE war_type = 'cwl' AND war_tag = ANY($1)
+		  AND lower(state) IN ('warended', 'ended')
+	`, warTags)
+	if err != nil {
+		return nil, 0, nil, nil, err
 	}
 	defer rows.Close()
-	rounds := map[string]int{}
-	var warIDs []string
+	rounds := make(map[string]int)
+	warIDs := make([]string, 0, len(warTags))
+	normalizedWars := make(map[string]cwlLeagueBackfillWar, len(warTags))
 	for rows.Next() {
-		var round int
 		var warID string
-		if err := rows.Scan(&round, &warID); err != nil {
-			return nil, 0, nil, err
+		var war cwlLeagueBackfillWar
+		if err := rows.Scan(
+			&warID, &war.tag, &war.state, &war.size, &war.clanTag, &war.opponentTag,
+			&war.clanStars, &war.opponentStars, &war.clanDestruction, &war.opponentDestruction,
+		); err != nil {
+			return nil, 0, nil, nil, err
 		}
-		rounds[warID] = round
+		rounds[warID] = roundByTag[war.tag]
 		warIDs = append(warIDs, warID)
+		normalizedWars[war.tag] = war
 	}
 	if err := rows.Err(); err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
 	}
 	wars, err := sqlArchiveWarsContext(c.UserContext(), a, warIDs)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, nil, err
+	}
+	var summary *cwlSeasonSummary
+	if value, ok := calculateCWLSeasonSummary(clanTag, cwlLeagueBackfillGroup{
+		cwlID: cwlID, state: state, clanTags: clanTags, roundTags: roundTags,
+	}, normalizedWars); ok {
+		summary = &value
 	}
 	attacks := make([]modelsv2.CWLPlayerHistoryAttack, 0)
 	missedAttacks := 0
-	var actualWarSize *int
-	warSizeConflict := false
+	var actualTeamSize *int
+	teamSizeConflict := false
 	for warID, war := range wars {
 		var own, opponent *wararchive.Clan
 		if war.Clan.Tag == clanTag {
@@ -686,13 +682,13 @@ func cwlPlayerWarFacts(c *fiber.Ctx, a apptypes.Deps, cwlID, playerTag, clanTag 
 		if member == nil {
 			continue
 		}
-		if !warSizeConflict {
-			if actualWarSize == nil {
+		if !teamSizeConflict {
+			if actualTeamSize == nil {
 				value := war.TeamSize
-				actualWarSize = &value
-			} else if *actualWarSize != war.TeamSize {
-				actualWarSize = nil
-				warSizeConflict = true
+				actualTeamSize = &value
+			} else if *actualTeamSize != war.TeamSize {
+				actualTeamSize = nil
+				teamSizeConflict = true
 			}
 		}
 		missedAttacks += max(0, war.AttacksPerMember-len(member.Attacks))
@@ -716,7 +712,7 @@ func cwlPlayerWarFacts(c *fiber.Ctx, a apptypes.Deps, cwlID, playerTag, clanTag 
 		}
 		return attacks[i].Round < attacks[j].Round
 	})
-	return attacks, missedAttacks, actualWarSize, nil
+	return attacks, missedAttacks, actualTeamSize, summary, nil
 }
 
 func cwlPlayerEarnedStarsPlacement(c *fiber.Ctx, a apptypes.Deps, cwlID, playerTag, clanTag string) (*modelsv2.CWLPlayerAttackPlacement, error) {
@@ -732,8 +728,8 @@ func cwlPlayerEarnedStarsPlacement(c *fiber.Ctx, a apptypes.Deps, cwlID, playerT
 		return nil, nil
 	}
 	var warTags []string
-	for _, round := range cwlRounds(roundsJSON) {
-		for _, tag := range round.WarTags {
+	for _, round := range decodeCWLRoundTags(roundsJSON) {
+		for _, tag := range round {
 			if tag != "" && tag != "#0" {
 				warTags = append(warTags, tag)
 			}

--- a/internal/swaggerdocs/openapi.json
+++ b/internal/swaggerdocs/openapi.json
@@ -1802,6 +1802,9 @@
               "null"
             ]
           },
+          "warLeague": {
+            "$ref": "#/components/schemas/modelsv2.LeagueReference"
+          },
           "wars": {
             "allOf": [
               {
@@ -1827,12 +1830,6 @@
           "clan": {
             "$ref": "#/components/schemas/modelsv2.CWLPlayerHistoryClan"
           },
-          "cwlLeagueId": {
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
           "missedAttacks": {
             "type": "integer"
           },
@@ -1850,14 +1847,14 @@
           "season": {
             "type": "string"
           },
-          "townHallLevel": {
-            "type": "integer"
-          },
-          "warSize": {
+          "teamSize": {
             "type": [
               "integer",
               "null"
             ]
+          },
+          "townHallLevel": {
+            "type": "integer"
           }
         },
         "type": "object"
@@ -2044,34 +2041,6 @@
           },
           "tag": {
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.CWLThresholdItem": {
-        "properties": {
-          "demote": {
-            "type": "integer"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "promo": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.CWLThresholdResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.CWLThresholdItem"
-            },
-            "type": "array"
           }
         },
         "type": "object"
@@ -9475,7 +9444,7 @@
     },
     "/cwl/{clanTag}/group": {
       "get": {
-        "description": "Returns the current season CWL group for a clan.",
+        "description": "Returns the clan's current CWL group through the legacy response shape used by older clients.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -9499,15 +9468,15 @@
             "description": "OK"
           }
         },
-        "summary": "Get current CWL group",
+        "summary": "View a clan's current CWL group",
         "tags": [
-          "War"
+          "CWL"
         ]
       }
     },
     "/cwl/{clanTag}/{season}": {
       "get": {
-        "description": "Returns the CWL group for a clan and season.",
+        "description": "Returns the clan's CWL group for a selected season through the legacy response shape used by older clients.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -9560,9 +9529,9 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get CWL group by season",
+        "summary": "View a clan's CWL group by season",
         "tags": [
-          "War"
+          "CWL"
         ]
       }
     },
@@ -11228,7 +11197,7 @@
     },
     "/v2/clan/{clan_tag}/cached": {
       "get": {
-        "description": "Returns ClashKing's cached version of the clan response. The data may be several hours old.",
+        "description": "Returns a stored clan profile when live data is unnecessary. Values may be several hours behind the official API.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11262,7 +11231,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get a cached clan profile",
+        "summary": "Read a recently cached clan profile",
         "tags": [
           "Clan"
         ]
@@ -11270,7 +11239,7 @@
     },
     "/v2/clan/{clan_tag}/history/changes": {
       "get": {
-        "description": "Returns description or clan-level changes. Values are strings or integers according to type.",
+        "description": "Returns stored description or clan-level changes with optional inclusive time bounds. Each value keeps its natural string or integer type.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11353,7 +11322,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get clan change history",
+        "summary": "Review changes to a clan's profile",
         "tags": [
           "Clan"
         ]
@@ -11361,7 +11330,7 @@
     },
     "/v2/clan/{clan_tag}/join-leave": {
       "get": {
-        "description": "Returns join and leave history for a single clan tag. available and uniquePlayers are all-time totals; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.",
+        "description": "Returns stored joins and leaves for one clan. Time filters affect returned events, while available and uniquePlayers remain all-time totals.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11432,7 +11401,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get clan join-leave history",
+        "summary": "Review a clan's membership changes",
         "tags": [
           "Clan"
         ]
@@ -11589,7 +11558,7 @@
     },
     "/v2/clan/{clan_tag}/rankings": {
       "get": {
-        "description": "Returns Home Village, Builder Base, and Clan Capital current points with every stored global/location placement.",
+        "description": "Returns current Home Village, Builder Base, and Clan Capital scores with every available global and local leaderboard position.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11623,7 +11592,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get rankings of a clan",
+        "summary": "View a clan's current leaderboard positions",
         "tags": [
           "Clan"
         ]
@@ -11631,7 +11600,7 @@
     },
     "/v2/clan/{clan_tag}/records": {
       "get": {
-        "description": "Returns the highest tracked clan-points and war-win-streak records for a clan.",
+        "description": "Returns the clan's highest tracked points and longest war win streak, including when each record was reached.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11665,7 +11634,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get clan records",
+        "summary": "View a clan's tracked records",
         "tags": [
           "Clan"
         ]
@@ -11673,7 +11642,7 @@
     },
     "/v2/clan/{clan_tag}/warlog": {
       "get": {
-        "description": "Returns wars stored in ClashKing's history.",
+        "description": "Returns stored wars in the official clan war-log shape, with optional type and end-time filters for paging historical results.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11757,7 +11726,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get a clan war log",
+        "summary": "Official API-compatible war log from stored war history",
         "tags": [
           "Clan"
         ]
@@ -11765,7 +11734,7 @@
     },
     "/v2/clan/{clan_tag}/wars": {
       "get": {
-        "description": "Returns previous wars for a clan rebuilt from SQL war rows, attacks, and missed attacks.",
+        "description": "Returns complete stored war details, including members and attacks, filtered by war type and inclusive end-time boundaries.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11777,43 +11746,43 @@
             }
           },
           {
-            "description": "Start Unix timestamp. Defaults to all history.",
+            "description": "War type",
             "in": "query",
-            "name": "timestamp_start",
+            "name": "type",
             "schema": {
-              "type": "integer"
+              "enum": [
+                "cwl",
+                "random",
+                "friendly"
+              ],
+              "type": "string"
             }
           },
           {
-            "description": "End Unix timestamp",
+            "description": "Only include wars ending at or after this ISO-8601 time",
             "in": "query",
-            "name": "timestamp_end",
+            "name": "time[after]",
             "schema": {
-              "type": "integer"
+              "type": "string"
             }
           },
           {
-            "description": "Maximum number of wars. Max 250.",
+            "description": "Only include wars ending at or before this ISO-8601 time",
+            "in": "query",
+            "name": "time[before]",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum wars to return",
             "in": "query",
             "name": "limit",
             "schema": {
+              "default": 15,
+              "maximum": 500,
+              "minimum": 1,
               "type": "integer"
-            }
-          },
-          {
-            "description": "War type filter. Repeatable. Values: random, friendly, cwl, all.",
-            "in": "query",
-            "name": "war_type",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Comma-separated war type filter. Values: random,friendly,cwl.",
-            "in": "query",
-            "name": "war_types",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -11828,6 +11797,16 @@
             },
             "description": "OK"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -11839,7 +11818,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get stored clan wars",
+        "summary": "Complete stored wars for a clan",
         "tags": [
           "Clan"
         ]
@@ -12068,100 +12047,9 @@
         ]
       }
     },
-    "/v2/cwl/league-thresholds": {
-      "get": {
-        "description": "Returns the static CWL promotion and demotion thresholds list.",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.CWLThresholdResponse"
-                }
-              }
-            },
-            "description": "OK"
-          }
-        },
-        "summary": "Promo and demotion thresholds for CWL leagues",
-        "tags": [
-          "War"
-        ]
-      }
-    },
-    "/v2/cwl/leagues/{league_id}/rankings": {
-      "get": {
-        "description": "Returns only persisted standings for one season, league, and war size. Empty standings are a successful empty result until Tracking has computed them.",
-        "parameters": [
-          {
-            "description": "CWL league ID",
-            "in": "path",
-            "name": "league_id",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "CWL season (YYYY-MM)",
-            "in": "query",
-            "name": "season",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "CWL war size",
-            "in": "query",
-            "name": "war_size",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.CWLLeagueRankingsResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Persisted CWL league rankings",
-        "tags": [
-          "War"
-        ]
-      }
-    },
     "/v2/cwl/{clan_tag}": {
       "get": {
-        "description": "Returns the requested season, or the most recent stored season when season is omitted.",
+        "description": "Returns the requested CWL group with its roster, rounds, and wars, or the clan's most recent stored season when omitted.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -12203,7 +12091,7 @@
             "description": "Not Found"
           }
         },
-        "summary": "Get a stored CWL group",
+        "summary": "View a clan's stored CWL group",
         "tags": [
           "CWL"
         ]
@@ -12211,7 +12099,7 @@
     },
     "/v2/cwl/{clan_tag}/ranking-history": {
       "get": {
-        "description": "Returns typed CWL group snapshots for a clan. A group without persisted standings returns its roster and lifecycle data with no synthetic ranking.",
+        "description": "Returns every stored CWL group containing the clan. Rosters and rounds are historical snapshots; rankings appear only when separately saved.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -12245,14 +12133,15 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "CWL group history for a clan",
+        "summary": "Browse a clan's stored CWL groups",
         "tags": [
-          "War"
+          "CWL"
         ]
       }
     },
     "/v2/cwl/{clan_tag}/seasons": {
       "get": {
+        "description": "Lists every stored CWL season containing the clan, with its league, team size, state, and available group standing.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -12276,7 +12165,7 @@
             "description": "OK"
           }
         },
-        "summary": "List stored CWL seasons for a clan",
+        "summary": "List a clan's stored CWL seasons",
         "tags": [
           "CWL"
         ]
@@ -13150,6 +13039,76 @@
           }
         },
         "summary": "Get clan win streak leaderboard",
+        "tags": [
+          "Leaderboard"
+        ]
+      }
+    },
+    "/v2/leaderboard/cwl/{league_id}": {
+      "get": {
+        "description": "Returns the saved leaderboard for one CWL season, league, and team size, ordered by global rank and then group rank.",
+        "parameters": [
+          {
+            "description": "CWL league ID",
+            "in": "path",
+            "name": "league_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "CWL season (YYYY-MM)",
+            "in": "query",
+            "name": "season",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "CWL team size",
+            "in": "query",
+            "name": "team_size",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.CWLLeagueRankingsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Rank CWL clans within a league",
         "tags": [
           "Leaderboard"
         ]
@@ -15305,7 +15264,7 @@
     },
     "/v2/player/{player_tag}/battlelog/history": {
       "get": {
-        "description": "Returns historical returned battlelogs for a player, including farming hits when present.",
+        "description": "Returns previously observed battle logs for the player, including farming attacks when those results were available during tracking.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15381,7 +15340,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player battlelog history",
+        "summary": "Browse a player's saved battle history",
         "tags": [
           "Player"
         ]
@@ -15389,7 +15348,7 @@
     },
     "/v2/player/{player_tag}/cwl/history": {
       "get": {
-        "description": "Returns player-centric CWL seasons from normalized roster, completed war lineup, and attack facts. Clan totals and placements are returned only when persisted standings or complete war facts support them.",
+        "description": "Returns each season containing the player, with their clan, league, team size, attacks, missed attacks, results, stars, and placements.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15423,15 +15382,15 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "CWL group history for a player",
+        "summary": "Review a player's CWL season history",
         "tags": [
-          "War"
+          "Player"
         ]
       }
     },
     "/v2/player/{player_tag}/history/changes": {
       "get": {
-        "description": "Returns stored player profile changes of the requested type.",
+        "description": "Returns stored changes of one required type, such as upgrades or trophies, with optional inclusive time bounds.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15525,7 +15484,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player change history",
+        "summary": "Review changes to a player's profile",
         "tags": [
           "Player"
         ]
@@ -15533,7 +15492,7 @@
     },
     "/v2/player/{player_tag}/history/stats": {
       "get": {
-        "description": "Returns stored typed positive stat changes for a player over an inclusive ISO-8601 time range, newest first.",
+        "description": "Returns positive changes for one required activity type over an inclusive time range, newest first and limited to stored observations.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15629,7 +15588,7 @@
             "description": "Service Unavailable"
           }
         },
-        "summary": "Get player stat changes",
+        "summary": "Track a player's activity gains",
         "tags": [
           "Player"
         ]
@@ -15637,7 +15596,7 @@
     },
     "/v2/player/{player_tag}/join-leave": {
       "get": {
-        "description": "Returns join and leave history for a single player tag. available is the all-time event total; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.",
+        "description": "Returns stored clan joins and leaves for one player. Time filters affect returned events, while available remains the all-time total.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15708,7 +15667,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player join-leave history",
+        "summary": "Review a player's clan movements",
         "tags": [
           "Player"
         ]
@@ -15716,7 +15675,7 @@
     },
     "/v2/player/{player_tag}/join-leave/shared": {
       "get": {
-        "description": "Returns clans two players shared, total shared minutes per clan, and each shared time range.",
+        "description": "Returns every clan the two players shared, including their total overlap and the exact stored time ranges together.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15769,7 +15728,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get shared player join-leave clan totals",
+        "summary": "Find clans shared by two players",
         "tags": [
           "Player"
         ]
@@ -15777,7 +15736,7 @@
     },
     "/v2/player/{player_tag}/join-leave/totals": {
       "get": {
-        "description": "Returns total minutes and join visit counts for each clan a player spent time in across all stored join-leave history.",
+        "description": "Totals the player's stored time and visits for every clan, making long-term clan membership easy to compare.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15821,7 +15780,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player join-leave clan totals",
+        "summary": "Measure a player's time in each clan",
         "tags": [
           "Player"
         ]
@@ -15966,7 +15925,7 @@
     },
     "/v2/player/{player_tag}/ranked/{season}/battlelog": {
       "get": {
-        "description": "Returns player ranked season placement plus recent ranked battlelog rows.",
+        "description": "Returns the player's placement for one ranked season together with the recent battles saved for that season.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16027,7 +15986,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player ranked battlelog",
+        "summary": "Review a player's ranked season battles",
         "tags": [
           "Player"
         ]
@@ -16035,7 +15994,7 @@
     },
     "/v2/player/{player_tag}/ranked/{season}/group": {
       "get": {
-        "description": "Returns ranked group data for the group containing the requested player.",
+        "description": "Returns the complete ranked group containing the player for one season, including every stored member and placement.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16088,7 +16047,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player ranked group",
+        "summary": "View a player's ranked season group",
         "tags": [
           "Player"
         ]
@@ -16096,7 +16055,7 @@
     },
     "/v2/player/{player_tag}/rankings": {
       "get": {
-        "description": "Returns current Home Village and Builder Base trophy rankings plus the player's retained official ranking location.",
+        "description": "Returns current Home Village and Builder Base trophy positions plus the player's official ranking location when it is known.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16150,7 +16109,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get current player rankings",
+        "summary": "View a player's current leaderboard positions",
         "tags": [
           "Player"
         ]
@@ -16158,7 +16117,7 @@
     },
     "/v2/player/{player_tag}/war/attacks": {
       "get": {
-        "description": "Returns stored attacks and defenses involving a player, most recent first.",
+        "description": "Returns stored attacks made by or against the player, with optional war type and inclusive time filters, newest first.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16242,7 +16201,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player war attacks",
+        "summary": "Browse a player's war attacks and defenses",
         "tags": [
           "Player"
         ]
@@ -16250,7 +16209,7 @@
     },
     "/v2/player/{player_tag}/war/stats": {
       "get": {
-        "description": "Returns wars in which the player was rostered, with their attacks and defenses. Empty attack and defense arrays are retained so missed attacks can be derived from attacksPerMember.",
+        "description": "Returns wars where the player appeared, including both sides and every attack involving them. Empty attack lists reveal missed opportunities.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16334,7 +16293,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player war history",
+        "summary": "Review a player's complete war history",
         "tags": [
           "Player"
         ]
@@ -21325,6 +21284,7 @@
     },
     "/v2/server/{server_id}/cwl/{clan_tag}/bonus-recipients": {
       "get": {
+        "description": "Returns the saved bonus-medal recipients for one server, clan, and CWL season so an existing award plan can be reviewed.",
         "parameters": [
           {
             "description": "Discord server ID",
@@ -21371,12 +21331,13 @@
             "ApiKeyAuth": []
           }
         ],
-        "summary": "Get stored CWL bonus recipients",
+        "summary": "View saved CWL bonus recipients",
         "tags": [
           "CWL"
         ]
       },
       "put": {
+        "description": "Replaces the saved bonus-medal recipients for one server, clan, and CWL season with the submitted player list.",
         "parameters": [
           {
             "description": "Discord server ID",
@@ -21434,7 +21395,7 @@
             "ApiKeyAuth": []
           }
         ],
-        "summary": "Replace stored CWL bonus recipients",
+        "summary": "Replace saved CWL bonus recipients",
         "tags": [
           "CWL"
         ]
@@ -25625,7 +25586,7 @@
     },
     "/v2/war/clan/stats": {
       "get": {
-        "description": "Returns the number of wars for the requested clan tags.",
+        "description": "Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.",
         "parameters": [
           {
             "description": "Clan tags",
@@ -25671,7 +25632,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Clan war stats",
+        "summary": "Count stored wars for selected clans",
         "tags": [
           "War"
         ]
@@ -25679,7 +25640,7 @@
     },
     "/v2/war/clans/warhits": {
       "post": {
-        "description": "Returns war hit rows for the requested clan tags.",
+        "description": "Returns stored attack performance for the requested clans, with filters for dates, war types, town halls, and attack freshness.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -25723,7 +25684,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Clan warhits stats",
+        "summary": "Compare war performance for selected clans",
         "tags": [
           "War"
         ]
@@ -25731,7 +25692,7 @@
     },
     "/v2/war/players/warhits": {
       "post": {
-        "description": "Returns war hit rows for the requested player tags.",
+        "description": "Returns stored attack performance for the requested players, with filters for dates, war types, town halls, and attack freshness.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -25775,7 +25736,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Player warhits stats",
+        "summary": "Compare war performance for selected players",
         "tags": [
           "War"
         ]
@@ -25783,7 +25744,7 @@
     },
     "/v2/war/stats": {
       "get": {
-        "description": "Returns the number of wars for the requested clan tags.",
+        "description": "Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.",
         "parameters": [
           {
             "description": "Clan tags",
@@ -25829,7 +25790,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Clan war stats",
+        "summary": "Count stored wars for selected clans",
         "tags": [
           "War"
         ]
@@ -25837,7 +25798,7 @@
     },
     "/v2/war/war-summary": {
       "post": {
-        "description": "Returns current war summary data for multiple clan tags.",
+        "description": "Returns a compact current-war summary for each submitted clan tag so multiple wars can be displayed or compared together.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -25881,81 +25842,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get full war summary for multiple clans",
-        "tags": [
-          "War"
-        ]
-      }
-    },
-    "/v2/war/{clan_tag}/previous": {
-      "get": {
-        "description": "Returns previous wars for a clan tag, optionally filtered to CWL.",
-        "parameters": [
-          {
-            "description": "Clan tag",
-            "in": "path",
-            "name": "clan_tag",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Start timestamp",
-            "in": "query",
-            "name": "timestamp_start",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "End timestamp",
-            "in": "query",
-            "name": "timestamp_end",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Include CWL wars",
-            "in": "query",
-            "name": "include_cwl",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "description": "Maximum number of results",
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.WarListResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Previous wars for a clan",
+        "summary": "Compare current wars across several clans",
         "tags": [
           "War"
         ]
@@ -25963,7 +25850,7 @@
     },
     "/v2/war/{clan_tag}/war-summary": {
       "get": {
-        "description": "Returns current war summary data for a single clan tag.",
+        "description": "Returns a compact summary of the clan's current war, including state, opponent, scores, attacks, timing, and team size.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -25997,7 +25884,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get war summary for a clan",
+        "summary": "View a clan's current war summary",
         "tags": [
           "War"
         ]
@@ -26005,7 +25892,7 @@
     },
     "/war/{clanTag}/basic": {
       "get": {
-        "description": "Returns the current or most recent non-CWL war for a clan.",
+        "description": "Returns the clan's current or most recent non-CWL war through the legacy response shape used by older clients.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -26039,7 +25926,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get current or recent war",
+        "summary": "View a clan's latest regular war",
         "tags": [
           "War"
         ]
@@ -26047,7 +25934,7 @@
     },
     "/war/{clanTag}/previous": {
       "get": {
-        "description": "Returns the stored previous war near the supplied Clash API end time.",
+        "description": "Returns the stored clan war nearest the supplied official end time through the legacy response shape.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -26100,7 +25987,7 @@
             "description": "Not Found"
           }
         },
-        "summary": "Get previous war by end time",
+        "summary": "Find a stored war by end time",
         "tags": [
           "War"
         ]

--- a/internal/swaggerdocs/openapi.scalar.json
+++ b/internal/swaggerdocs/openapi.scalar.json
@@ -1802,6 +1802,9 @@
               "null"
             ]
           },
+          "warLeague": {
+            "$ref": "#/components/schemas/modelsv2.LeagueReference"
+          },
           "wars": {
             "allOf": [
               {
@@ -1827,12 +1830,6 @@
           "clan": {
             "$ref": "#/components/schemas/modelsv2.CWLPlayerHistoryClan"
           },
-          "cwlLeagueId": {
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
           "missedAttacks": {
             "type": "integer"
           },
@@ -1850,14 +1847,14 @@
           "season": {
             "type": "string"
           },
-          "townHallLevel": {
-            "type": "integer"
-          },
-          "warSize": {
+          "teamSize": {
             "type": [
               "integer",
               "null"
             ]
+          },
+          "townHallLevel": {
+            "type": "integer"
           }
         },
         "type": "object"
@@ -2044,34 +2041,6 @@
           },
           "tag": {
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.CWLThresholdItem": {
-        "properties": {
-          "demote": {
-            "type": "integer"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          },
-          "promo": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.CWLThresholdResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.CWLThresholdItem"
-            },
-            "type": "array"
           }
         },
         "type": "object"
@@ -9475,7 +9444,7 @@
     },
     "/cwl/{clanTag}/group": {
       "get": {
-        "description": "Returns the current season CWL group for a clan.",
+        "description": "Returns the clan's current CWL group through the legacy response shape used by older clients.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -9499,15 +9468,15 @@
             "description": "OK"
           }
         },
-        "summary": "Get current CWL group",
+        "summary": "View a clan's current CWL group",
         "tags": [
-          "War"
+          "CWL"
         ]
       }
     },
     "/cwl/{clanTag}/{season}": {
       "get": {
-        "description": "Returns the CWL group for a clan and season.",
+        "description": "Returns the clan's CWL group for a selected season through the legacy response shape used by older clients.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -9560,9 +9529,9 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get CWL group by season",
+        "summary": "View a clan's CWL group by season",
         "tags": [
-          "War"
+          "CWL"
         ]
       }
     },
@@ -11228,7 +11197,7 @@
     },
     "/v2/clan/{clan_tag}/cached": {
       "get": {
-        "description": "Returns ClashKing's cached version of the clan response. The data may be several hours old.",
+        "description": "Returns a stored clan profile when live data is unnecessary. Values may be several hours behind the official API.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11262,7 +11231,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get a cached clan profile",
+        "summary": "Read a recently cached clan profile",
         "tags": [
           "Clan"
         ]
@@ -11270,7 +11239,7 @@
     },
     "/v2/clan/{clan_tag}/history/changes": {
       "get": {
-        "description": "Returns description or clan-level changes. Values are strings or integers according to type.",
+        "description": "Returns stored description or clan-level changes with optional inclusive time bounds. Each value keeps its natural string or integer type.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11353,7 +11322,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get clan change history",
+        "summary": "Review changes to a clan's profile",
         "tags": [
           "Clan"
         ]
@@ -11361,7 +11330,7 @@
     },
     "/v2/clan/{clan_tag}/join-leave": {
       "get": {
-        "description": "Returns join and leave history for a single clan tag. available and uniquePlayers are all-time totals; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.",
+        "description": "Returns stored joins and leaves for one clan. Time filters affect returned events, while available and uniquePlayers remain all-time totals.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11432,7 +11401,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get clan join-leave history",
+        "summary": "Review a clan's membership changes",
         "tags": [
           "Clan"
         ]
@@ -11589,7 +11558,7 @@
     },
     "/v2/clan/{clan_tag}/rankings": {
       "get": {
-        "description": "Returns Home Village, Builder Base, and Clan Capital current points with every stored global/location placement.",
+        "description": "Returns current Home Village, Builder Base, and Clan Capital scores with every available global and local leaderboard position.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11623,7 +11592,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get rankings of a clan",
+        "summary": "View a clan's current leaderboard positions",
         "tags": [
           "Clan"
         ]
@@ -11631,7 +11600,7 @@
     },
     "/v2/clan/{clan_tag}/records": {
       "get": {
-        "description": "Returns the highest tracked clan-points and war-win-streak records for a clan.",
+        "description": "Returns the clan's highest tracked points and longest war win streak, including when each record was reached.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11665,7 +11634,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get clan records",
+        "summary": "View a clan's tracked records",
         "tags": [
           "Clan"
         ]
@@ -11673,7 +11642,7 @@
     },
     "/v2/clan/{clan_tag}/warlog": {
       "get": {
-        "description": "Returns wars stored in ClashKing's history.",
+        "description": "Returns stored wars in the official clan war-log shape, with optional type and end-time filters for paging historical results.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11757,7 +11726,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get a clan war log",
+        "summary": "Official API-compatible war log from stored war history",
         "tags": [
           "Clan"
         ]
@@ -11765,7 +11734,7 @@
     },
     "/v2/clan/{clan_tag}/wars": {
       "get": {
-        "description": "Returns previous wars for a clan rebuilt from SQL war rows, attacks, and missed attacks.",
+        "description": "Returns complete stored war details, including members and attacks, filtered by war type and inclusive end-time boundaries.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -11777,43 +11746,43 @@
             }
           },
           {
-            "description": "Start Unix timestamp. Defaults to all history.",
+            "description": "War type",
             "in": "query",
-            "name": "timestamp_start",
+            "name": "type",
             "schema": {
-              "type": "integer"
+              "enum": [
+                "cwl",
+                "random",
+                "friendly"
+              ],
+              "type": "string"
             }
           },
           {
-            "description": "End Unix timestamp",
+            "description": "Only include wars ending at or after this ISO-8601 time",
             "in": "query",
-            "name": "timestamp_end",
+            "name": "time[after]",
             "schema": {
-              "type": "integer"
+              "type": "string"
             }
           },
           {
-            "description": "Maximum number of wars. Max 250.",
+            "description": "Only include wars ending at or before this ISO-8601 time",
+            "in": "query",
+            "name": "time[before]",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum wars to return",
             "in": "query",
             "name": "limit",
             "schema": {
+              "default": 15,
+              "maximum": 500,
+              "minimum": 1,
               "type": "integer"
-            }
-          },
-          {
-            "description": "War type filter. Repeatable. Values: random, friendly, cwl, all.",
-            "in": "query",
-            "name": "war_type",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Comma-separated war type filter. Values: random,friendly,cwl.",
-            "in": "query",
-            "name": "war_types",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -11828,6 +11797,16 @@
             },
             "description": "OK"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
           "500": {
             "content": {
               "application/json": {
@@ -11839,7 +11818,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get stored clan wars",
+        "summary": "Complete stored wars for a clan",
         "tags": [
           "Clan"
         ]
@@ -12068,100 +12047,9 @@
         ]
       }
     },
-    "/v2/cwl/league-thresholds": {
-      "get": {
-        "description": "Returns the static CWL promotion and demotion thresholds list.",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.CWLThresholdResponse"
-                }
-              }
-            },
-            "description": "OK"
-          }
-        },
-        "summary": "Promo and demotion thresholds for CWL leagues",
-        "tags": [
-          "War"
-        ]
-      }
-    },
-    "/v2/cwl/leagues/{league_id}/rankings": {
-      "get": {
-        "description": "Returns only persisted standings for one season, league, and war size. Empty standings are a successful empty result until Tracking has computed them.",
-        "parameters": [
-          {
-            "description": "CWL league ID",
-            "in": "path",
-            "name": "league_id",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "CWL season (YYYY-MM)",
-            "in": "query",
-            "name": "season",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "CWL war size",
-            "in": "query",
-            "name": "war_size",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.CWLLeagueRankingsResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Persisted CWL league rankings",
-        "tags": [
-          "War"
-        ]
-      }
-    },
     "/v2/cwl/{clan_tag}": {
       "get": {
-        "description": "Returns the requested season, or the most recent stored season when season is omitted.",
+        "description": "Returns the requested CWL group with its roster, rounds, and wars, or the clan's most recent stored season when omitted.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -12203,7 +12091,7 @@
             "description": "Not Found"
           }
         },
-        "summary": "Get a stored CWL group",
+        "summary": "View a clan's stored CWL group",
         "tags": [
           "CWL"
         ]
@@ -12211,7 +12099,7 @@
     },
     "/v2/cwl/{clan_tag}/ranking-history": {
       "get": {
-        "description": "Returns typed CWL group snapshots for a clan. A group without persisted standings returns its roster and lifecycle data with no synthetic ranking.",
+        "description": "Returns every stored CWL group containing the clan. Rosters and rounds are historical snapshots; rankings appear only when separately saved.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -12245,14 +12133,15 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "CWL group history for a clan",
+        "summary": "Browse a clan's stored CWL groups",
         "tags": [
-          "War"
+          "CWL"
         ]
       }
     },
     "/v2/cwl/{clan_tag}/seasons": {
       "get": {
+        "description": "Lists every stored CWL season containing the clan, with its league, team size, state, and available group standing.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -12276,7 +12165,7 @@
             "description": "OK"
           }
         },
-        "summary": "List stored CWL seasons for a clan",
+        "summary": "List a clan's stored CWL seasons",
         "tags": [
           "CWL"
         ]
@@ -13151,6 +13040,76 @@
           }
         },
         "summary": "Get clan win streak leaderboard",
+        "tags": [
+          "Leaderboard"
+        ]
+      }
+    },
+    "/v2/leaderboard/cwl/{league_id}": {
+      "get": {
+        "description": "Returns the saved leaderboard for one CWL season, league, and team size, ordered by global rank and then group rank.",
+        "parameters": [
+          {
+            "description": "CWL league ID",
+            "in": "path",
+            "name": "league_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "CWL season (YYYY-MM)",
+            "in": "query",
+            "name": "season",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "CWL team size",
+            "in": "query",
+            "name": "team_size",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.CWLLeagueRankingsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Rank CWL clans within a league",
         "tags": [
           "Leaderboard"
         ]
@@ -15306,7 +15265,7 @@
     },
     "/v2/player/{player_tag}/battlelog/history": {
       "get": {
-        "description": "Returns historical returned battlelogs for a player, including farming hits when present.",
+        "description": "Returns previously observed battle logs for the player, including farming attacks when those results were available during tracking.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15382,7 +15341,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player battlelog history",
+        "summary": "Browse a player's saved battle history",
         "tags": [
           "Player"
         ]
@@ -15390,7 +15349,7 @@
     },
     "/v2/player/{player_tag}/cwl/history": {
       "get": {
-        "description": "Returns player-centric CWL seasons from normalized roster, completed war lineup, and attack facts. Clan totals and placements are returned only when persisted standings or complete war facts support them.",
+        "description": "Returns each season containing the player, with their clan, league, team size, attacks, missed attacks, results, stars, and placements.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15424,15 +15383,15 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "CWL group history for a player",
+        "summary": "Review a player's CWL season history",
         "tags": [
-          "War"
+          "Player"
         ]
       }
     },
     "/v2/player/{player_tag}/history/changes": {
       "get": {
-        "description": "Returns stored player profile changes of the requested type.",
+        "description": "Returns stored changes of one required type, such as upgrades or trophies, with optional inclusive time bounds.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15526,7 +15485,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player change history",
+        "summary": "Review changes to a player's profile",
         "tags": [
           "Player"
         ]
@@ -15534,7 +15493,7 @@
     },
     "/v2/player/{player_tag}/history/stats": {
       "get": {
-        "description": "Returns stored typed positive stat changes for a player over an inclusive ISO-8601 time range, newest first.",
+        "description": "Returns positive changes for one required activity type over an inclusive time range, newest first and limited to stored observations.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15630,7 +15589,7 @@
             "description": "Service Unavailable"
           }
         },
-        "summary": "Get player stat changes",
+        "summary": "Track a player's activity gains",
         "tags": [
           "Player"
         ]
@@ -15638,7 +15597,7 @@
     },
     "/v2/player/{player_tag}/join-leave": {
       "get": {
-        "description": "Returns join and leave history for a single player tag. available is the all-time event total; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.",
+        "description": "Returns stored clan joins and leaves for one player. Time filters affect returned events, while available remains the all-time total.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15709,7 +15668,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player join-leave history",
+        "summary": "Review a player's clan movements",
         "tags": [
           "Player"
         ]
@@ -15717,7 +15676,7 @@
     },
     "/v2/player/{player_tag}/join-leave/shared": {
       "get": {
-        "description": "Returns clans two players shared, total shared minutes per clan, and each shared time range.",
+        "description": "Returns every clan the two players shared, including their total overlap and the exact stored time ranges together.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15770,7 +15729,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get shared player join-leave clan totals",
+        "summary": "Find clans shared by two players",
         "tags": [
           "Player"
         ]
@@ -15778,7 +15737,7 @@
     },
     "/v2/player/{player_tag}/join-leave/totals": {
       "get": {
-        "description": "Returns total minutes and join visit counts for each clan a player spent time in across all stored join-leave history.",
+        "description": "Totals the player's stored time and visits for every clan, making long-term clan membership easy to compare.",
         "parameters": [
           {
             "description": "Player tag",
@@ -15822,7 +15781,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player join-leave clan totals",
+        "summary": "Measure a player's time in each clan",
         "tags": [
           "Player"
         ]
@@ -15967,7 +15926,7 @@
     },
     "/v2/player/{player_tag}/ranked/{season}/battlelog": {
       "get": {
-        "description": "Returns player ranked season placement plus recent ranked battlelog rows.",
+        "description": "Returns the player's placement for one ranked season together with the recent battles saved for that season.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16028,7 +15987,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player ranked battlelog",
+        "summary": "Review a player's ranked season battles",
         "tags": [
           "Player"
         ]
@@ -16036,7 +15995,7 @@
     },
     "/v2/player/{player_tag}/ranked/{season}/group": {
       "get": {
-        "description": "Returns ranked group data for the group containing the requested player.",
+        "description": "Returns the complete ranked group containing the player for one season, including every stored member and placement.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16089,7 +16048,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player ranked group",
+        "summary": "View a player's ranked season group",
         "tags": [
           "Player"
         ]
@@ -16097,7 +16056,7 @@
     },
     "/v2/player/{player_tag}/rankings": {
       "get": {
-        "description": "Returns current Home Village and Builder Base trophy rankings plus the player's retained official ranking location.",
+        "description": "Returns current Home Village and Builder Base trophy positions plus the player's official ranking location when it is known.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16151,7 +16110,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get current player rankings",
+        "summary": "View a player's current leaderboard positions",
         "tags": [
           "Player"
         ]
@@ -16159,7 +16118,7 @@
     },
     "/v2/player/{player_tag}/war/attacks": {
       "get": {
-        "description": "Returns stored attacks and defenses involving a player, most recent first.",
+        "description": "Returns stored attacks made by or against the player, with optional war type and inclusive time filters, newest first.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16243,7 +16202,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player war attacks",
+        "summary": "Browse a player's war attacks and defenses",
         "tags": [
           "Player"
         ]
@@ -16251,7 +16210,7 @@
     },
     "/v2/player/{player_tag}/war/stats": {
       "get": {
-        "description": "Returns wars in which the player was rostered, with their attacks and defenses. Empty attack and defense arrays are retained so missed attacks can be derived from attacksPerMember.",
+        "description": "Returns wars where the player appeared, including both sides and every attack involving them. Empty attack lists reveal missed opportunities.",
         "parameters": [
           {
             "description": "Player tag",
@@ -16335,7 +16294,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get player war history",
+        "summary": "Review a player's complete war history",
         "tags": [
           "Player"
         ]
@@ -21328,6 +21287,7 @@
     },
     "/v2/server/{server_id}/cwl/{clan_tag}/bonus-recipients": {
       "get": {
+        "description": "Returns the saved bonus-medal recipients for one server, clan, and CWL season so an existing award plan can be reviewed.",
         "parameters": [
           {
             "description": "Discord server ID",
@@ -21374,12 +21334,13 @@
             "ApiKeyAuth": []
           }
         ],
-        "summary": "Get stored CWL bonus recipients",
+        "summary": "View saved CWL bonus recipients",
         "tags": [
           "CWL"
         ]
       },
       "put": {
+        "description": "Replaces the saved bonus-medal recipients for one server, clan, and CWL season with the submitted player list.",
         "parameters": [
           {
             "description": "Discord server ID",
@@ -21437,7 +21398,7 @@
             "ApiKeyAuth": []
           }
         ],
-        "summary": "Replace stored CWL bonus recipients",
+        "summary": "Replace saved CWL bonus recipients",
         "tags": [
           "CWL"
         ]
@@ -25633,7 +25594,7 @@
     },
     "/v2/war/clan/stats": {
       "get": {
-        "description": "Returns the number of wars for the requested clan tags.",
+        "description": "Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.",
         "parameters": [
           {
             "description": "Clan tags",
@@ -25679,7 +25640,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Clan war stats",
+        "summary": "Count stored wars for selected clans",
         "tags": [
           "War"
         ]
@@ -25687,7 +25648,7 @@
     },
     "/v2/war/clans/warhits": {
       "post": {
-        "description": "Returns war hit rows for the requested clan tags.",
+        "description": "Returns stored attack performance for the requested clans, with filters for dates, war types, town halls, and attack freshness.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -25731,7 +25692,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Clan warhits stats",
+        "summary": "Compare war performance for selected clans",
         "tags": [
           "War"
         ]
@@ -25739,7 +25700,7 @@
     },
     "/v2/war/players/warhits": {
       "post": {
-        "description": "Returns war hit rows for the requested player tags.",
+        "description": "Returns stored attack performance for the requested players, with filters for dates, war types, town halls, and attack freshness.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -25783,7 +25744,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Player warhits stats",
+        "summary": "Compare war performance for selected players",
         "tags": [
           "War"
         ]
@@ -25791,7 +25752,7 @@
     },
     "/v2/war/stats": {
       "get": {
-        "description": "Returns the number of wars for the requested clan tags.",
+        "description": "Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.",
         "parameters": [
           {
             "description": "Clan tags",
@@ -25837,7 +25798,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Clan war stats",
+        "summary": "Count stored wars for selected clans",
         "tags": [
           "War"
         ]
@@ -25845,7 +25806,7 @@
     },
     "/v2/war/war-summary": {
       "post": {
-        "description": "Returns current war summary data for multiple clan tags.",
+        "description": "Returns a compact current-war summary for each submitted clan tag so multiple wars can be displayed or compared together.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -25889,81 +25850,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get full war summary for multiple clans",
-        "tags": [
-          "War"
-        ]
-      }
-    },
-    "/v2/war/{clan_tag}/previous": {
-      "get": {
-        "description": "Returns previous wars for a clan tag, optionally filtered to CWL.",
-        "parameters": [
-          {
-            "description": "Clan tag",
-            "in": "path",
-            "name": "clan_tag",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Start timestamp",
-            "in": "query",
-            "name": "timestamp_start",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "End timestamp",
-            "in": "query",
-            "name": "timestamp_end",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Include CWL wars",
-            "in": "query",
-            "name": "include_cwl",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "description": "Maximum number of results",
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.WarListResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Previous wars for a clan",
+        "summary": "Compare current wars across several clans",
         "tags": [
           "War"
         ]
@@ -25971,7 +25858,7 @@
     },
     "/v2/war/{clan_tag}/war-summary": {
       "get": {
-        "description": "Returns current war summary data for a single clan tag.",
+        "description": "Returns a compact summary of the clan's current war, including state, opponent, scores, attacks, timing, and team size.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -26005,7 +25892,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get war summary for a clan",
+        "summary": "View a clan's current war summary",
         "tags": [
           "War"
         ]
@@ -26013,7 +25900,7 @@
     },
     "/war/{clanTag}/basic": {
       "get": {
-        "description": "Returns the current or most recent non-CWL war for a clan.",
+        "description": "Returns the clan's current or most recent non-CWL war through the legacy response shape used by older clients.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -26047,7 +25934,7 @@
             "description": "Internal Server Error"
           }
         },
-        "summary": "Get current or recent war",
+        "summary": "View a clan's latest regular war",
         "tags": [
           "War"
         ]
@@ -26055,7 +25942,7 @@
     },
     "/war/{clanTag}/previous": {
       "get": {
-        "description": "Returns the stored previous war near the supplied Clash API end time.",
+        "description": "Returns the stored clan war nearest the supplied official end time through the legacy response shape.",
         "parameters": [
           {
             "description": "Clan tag",
@@ -26108,7 +25995,7 @@
             "description": "Not Found"
           }
         },
-        "summary": "Get previous war by end time",
+        "summary": "Find a stored war by end time",
         "tags": [
           "War"
         ]

--- a/internal/swaggerdocs/openapi.yaml
+++ b/internal/swaggerdocs/openapi.yaml
@@ -1176,6 +1176,8 @@ components:
                     type:
                         - integer
                         - "null"
+                warLeague:
+                    $ref: '#/components/schemas/modelsv2.LeagueReference'
                 wars:
                     allOf:
                         - $ref: '#/components/schemas/modelsv2.CWLPlayerHistoryWarRecord'
@@ -1191,10 +1193,6 @@ components:
                     type: array
                 clan:
                     $ref: '#/components/schemas/modelsv2.CWLPlayerHistoryClan'
-                cwlLeagueId:
-                    type:
-                        - integer
-                        - "null"
                 missedAttacks:
                     type: integer
                 placement:
@@ -1205,12 +1203,12 @@ components:
                         - "null"
                 season:
                     type: string
-                townHallLevel:
-                    type: integer
-                warSize:
+                teamSize:
                     type:
                         - integer
                         - "null"
+                townHallLevel:
+                    type: integer
             type: object
         modelsv2.CWLPlayerHistoryResponse:
             properties:
@@ -1332,24 +1330,6 @@ components:
                     type: string
                 tag:
                     type: string
-            type: object
-        modelsv2.CWLThresholdItem:
-            properties:
-                demote:
-                    type: integer
-                id:
-                    type: integer
-                name:
-                    type: string
-                promo:
-                    type: integer
-            type: object
-        modelsv2.CWLThresholdResponse:
-            properties:
-                items:
-                    items:
-                        $ref: '#/components/schemas/modelsv2.CWLThresholdItem'
-                    type: array
             type: object
         modelsv2.ClanBadgeURLs:
             properties:
@@ -6236,7 +6216,7 @@ paths:
                 - Other
     /cwl/{clanTag}/{season}:
         get:
-            description: Returns the CWL group for a clan and season.
+            description: Returns the clan's CWL group for a selected season through the legacy response shape used by older clients.
             parameters:
                 - description: Clan tag
                   in: path
@@ -6269,12 +6249,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get CWL group by season
+            summary: View a clan's CWL group by season
             tags:
-                - War
+                - CWL
     /cwl/{clanTag}/group:
         get:
-            description: Returns the current season CWL group for a clan.
+            description: Returns the clan's current CWL group through the legacy response shape used by older clients.
             parameters:
                 - description: Clan tag
                   in: path
@@ -6289,9 +6269,9 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.CWLGroupResponse'
                     description: OK
-            summary: Get current CWL group
+            summary: View a clan's current CWL group
             tags:
-                - War
+                - CWL
     /global/counts:
         get:
             description: Returns global tracking counts used by legacy clients.
@@ -7301,7 +7281,7 @@ paths:
                 - Other
     /v2/clan/{clan_tag}/cached:
         get:
-            description: Returns ClashKing's cached version of the clan response. The data may be several hours old.
+            description: Returns a stored clan profile when live data is unnecessary. Values may be several hours behind the official API.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7322,12 +7302,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get a cached clan profile
+            summary: Read a recently cached clan profile
             tags:
                 - Clan
     /v2/clan/{clan_tag}/history/changes:
         get:
-            description: Returns description or clan-level changes. Values are strings or integers according to type.
+            description: Returns stored description or clan-level changes with optional inclusive time bounds. Each value keeps its natural string or integer type.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7380,12 +7360,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get clan change history
+            summary: Review changes to a clan's profile
             tags:
                 - Clan
     /v2/clan/{clan_tag}/join-leave:
         get:
-            description: Returns join and leave history for a single clan tag. available and uniquePlayers are all-time totals; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.
+            description: Returns stored joins and leaves for one clan. Time filters affect returned events, while available and uniquePlayers remain all-time totals.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7430,7 +7410,7 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get clan join-leave history
+            summary: Review a clan's membership changes
             tags:
                 - Clan
     /v2/clan/{clan_tag}/leaderboard-history/{leaderboard_type}:
@@ -7529,7 +7509,7 @@ paths:
                 - Leaderboard
     /v2/clan/{clan_tag}/rankings:
         get:
-            description: Returns Home Village, Builder Base, and Clan Capital current points with every stored global/location placement.
+            description: Returns current Home Village, Builder Base, and Clan Capital scores with every available global and local leaderboard position.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7550,12 +7530,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get rankings of a clan
+            summary: View a clan's current leaderboard positions
             tags:
                 - Clan
     /v2/clan/{clan_tag}/records:
         get:
-            description: Returns the highest tracked clan-points and war-win-streak records for a clan.
+            description: Returns the clan's highest tracked points and longest war win streak, including when each record was reached.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7576,12 +7556,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get clan records
+            summary: View a clan's tracked records
             tags:
                 - Clan
     /v2/clan/{clan_tag}/warlog:
         get:
-            description: Returns wars stored in ClashKing's history.
+            description: Returns stored wars in the official clan war-log shape, with optional type and end-time filters for paging historical results.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7635,12 +7615,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get a clan war log
+            summary: Official API-compatible war log from stored war history
             tags:
                 - Clan
     /v2/clan/{clan_tag}/wars:
         get:
-            description: Returns previous wars for a clan rebuilt from SQL war rows, attacks, and missed attacks.
+            description: Returns complete stored war details, including members and attacks, filtered by war type and inclusive end-time boundaries.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7648,31 +7628,33 @@ paths:
                   required: true
                   schema:
                     type: string
-                - description: Start Unix timestamp. Defaults to all history.
+                - description: War type
                   in: query
-                  name: timestamp_start
+                  name: type
                   schema:
-                    type: integer
-                - description: End Unix timestamp
+                    enum:
+                        - cwl
+                        - random
+                        - friendly
+                    type: string
+                - description: Only include wars ending at or after this ISO-8601 time
                   in: query
-                  name: timestamp_end
+                  name: time[after]
                   schema:
-                    type: integer
-                - description: Maximum number of wars. Max 250.
+                    type: string
+                - description: Only include wars ending at or before this ISO-8601 time
+                  in: query
+                  name: time[before]
+                  schema:
+                    type: string
+                - description: Maximum wars to return
                   in: query
                   name: limit
                   schema:
+                    default: 15
+                    maximum: 500
+                    minimum: 1
                     type: integer
-                - description: 'War type filter. Repeatable. Values: random, friendly, cwl, all.'
-                  in: query
-                  name: war_type
-                  schema:
-                    type: string
-                - description: 'Comma-separated war type filter. Values: random,friendly,cwl.'
-                  in: query
-                  name: war_types
-                  schema:
-                    type: string
             responses:
                 "200":
                     content:
@@ -7680,13 +7662,19 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.WarListResponse'
                     description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
+                    description: Bad Request
                 "500":
                     content:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get stored clan wars
+            summary: Complete stored wars for a clan
             tags:
                 - Clan
     /v2/config/public:
@@ -7826,7 +7814,7 @@ paths:
                 - Counts
     /v2/cwl/{clan_tag}:
         get:
-            description: Returns the requested season, or the most recent stored season when season is omitted.
+            description: Returns the requested CWL group with its roster, rounds, and wars, or the clan's most recent stored season when omitted.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7852,12 +7840,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Not Found
-            summary: Get a stored CWL group
+            summary: View a clan's stored CWL group
             tags:
                 - CWL
     /v2/cwl/{clan_tag}/ranking-history:
         get:
-            description: Returns typed CWL group snapshots for a clan. A group without persisted standings returns its roster and lifecycle data with no synthetic ranking.
+            description: Returns every stored CWL group containing the clan. Rosters and rounds are historical snapshots; rankings appear only when separately saved.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7878,11 +7866,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: CWL group history for a clan
+            summary: Browse a clan's stored CWL groups
             tags:
-                - War
+                - CWL
     /v2/cwl/{clan_tag}/seasons:
         get:
+            description: Lists every stored CWL season containing the clan, with its league, team size, state, and available group standing.
             parameters:
                 - description: Clan tag
                   in: path
@@ -7897,66 +7886,9 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.CWLSeasonsResponse'
                     description: OK
-            summary: List stored CWL seasons for a clan
+            summary: List a clan's stored CWL seasons
             tags:
                 - CWL
-    /v2/cwl/league-thresholds:
-        get:
-            description: Returns the static CWL promotion and demotion thresholds list.
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.CWLThresholdResponse'
-                    description: OK
-            summary: Promo and demotion thresholds for CWL leagues
-            tags:
-                - War
-    /v2/cwl/leagues/{league_id}/rankings:
-        get:
-            description: Returns only persisted standings for one season, league, and war size. Empty standings are a successful empty result until Tracking has computed them.
-            parameters:
-                - description: CWL league ID
-                  in: path
-                  name: league_id
-                  required: true
-                  schema:
-                    type: integer
-                - description: CWL season (YYYY-MM)
-                  in: query
-                  name: season
-                  required: true
-                  schema:
-                    type: string
-                - description: CWL war size
-                  in: query
-                  name: war_size
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.CWLLeagueRankingsResponse'
-                    description: OK
-                "400":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Bad Request
-                "500":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Internal Server Error
-            summary: Persisted CWL league rankings
-            tags:
-                - War
     /v2/dates/current:
         get:
             description: Returns current season and event date identifiers.
@@ -8592,6 +8524,50 @@ paths:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
             summary: Get clan win streak leaderboard
+            tags:
+                - Leaderboard
+    /v2/leaderboard/cwl/{league_id}:
+        get:
+            description: Returns the saved leaderboard for one CWL season, league, and team size, ordered by global rank and then group rank.
+            parameters:
+                - description: CWL league ID
+                  in: path
+                  name: league_id
+                  required: true
+                  schema:
+                    type: integer
+                - description: CWL season (YYYY-MM)
+                  in: query
+                  name: season
+                  required: true
+                  schema:
+                    type: string
+                - description: CWL team size
+                  in: query
+                  name: team_size
+                  required: true
+                  schema:
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/modelsv2.CWLLeagueRankingsResponse'
+                    description: OK
+                "400":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
+                    description: Bad Request
+                "500":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
+                    description: Internal Server Error
+            summary: Rank CWL clans within a league
             tags:
                 - Leaderboard
     /v2/leaderboard/history/{leaderboard_type}/{location_id}/{date}:
@@ -9796,7 +9772,7 @@ paths:
                 - Notifications
     /v2/player/{player_tag}/battlelog/history:
         get:
-            description: Returns historical returned battlelogs for a player, including farming hits when present.
+            description: Returns previously observed battle logs for the player, including farming attacks when those results were available during tracking.
             parameters:
                 - description: Player tag
                   in: path
@@ -9843,12 +9819,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player battlelog history
+            summary: Browse a player's saved battle history
             tags:
                 - Player
     /v2/player/{player_tag}/cwl/history:
         get:
-            description: Returns player-centric CWL seasons from normalized roster, completed war lineup, and attack facts. Clan totals and placements are returned only when persisted standings or complete war facts support them.
+            description: Returns each season containing the player, with their clan, league, team size, attacks, missed attacks, results, stars, and placements.
             parameters:
                 - description: Player tag
                   in: path
@@ -9869,12 +9845,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: CWL group history for a player
+            summary: Review a player's CWL season history
             tags:
-                - War
+                - Player
     /v2/player/{player_tag}/history/changes:
         get:
-            description: Returns stored player profile changes of the requested type.
+            description: Returns stored changes of one required type, such as upgrades or trophies, with optional inclusive time bounds.
             parameters:
                 - description: Player tag
                   in: path
@@ -9938,12 +9914,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player change history
+            summary: Review changes to a player's profile
             tags:
                 - Player
     /v2/player/{player_tag}/history/stats:
         get:
-            description: Returns stored typed positive stat changes for a player over an inclusive ISO-8601 time range, newest first.
+            description: Returns positive changes for one required activity type over an inclusive time range, newest first and limited to stored observations.
             parameters:
                 - description: Player tag
                   in: path
@@ -10005,12 +9981,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Service Unavailable
-            summary: Get player stat changes
+            summary: Track a player's activity gains
             tags:
                 - Player
     /v2/player/{player_tag}/join-leave:
         get:
-            description: Returns join and leave history for a single player tag. available is the all-time event total; date filters only affect returned items. Date filters use ISO-8601 values such as 2026-05-01T00:00:00Z.
+            description: Returns stored clan joins and leaves for one player. Time filters affect returned events, while available remains the all-time total.
             parameters:
                 - description: Player tag
                   in: path
@@ -10055,12 +10031,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player join-leave history
+            summary: Review a player's clan movements
             tags:
                 - Player
     /v2/player/{player_tag}/join-leave/shared:
         get:
-            description: Returns clans two players shared, total shared minutes per clan, and each shared time range.
+            description: Returns every clan the two players shared, including their total overlap and the exact stored time ranges together.
             parameters:
                 - description: Player tag
                   in: path
@@ -10093,12 +10069,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get shared player join-leave clan totals
+            summary: Find clans shared by two players
             tags:
                 - Player
     /v2/player/{player_tag}/join-leave/totals:
         get:
-            description: Returns total minutes and join visit counts for each clan a player spent time in across all stored join-leave history.
+            description: Totals the player's stored time and visits for every clan, making long-term clan membership easy to compare.
             parameters:
                 - description: Player tag
                   in: path
@@ -10125,7 +10101,7 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player join-leave clan totals
+            summary: Measure a player's time in each clan
             tags:
                 - Player
     /v2/player/{player_tag}/leaderboard-history/{leaderboard_type}:
@@ -10215,7 +10191,7 @@ paths:
                 - Leaderboard
     /v2/player/{player_tag}/ranked/{season}/battlelog:
         get:
-            description: Returns player ranked season placement plus recent ranked battlelog rows.
+            description: Returns the player's placement for one ranked season together with the recent battles saved for that season.
             parameters:
                 - description: Player tag
                   in: path
@@ -10253,12 +10229,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player ranked battlelog
+            summary: Review a player's ranked season battles
             tags:
                 - Player
     /v2/player/{player_tag}/ranked/{season}/group:
         get:
-            description: Returns ranked group data for the group containing the requested player.
+            description: Returns the complete ranked group containing the player for one season, including every stored member and placement.
             parameters:
                 - description: Player tag
                   in: path
@@ -10291,12 +10267,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player ranked group
+            summary: View a player's ranked season group
             tags:
                 - Player
     /v2/player/{player_tag}/rankings:
         get:
-            description: Returns current Home Village and Builder Base trophy rankings plus the player's retained official ranking location.
+            description: Returns current Home Village and Builder Base trophy positions plus the player's official ranking location when it is known.
             parameters:
                 - description: Player tag
                   in: path
@@ -10329,12 +10305,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get current player rankings
+            summary: View a player's current leaderboard positions
             tags:
                 - Player
     /v2/player/{player_tag}/war/attacks:
         get:
-            description: Returns stored attacks and defenses involving a player, most recent first.
+            description: Returns stored attacks made by or against the player, with optional war type and inclusive time filters, newest first.
             parameters:
                 - description: Player tag
                   in: path
@@ -10388,12 +10364,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player war attacks
+            summary: Browse a player's war attacks and defenses
             tags:
                 - Player
     /v2/player/{player_tag}/war/stats:
         get:
-            description: Returns wars in which the player was rostered, with their attacks and defenses. Empty attack and defense arrays are retained so missed attacks can be derived from attacksPerMember.
+            description: Returns wars where the player appeared, including both sides and every attack involving them. Empty attack lists reveal missed opportunities.
             parameters:
                 - description: Player tag
                   in: path
@@ -10447,7 +10423,7 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get player war history
+            summary: Review a player's complete war history
             tags:
                 - Player
     /v2/public:
@@ -13477,6 +13453,7 @@ paths:
                 - Server Countdowns
     /v2/server/{server_id}/cwl/{clan_tag}/bonus-recipients:
         get:
+            description: Returns the saved bonus-medal recipients for one server, clan, and CWL season so an existing award plan can be reviewed.
             parameters:
                 - description: Discord server ID
                   in: path
@@ -13505,10 +13482,11 @@ paths:
                     description: OK
             security:
                 - ApiKeyAuth: []
-            summary: Get stored CWL bonus recipients
+            summary: View saved CWL bonus recipients
             tags:
                 - CWL
         put:
+            description: Replaces the saved bonus-medal recipients for one server, clan, and CWL season with the submitted player list.
             parameters:
                 - description: Discord server ID
                   in: path
@@ -13544,7 +13522,7 @@ paths:
                     description: OK
             security:
                 - ApiKeyAuth: []
-            summary: Replace stored CWL bonus recipients
+            summary: Replace saved CWL bonus recipients
             tags:
                 - CWL
     /v2/server/{server_id}/dashboard-access:
@@ -16086,55 +16064,9 @@ paths:
             summary: Verify email address with 6-digit code
             tags:
                 - App Authentication
-    /v2/war/{clan_tag}/previous:
-        get:
-            description: Returns previous wars for a clan tag, optionally filtered to CWL.
-            parameters:
-                - description: Clan tag
-                  in: path
-                  name: clan_tag
-                  required: true
-                  schema:
-                    type: string
-                - description: Start timestamp
-                  in: query
-                  name: timestamp_start
-                  schema:
-                    type: integer
-                - description: End timestamp
-                  in: query
-                  name: timestamp_end
-                  schema:
-                    type: integer
-                - description: Include CWL wars
-                  in: query
-                  name: include_cwl
-                  schema:
-                    type: boolean
-                - description: Maximum number of results
-                  in: query
-                  name: limit
-                  schema:
-                    type: integer
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.WarListResponse'
-                    description: OK
-                "500":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Internal Server Error
-            summary: Previous wars for a clan
-            tags:
-                - War
     /v2/war/{clan_tag}/war-summary:
         get:
-            description: Returns current war summary data for a single clan tag.
+            description: Returns a compact summary of the clan's current war, including state, opponent, scores, attacks, timing, and team size.
             parameters:
                 - description: Clan tag
                   in: path
@@ -16155,12 +16087,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get war summary for a clan
+            summary: View a clan's current war summary
             tags:
                 - War
     /v2/war/clan/stats:
         get:
-            description: Returns the number of wars for the requested clan tags.
+            description: Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.
             parameters:
                 - description: Clan tags
                   explode: false
@@ -16189,12 +16121,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Clan war stats
+            summary: Count stored wars for selected clans
             tags:
                 - War
     /v2/war/clans/warhits:
         post:
-            description: Returns war hit rows for the requested clan tags.
+            description: Returns stored attack performance for the requested clans, with filters for dates, war types, town halls, and attack freshness.
             requestBody:
                 content:
                     application/json:
@@ -16221,12 +16153,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Clan warhits stats
+            summary: Compare war performance for selected clans
             tags:
                 - War
     /v2/war/players/warhits:
         post:
-            description: Returns war hit rows for the requested player tags.
+            description: Returns stored attack performance for the requested players, with filters for dates, war types, town halls, and attack freshness.
             requestBody:
                 content:
                     application/json:
@@ -16253,12 +16185,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Player warhits stats
+            summary: Compare war performance for selected players
             tags:
                 - War
     /v2/war/stats:
         get:
-            description: Returns the number of wars for the requested clan tags.
+            description: Returns the number of stored wars for each requested clan, with filters available for dates, war types, and preparation states.
             parameters:
                 - description: Clan tags
                   explode: false
@@ -16287,12 +16219,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Clan war stats
+            summary: Count stored wars for selected clans
             tags:
                 - War
     /v2/war/war-summary:
         post:
-            description: Returns current war summary data for multiple clan tags.
+            description: Returns a compact current-war summary for each submitted clan tag so multiple wars can be displayed or compared together.
             requestBody:
                 content:
                     application/json:
@@ -16319,12 +16251,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get full war summary for multiple clans
+            summary: Compare current wars across several clans
             tags:
                 - War
     /war/{clanTag}/basic:
         get:
-            description: Returns the current or most recent non-CWL war for a clan.
+            description: Returns the clan's current or most recent non-CWL war through the legacy response shape used by older clients.
             parameters:
                 - description: Clan tag
                   in: path
@@ -16345,12 +16277,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Internal Server Error
-            summary: Get current or recent war
+            summary: View a clan's latest regular war
             tags:
                 - War
     /war/{clanTag}/previous:
         get:
-            description: Returns the stored previous war near the supplied Clash API end time.
+            description: Returns the stored clan war nearest the supplied official end time through the legacy response shape.
             parameters:
                 - description: Clan tag
                   in: path
@@ -16383,7 +16315,7 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Not Found
-            summary: Get previous war by end time
+            summary: Find a stored war by end time
             tags:
                 - War
 tags:

--- a/test/api/swagger_test.go
+++ b/test/api/swagger_test.go
@@ -537,9 +537,13 @@ func TestBuildDocOmitsRemovedRoutesAndKeepsV2JoinLeave(t *testing.T) {
 
 	builderBaseLeagues := paths["/builderbaseleagues"].(map[string]any)["get"].(map[string]any)
 	assertTags(t, builderBaseLeagues, []string{"Other"})
-	for _, path := range []string{"/war/{clanTag}/previous", "/war/{clanTag}/basic", "/cwl/{clanTag}/group", "/cwl/{clanTag}/{season}"} {
+	for _, path := range []string{"/war/{clanTag}/previous", "/war/{clanTag}/basic"} {
 		operation := paths[path].(map[string]any)["get"].(map[string]any)
 		assertTags(t, operation, []string{"War"})
+	}
+	for _, path := range []string{"/cwl/{clanTag}/group", "/cwl/{clanTag}/{season}"} {
+		operation := paths[path].(map[string]any)["get"].(map[string]any)
+		assertTags(t, operation, []string{"CWL"})
 	}
 	for _, path := range []string{"/list/townhalls", "/list/seasons"} {
 		if _, exists := paths[path]; exists {
@@ -948,6 +952,15 @@ func TestClanHistoryAndCachedClanOpenAPIContracts(t *testing.T) {
 		}
 	}
 
+	warsPath := "/v2/clan/{clan_tag}/wars"
+	wars := paths[warsPath].(map[string]any)["get"].(map[string]any)
+	assertParameterEnum(t, wars["parameters"], "type", []any{"cwl", "random", "friendly"})
+	if got := swaggerQueryParams(t, paths, warsPath); !reflect.DeepEqual(got, []string{"type", "time[after]", "time[before]", "limit"}) {
+		t.Fatalf("clan wars query params = %v", got)
+	}
+	assertQueryParameterSchemaValue(t, wars["parameters"], "limit", "default", float64(15))
+	assertQueryParameterSchemaValue(t, wars["parameters"], "limit", "maximum", float64(500))
+
 	cached := swaggerDefinitionProperties(t, definitions, "modelsv2.ClanCachedResponse")
 	if _, exists := cached["records"]; exists {
 		t.Fatal("cached clan response exposes records")
@@ -960,6 +973,48 @@ func TestClanHistoryAndCachedClanOpenAPIContracts(t *testing.T) {
 	}
 	if _, exists := paths["/v2/clan/{clan_tag}/records"]; !exists {
 		t.Fatal("clan records path is missing")
+	}
+}
+
+func TestCWLOpenAPIRoutesUseTheirOwningSections(t *testing.T) {
+	doc := buildSwaggerDoc(t)
+	paths := swaggerPaths(t, doc)
+	definitions := swaggerDefinitions(t, doc)
+
+	if _, exists := paths["/v2/war/{clan_tag}/previous"]; exists {
+		t.Fatal("retired v2 previous-war route remains in swagger")
+	}
+	if _, exists := paths["/v2/cwl/league-thresholds"]; exists {
+		t.Fatal("retired CWL threshold route remains in swagger")
+	}
+	if _, exists := paths["/v2/cwl/leagues/{league_id}/rankings"]; exists {
+		t.Fatal("old CWL rankings route remains in swagger")
+	}
+
+	playerHistory := paths["/v2/player/{player_tag}/cwl/history"].(map[string]any)["get"].(map[string]any)
+	assertTags(t, playerHistory, []string{"Player"})
+	groupHistory := paths["/v2/cwl/{clan_tag}/ranking-history"].(map[string]any)["get"].(map[string]any)
+	assertTags(t, groupHistory, []string{"CWL"})
+	leaderboard := paths["/v2/leaderboard/cwl/{league_id}"].(map[string]any)["get"].(map[string]any)
+	assertTags(t, leaderboard, []string{"Leaderboard"})
+	if got := swaggerQueryParams(t, paths, "/v2/leaderboard/cwl/{league_id}"); !reflect.DeepEqual(got, []string{"season", "team_size"}) {
+		t.Fatalf("CWL leaderboard query params = %v", got)
+	}
+
+	item := swaggerDefinitionProperties(t, definitions, "modelsv2.CWLPlayerHistoryItem")
+	for _, field := range []string{"season", "townHallLevel", "teamSize", "clan", "attacks", "placement", "missedAttacks"} {
+		if _, exists := item[field]; !exists {
+			t.Fatalf("CWL player history item missing %s", field)
+		}
+	}
+	for _, retired := range []string{"cwlLeagueId", "warSize"} {
+		if _, exists := item[retired]; exists {
+			t.Fatalf("CWL player history item exposes retired field %s", retired)
+		}
+	}
+	clan := swaggerDefinitionProperties(t, definitions, "modelsv2.CWLPlayerHistoryClan")
+	if _, exists := clan["warLeague"]; !exists {
+		t.Fatal("CWL player history clan omits warLeague")
 	}
 }
 
@@ -1573,6 +1628,25 @@ func assertParameterEnum(t *testing.T, value any, name string, want []any) {
 		}
 	}
 	t.Fatalf("expected %s parameter in %v", name, params)
+}
+
+func assertQueryParameterSchemaValue(t *testing.T, value any, name, key string, want any) {
+	t.Helper()
+	params, ok := value.([]any)
+	if !ok {
+		t.Fatalf("expected parameters array, got %v", value)
+	}
+	for _, raw := range params {
+		param, _ := raw.(map[string]any)
+		if param["name"] == name && param["in"] == "query" {
+			schema, _ := param["schema"].(map[string]any)
+			if !reflect.DeepEqual(schema[key], want) {
+				t.Fatalf("expected %s %s %v, got %v", name, key, want, param)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected query parameter %s in %v", name, params)
 }
 
 func assertRequiredParameter(t *testing.T, params []any, name string, in string) {


### PR DESCRIPTION
## Summary
- standardize clan war history on `type`, `time[after]`, `time[before]`, and a 15-war default
- move CWL league rankings to `/v2/leaderboard/cwl/{league_id}` and remove redundant thresholds and v2 previous-war routes
- move CWL operations into their Player, CWL, and Leaderboard Swagger sections
- reshape player CWL history with `teamSize` and `clan.warLeague`, and derive missing season totals, records, and group placement from stored wars
- support both historical and official CWL round snapshot formats so player attacks and placements populate correctly
- rewrite Player, Clan, War, and CWL Swagger summaries and descriptions in plain language

## Breaking API changes
- `GET /v2/clan/{clan_tag}/wars` replaces timestamp and plural war-type filters with one optional `type` plus ISO-8601 time bounds
- `GET /v2/cwl/leagues/{league_id}/rankings` moves to `GET /v2/leaderboard/cwl/{league_id}` and uses `team_size`
- `GET /v2/war/{clan_tag}/previous` and `GET /v2/cwl/league-thresholds` are removed
- player CWL history replaces top-level `cwlLeagueId` and `warSize` with `clan.warLeague` and `teamSize`

## Validation
- `go generate ./...`
- `go test -buildvcs=false -count=1 ./...`