### PR TITLE
feat(api): restore legacy compatibility endpoints

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -41,6 +41,130 @@ const docTemplate = `{
                 }
             }
         },
+        "/clan/{clan_tag}/join-leave": {
+            "get": {
+                "description": "Legacy v1-compatible tracked clan membership events.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "Clan join and leave history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Clan tag",
+                        "name": "clan_tag",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Inclusive Unix timestamp",
+                        "name": "timestamp_start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 9999999999,
+                        "description": "Inclusive Unix timestamp",
+                        "name": "time_stamp_end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 250,
+                        "description": "Maximum events",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.JoinLeaveResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cwl/{clan_tag}/group": {
+            "get": {
+                "description": "Legacy v1-compatible Mongo-style CWL group envelope. Returns null when unavailable.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "Current-season CWL group for a clan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Clan tag",
+                        "name": "clan_tag",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.CWLGroupEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/cwl/{clan_tag}/{season}": {
+            "get": {
+                "description": "Legacy v1-compatible CWL group with round war tags expanded into stored wars.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "CWL information for a clan in a season",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Clan tag",
+                        "name": "clan_tag",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Season in YYYY-MM or date form",
+                        "name": "season",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.CWLGroup"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/global/counts": {
             "get": {
                 "description": "Returns global tracking counts used by legacy clients.",
@@ -56,6 +180,107 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/modelsv2.GlobalCountsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/player/{player_tag}/join-leave": {
+            "get": {
+                "description": "Legacy v1-compatible tracked player membership events.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "Player join and leave history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Player tag",
+                        "name": "player_tag",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Inclusive Unix timestamp",
+                        "name": "timestamp_start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 9999999999,
+                        "description": "Inclusive Unix timestamp",
+                        "name": "time_stamp_end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 250,
+                        "description": "Maximum source events",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.JoinLeaveResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/player/{player_tag}/warhits": {
+            "get": {
+                "description": "Legacy v1-compatible war-grouped player history.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "War attacks and defenses for a player",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Player tag",
+                        "name": "player_tag",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Inclusive preparation-time start",
+                        "name": "timestamp_start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 2527625513,
+                        "description": "Inclusive preparation-time end",
+                        "name": "timestamp_end",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Maximum wars",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.PlayerWarHitsResponse"
                         }
                     }
                 }
@@ -13904,9 +14129,442 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/war/{clan_tag}/previous": {
+            "get": {
+                "description": "Legacy v1-compatible stored full-war history.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "Previous wars for a clan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Clan tag",
+                        "name": "clan_tag",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Inclusive preparation-time start",
+                        "name": "timestamp_start",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 9999999999,
+                        "description": "Inclusive preparation-time end",
+                        "name": "timestamp_end",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 50,
+                        "description": "Maximum wars",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.WarListResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/war/{clan_tag}/previous/{end_time}": {
+            "get": {
+                "description": "Legacy v1-compatible lookup within five minutes of the supplied Clash timestamp.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Legacy"
+                ],
+                "summary": "Previous war at an end time",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Clan tag",
+                        "name": "clan_tag",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "End time in Clash format",
+                        "name": "end_time",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/legacy.War"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "legacy.BadgeURLs": {
+            "type": "object",
+            "properties": {
+                "large": {
+                    "type": "string"
+                },
+                "medium": {
+                    "type": "string"
+                },
+                "small": {
+                    "type": "string"
+                }
+            }
+        },
+        "legacy.CWLClan": {
+            "type": "object",
+            "properties": {
+                "badgeUrls": {
+                    "$ref": "#/definitions/legacy.BadgeURLs"
+                },
+                "clanLevel": {
+                    "type": "integer"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.CWLMember"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "legacy.CWLGroup": {
+            "type": "object",
+            "properties": {
+                "clans": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.CWLClan"
+                    }
+                },
+                "rounds": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.CWLRound"
+                    }
+                },
+                "season": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
+        "legacy.CWLGroupEnvelope": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/legacy.CWLGroup"
+                }
+            }
+        },
+        "legacy.CWLMember": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "townHallLevel": {
+                    "type": "integer"
+                }
+            }
+        },
+        "legacy.CWLRound": {
+            "type": "object",
+            "properties": {
+                "warTags": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
+        },
+        "legacy.JoinLeaveEvent": {
+            "type": "object",
+            "properties": {
+                "clan": {
+                    "type": "string"
+                },
+                "clan_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "th": {
+                    "type": "integer"
+                },
+                "time": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "legacy.JoinLeaveResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.JoinLeaveEvent"
+                    }
+                }
+            }
+        },
+        "legacy.PlayerWarHit": {
+            "type": "object",
+            "properties": {
+                "attacks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.WarHitAttack"
+                    }
+                },
+                "defenses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.WarHitAttack"
+                    }
+                },
+                "member_data": {
+                    "$ref": "#/definitions/legacy.WarMember"
+                },
+                "war_data": {
+                    "$ref": "#/definitions/legacy.War"
+                }
+            }
+        },
+        "legacy.PlayerWarHitsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.PlayerWarHit"
+                    }
+                }
+            }
+        },
+        "legacy.War": {
+            "type": "object",
+            "properties": {
+                "attacksPerMember": {
+                    "type": "integer"
+                },
+                "battleModifier": {
+                    "type": "string"
+                },
+                "clan": {
+                    "$ref": "#/definitions/legacy.WarClan"
+                },
+                "endTime": {
+                    "type": "string"
+                },
+                "opponent": {
+                    "$ref": "#/definitions/legacy.WarClan"
+                },
+                "preparationStartTime": {
+                    "type": "string"
+                },
+                "season": {
+                    "type": "string"
+                },
+                "startTime": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "teamSize": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "warStartTime": {
+                    "type": "string"
+                }
+            }
+        },
+        "legacy.WarAttack": {
+            "type": "object",
+            "properties": {
+                "attackerTag": {
+                    "type": "string"
+                },
+                "defenderTag": {
+                    "type": "string"
+                },
+                "destructionPercentage": {
+                    "type": "integer"
+                },
+                "duration": {
+                    "type": "integer"
+                },
+                "order": {
+                    "type": "integer"
+                },
+                "stars": {
+                    "type": "integer"
+                }
+            }
+        },
+        "legacy.WarClan": {
+            "type": "object",
+            "properties": {
+                "attacks": {
+                    "type": "integer"
+                },
+                "badgeUrls": {
+                    "$ref": "#/definitions/legacy.BadgeURLs"
+                },
+                "clanLevel": {
+                    "type": "integer"
+                },
+                "destructionPercentage": {
+                    "type": "number"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.WarMember"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "stars": {
+                    "type": "integer"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "legacy.WarHitAttack": {
+            "type": "object",
+            "properties": {
+                "attack_order": {
+                    "type": "integer"
+                },
+                "attacker": {
+                    "$ref": "#/definitions/legacy.WarMember"
+                },
+                "attackerTag": {
+                    "type": "string"
+                },
+                "defender": {
+                    "$ref": "#/definitions/legacy.WarMember"
+                },
+                "defenderTag": {
+                    "type": "string"
+                },
+                "destructionPercentage": {
+                    "type": "integer"
+                },
+                "duration": {
+                    "type": "integer"
+                },
+                "fresh": {
+                    "type": "boolean"
+                },
+                "order": {
+                    "type": "integer"
+                },
+                "stars": {
+                    "type": "integer"
+                }
+            }
+        },
+        "legacy.WarListResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.War"
+                    }
+                }
+            }
+        },
+        "legacy.WarMember": {
+            "type": "object",
+            "properties": {
+                "attacks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/legacy.WarAttack"
+                    }
+                },
+                "bestOpponentAttack": {
+                    "$ref": "#/definitions/legacy.WarAttack"
+                },
+                "mapPosition": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "opponentAttacks": {
+                    "type": "integer"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "townhallLevel": {
+                    "type": "integer"
+                }
+            }
+        },
         "modelsv2.AccountConflictErrorResponse": {
             "type": "object",
             "properties": {

--- a/internal/models/legacy/responses.go
+++ b/internal/models/legacy/responses.go
@@ -1,0 +1,132 @@
+package legacy
+
+// JoinLeaveResponse is the legacy envelope returned by clan and player history.
+type JoinLeaveResponse struct {
+	Items []JoinLeaveEvent `json:"items"`
+}
+
+// JoinLeaveEvent preserves the original v1 field names and timestamp format.
+type JoinLeaveEvent struct {
+	Name     string `json:"name"`
+	Tag      string `json:"tag"`
+	Townhall int    `json:"th"`
+	Time     string `json:"time"`
+	Clan     string `json:"clan"`
+	Type     string `json:"type"`
+	ClanName string `json:"clan_name,omitempty"`
+}
+
+// WarListResponse is the envelope used by legacy previous-war routes.
+type WarListResponse struct {
+	Items []War `json:"items"`
+}
+
+// War is an official-API-shaped stored war. Type and Season are only populated
+// by legacy endpoints that historically added those fields.
+type War struct {
+	Type                 string  `json:"type,omitempty"`
+	State                string  `json:"state"`
+	TeamSize             int     `json:"teamSize"`
+	AttacksPerMember     *int    `json:"attacksPerMember,omitempty"`
+	BattleModifier       string  `json:"battleModifier,omitempty"`
+	PreparationStartTime string  `json:"preparationStartTime"`
+	StartTime            string  `json:"startTime,omitempty"`
+	EndTime              string  `json:"endTime"`
+	Clan                 WarClan `json:"clan"`
+	Opponent             WarClan `json:"opponent"`
+	WarStartTime         string  `json:"warStartTime,omitempty"`
+	Tag                  string  `json:"tag,omitempty"`
+	Season               string  `json:"season,omitempty"`
+}
+
+type BadgeURLs struct {
+	Small  string `json:"small"`
+	Large  string `json:"large"`
+	Medium string `json:"medium"`
+}
+
+type WarClan struct {
+	Tag                   string      `json:"tag"`
+	Name                  string      `json:"name"`
+	BadgeURLs             BadgeURLs   `json:"badgeUrls"`
+	ClanLevel             int         `json:"clanLevel"`
+	Attacks               int         `json:"attacks"`
+	Stars                 int         `json:"stars"`
+	DestructionPercentage float64     `json:"destructionPercentage"`
+	Members               []WarMember `json:"members,omitempty"`
+}
+
+type WarMember struct {
+	Tag                string      `json:"tag"`
+	Name               string      `json:"name"`
+	TownhallLevel      int         `json:"townhallLevel"`
+	MapPosition        int         `json:"mapPosition"`
+	Attacks            []WarAttack `json:"attacks,omitempty"`
+	OpponentAttacks    *int        `json:"opponentAttacks,omitempty"`
+	BestOpponentAttack *WarAttack  `json:"bestOpponentAttack,omitempty"`
+}
+
+type WarAttack struct {
+	AttackerTag           string `json:"attackerTag"`
+	DefenderTag           string `json:"defenderTag"`
+	Stars                 int    `json:"stars"`
+	DestructionPercentage int    `json:"destructionPercentage"`
+	Order                 int    `json:"order"`
+	Duration              int    `json:"duration"`
+}
+
+type PlayerWarHitsResponse struct {
+	Items []PlayerWarHit `json:"items"`
+}
+
+type PlayerWarHit struct {
+	WarData    War            `json:"war_data"`
+	MemberData WarMember      `json:"member_data"`
+	Attacks    []WarHitAttack `json:"attacks"`
+	Defenses   []WarHitAttack `json:"defenses"`
+}
+
+type WarHitAttack struct {
+	AttackerTag           string     `json:"attackerTag"`
+	DefenderTag           string     `json:"defenderTag"`
+	Stars                 int        `json:"stars"`
+	DestructionPercentage int        `json:"destructionPercentage"`
+	Order                 int        `json:"order"`
+	Duration              int        `json:"duration"`
+	Fresh                 bool       `json:"fresh"`
+	Defender              *WarMember `json:"defender,omitempty"`
+	Attacker              *WarMember `json:"attacker,omitempty"`
+	AttackOrder           int        `json:"attack_order"`
+}
+
+// CWLGroupEnvelope preserves the Mongo document wrapper returned by /group.
+type CWLGroupEnvelope struct {
+	Data CWLGroup `json:"data"`
+}
+
+type CWLGroup struct {
+	State  string     `json:"state"`
+	Season string     `json:"season"`
+	Clans  []CWLClan  `json:"clans"`
+	Rounds []CWLRound `json:"rounds"`
+}
+
+type CWLClan struct {
+	Tag       string      `json:"tag"`
+	Name      string      `json:"name"`
+	ClanLevel int         `json:"clanLevel"`
+	BadgeURLs BadgeURLs   `json:"badgeUrls"`
+	Members   []CWLMember `json:"members"`
+}
+
+type CWLMember struct {
+	Tag           string `json:"tag"`
+	Name          string `json:"name"`
+	TownHallLevel int    `json:"townHallLevel"`
+}
+
+// WarTags contains strings for /group and full War objects or tag placeholders
+// for the season endpoint, matching the old dynamic response.
+type CWLRound struct {
+	WarTags []any `json:"warTags" swaggertype:"array,object"`
+}

--- a/internal/routes/legacy/contract_test.go
+++ b/internal/routes/legacy/contract_test.go
@@ -1,0 +1,113 @@
+package legacy
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ClashKingInc/ClashKingAPI/internal/wararchive"
+)
+
+func TestBuildPlayerWarHitMatchesLegacyNestedShape(t *testing.T) {
+	preparation := time.Date(2026, time.August, 1, 1, 2, 3, 0, time.UTC)
+	start := preparation.Add(23 * time.Hour)
+	war := wararchive.War{
+		Type: "random", State: "ended", TeamSize: 2, AttacksPerMember: 2,
+		PreparationStartTime: preparation, StartTime: &start, EndTime: start.Add(24 * time.Hour),
+		Clan: wararchive.Clan{Tag: "#OURS", Name: "Ours", Members: []wararchive.Member{
+			{Tag: "#PLAYER", Name: "Player", TownhallLevel: 17, MapPosition: 1, Attacks: []wararchive.Attack{{DefenderTag: "#ENEMY", Stars: 3, DestructionPercentage: 100, Duration: 120, Order: 2}}},
+		}},
+		Opponent: wararchive.Clan{Tag: "#THEM", Name: "Them", Members: []wararchive.Member{
+			{Tag: "#ENEMY", Name: "Enemy", TownhallLevel: 17, MapPosition: 1, Attacks: []wararchive.Attack{
+				{DefenderTag: "#PLAYER", Stars: 1, DestructionPercentage: 55, Duration: 180, Order: 1},
+				{DefenderTag: "#PLAYER", Stars: 2, DestructionPercentage: 80, Duration: 170, Order: 3},
+			}},
+		}},
+	}
+	item, ok := buildPlayerWarHit("#PLAYER", war)
+	if !ok {
+		t.Fatal("expected player war hit")
+	}
+	if item.WarData.Type != "random" || item.WarData.Clan.Members != nil || item.WarData.Opponent.Members != nil {
+		t.Fatalf("war_data did not match the stripped legacy shape: %#v", item.WarData)
+	}
+	if item.MemberData.Attacks != nil || item.MemberData.BestOpponentAttack != nil || item.MemberData.OpponentAttacks == nil || *item.MemberData.OpponentAttacks != 2 {
+		t.Fatalf("member_data did not match the stripped legacy shape: %#v", item.MemberData)
+	}
+	if len(item.Attacks) != 1 || item.Attacks[0].Defender == nil || item.Attacks[0].Attacker != nil || item.Attacks[0].AttackOrder != 2 {
+		t.Fatalf("unexpected attacks: %#v", item.Attacks)
+	}
+	if item.Attacks[0].Defender.OpponentAttacks == nil || *item.Attacks[0].Defender.OpponentAttacks != 1 {
+		t.Fatalf("nested defender lost opponentAttacks: %#v", item.Attacks[0].Defender)
+	}
+	if len(item.Defenses) != 2 || item.Defenses[0].Attacker == nil || !item.Defenses[0].Fresh || item.Defenses[1].Fresh {
+		t.Fatalf("unexpected defenses: %#v", item.Defenses)
+	}
+
+	payload, err := json.Marshal(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	warData := decoded["war_data"].(map[string]any)
+	if _, exists := warData["clan"].(map[string]any)["members"]; exists {
+		t.Fatal("war_data unexpectedly exposed clan members")
+	}
+	attack := decoded["attacks"].([]any)[0].(map[string]any)
+	if _, exists := attack["attack_order"]; !exists {
+		t.Fatalf("legacy attack_order is missing: %s", payload)
+	}
+}
+
+func TestLegacyFullWarOmitsSyntheticTypeAndKeepsMembers(t *testing.T) {
+	war := wararchive.War{
+		Type: "random", State: "warEnded", TeamSize: 1, AttacksPerMember: 2,
+		PreparationStartTime: time.Unix(1, 0), EndTime: time.Unix(2, 0),
+		Clan:     wararchive.Clan{Tag: "#A", Members: []wararchive.Member{{Tag: "#P"}}},
+		Opponent: wararchive.Clan{Tag: "#B", Members: []wararchive.Member{{Tag: "#Q"}}},
+	}
+	result := legacyWar(war, true)
+	if result.Type != "" || len(result.Clan.Members) != 1 || len(result.Opponent.Members) != 1 {
+		t.Fatalf("unexpected full war: %#v", result)
+	}
+}
+
+func TestProcessPlayerJoinLeaveMirrorsLegacyCorrection(t *testing.T) {
+	first := time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC)
+	events := []joinLeaveRow{
+		{Time: first, Type: "join", Clan: "#A", Tag: "#P"},
+		{Time: first.Add(time.Hour), Type: "leave", Clan: "#A", Tag: "#P"},
+		{Time: first.Add(2 * time.Hour), Type: "join", Clan: "#B", Tag: "#P"},
+	}
+	processed := processPlayerJoinLeave(events)
+	if len(processed) != 3 || !processed[0].Time.Equal(first) || processed[1].Type != "leave" || !processed[1].Time.Equal(first.Add(2*time.Hour)) || processed[2].Type != "join" {
+		t.Fatalf("unexpected corrected events: %#v", processed)
+	}
+	if got := legacyDateTime(first.Add(123456 * time.Microsecond)); got != "2024-04-05T00:00:00.123456" {
+		t.Fatalf("legacy timestamp = %q", got)
+	}
+}
+
+func TestCWLCompatibilityNormalizationAndRoundDecoding(t *testing.T) {
+	for input, expected := range map[string]string{
+		"2026-05":    "2026-05",
+		"2026-05-17": "2026-05",
+		"2026-06-14": "2026-06-14",
+		"2026-08":    "2026-08",
+		"invalid":    "invalid",
+	} {
+		if got := normalizeCWLSeason(input); got != expected {
+			t.Fatalf("normalizeCWLSeason(%q) = %q, want %q", input, got, expected)
+		}
+	}
+	if got := decodeCWLRounds([]byte(`[{"warTags":["#ONE","#0"]}]`)); !reflect.DeepEqual(got, [][]string{{"#ONE", "#0"}}) {
+		t.Fatalf("official rounds = %#v", got)
+	}
+	if got := decodeCWLRounds([]byte(`[["#TWO"]]`)); !reflect.DeepEqual(got, [][]string{{"#TWO"}}) {
+		t.Fatalf("direct rounds = %#v", got)
+	}
+}

--- a/internal/routes/legacy/cwl.go
+++ b/internal/routes/legacy/cwl.go
@@ -1,0 +1,237 @@
+package legacy
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	clashy "github.com/clashkinginc/clashy.go"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const cwlSeasonDateCutoff = "2026-06-14"
+
+// currentCWLGroup godoc
+// @Summary Current-season CWL group for a clan
+// @Description Legacy v1-compatible Mongo-style CWL group envelope. Returns null when unavailable.
+// @Tags Legacy
+// @Produce json
+// @Param clan_tag path string true "Clan tag"
+// @Success 200 {object} legacy.CWLGroupEnvelope
+// @Router /cwl/{clan_tag}/group [get]
+func currentCWLGroup(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		season := clashy.GetSeasonID()
+		group, err := loadCWLGroup(c, deps, fixTag(c.Params("clan_tag")), season, false)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apptypes.JSON(c, http.StatusOK, nil)
+		}
+		if err != nil {
+			return err
+		}
+		return apptypes.JSON(c, http.StatusOK, legacymodels.CWLGroupEnvelope{Data: *group})
+	}
+}
+
+// cwlSeason godoc
+// @Summary CWL information for a clan in a season
+// @Description Legacy v1-compatible CWL group with round war tags expanded into stored wars.
+// @Tags Legacy
+// @Produce json
+// @Param clan_tag path string true "Clan tag"
+// @Param season path string true "Season in YYYY-MM or date form"
+// @Success 200 {object} legacy.CWLGroup
+// @Failure 404 {object} map[string]string
+// @Router /cwl/{clan_tag}/{season} [get]
+func cwlSeason(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		season := normalizeCWLSeason(c.Params("season"))
+		group, err := loadCWLGroup(c, deps, fixTag(c.Params("clan_tag")), season, true)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apptypes.JSON(c, http.StatusNotFound, map[string]string{"detail": "No CWL Data Found"})
+		}
+		if err != nil {
+			return err
+		}
+		return apptypes.JSON(c, http.StatusOK, group)
+	}
+}
+
+func normalizeCWLSeason(season string) string {
+	raw := season
+	if len(raw) == len("2006-01") {
+		raw += "-01"
+	}
+	parsed, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return season
+	}
+	cutoff, _ := time.Parse("2006-01-02", cwlSeasonDateCutoff)
+	if parsed.Before(cutoff) {
+		return parsed.Format("2006-01")
+	}
+	return season
+}
+
+func loadCWLGroup(c *fiber.Ctx, deps apptypes.Deps, clanTag, season string, hydrateWars bool) (*legacymodels.CWLGroup, error) {
+	var id, storedSeason, state string
+	var roundsRaw []byte
+	err := deps.Store.SQL.QueryRow(c.UserContext(), `
+		SELECT groups.cwl_id, groups.season, groups.state, groups.rounds
+		FROM cwl_groups AS groups
+		JOIN cwl_group_clans AS clan ON clan.cwl_id = groups.cwl_id
+		WHERE clan.clan_tag = $1 AND groups.season = $2
+		ORDER BY groups.cwl_id DESC
+		LIMIT 1
+	`, clanTag, season).Scan(&id, &storedSeason, &state, &roundsRaw)
+	if err != nil {
+		return nil, err
+	}
+	clans, err := loadCWLClans(c, deps, id)
+	if err != nil {
+		return nil, err
+	}
+	rounds := decodeCWLRounds(roundsRaw)
+	response := &legacymodels.CWLGroup{State: state, Season: storedSeason, Clans: clans, Rounds: make([]legacymodels.CWLRound, 0, len(rounds))}
+	if !hydrateWars {
+		for _, tags := range rounds {
+			values := make([]any, 0, len(tags))
+			for _, tag := range tags {
+				values = append(values, tag)
+			}
+			response.Rounds = append(response.Rounds, legacymodels.CWLRound{WarTags: values})
+		}
+		return response, nil
+	}
+	wars, err := loadCWLWars(c, deps, rounds, storedSeason)
+	if err != nil {
+		return nil, err
+	}
+	for _, tags := range rounds {
+		values := make([]any, 0, len(tags))
+		for _, tag := range tags {
+			if war, ok := wars[tag]; ok {
+				values = append(values, war)
+			} else {
+				values = append(values, map[string]string{"tag": tag})
+			}
+		}
+		response.Rounds = append(response.Rounds, legacymodels.CWLRound{WarTags: values})
+	}
+	return response, nil
+}
+
+func decodeCWLRounds(raw []byte) [][]string {
+	var direct [][]string
+	if json.Unmarshal(raw, &direct) == nil {
+		return direct
+	}
+	var official []struct {
+		WarTags []string `json:"warTags"`
+	}
+	if json.Unmarshal(raw, &official) != nil {
+		return [][]string{}
+	}
+	direct = make([][]string, 0, len(official))
+	for _, round := range official {
+		direct = append(direct, round.WarTags)
+	}
+	return direct
+}
+
+func loadCWLClans(c *fiber.Ctx, deps apptypes.Deps, id string) ([]legacymodels.CWLClan, error) {
+	rows, err := deps.Store.SQL.Query(c.UserContext(), `
+		SELECT clan.clan_tag, clan.name, clan.clan_level, clan.badge_token,
+		       member.tag, member.name, member.town_hall
+		FROM cwl_group_clans AS clan
+		LEFT JOIN cwl_group_members AS member
+		  ON member.cwl_id = clan.cwl_id AND member.clan_tag = clan.clan_tag
+		WHERE clan.cwl_id = $1
+		ORDER BY clan.clan_tag, member.tag
+	`, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	clans := []legacymodels.CWLClan{}
+	indexes := map[string]int{}
+	for rows.Next() {
+		var tag, name, badgeToken string
+		var clanLevel int
+		var memberTag, memberName pgtype.Text
+		var townhall pgtype.Int2
+		if err := rows.Scan(&tag, &name, &clanLevel, &badgeToken, &memberTag, &memberName, &townhall); err != nil {
+			return nil, err
+		}
+		index, exists := indexes[tag]
+		if !exists {
+			clans = append(clans, legacymodels.CWLClan{Tag: tag, Name: name, ClanLevel: clanLevel, BadgeURLs: badgeURLs(badgeToken), Members: []legacymodels.CWLMember{}})
+			index = len(clans) - 1
+			indexes[tag] = index
+		}
+		if memberTag.Valid {
+			clans[index].Members = append(clans[index].Members, legacymodels.CWLMember{Tag: memberTag.String, Name: memberName.String, TownHallLevel: int(townhall.Int16)})
+		}
+	}
+	return clans, rows.Err()
+}
+
+func loadCWLWars(c *fiber.Ctx, deps apptypes.Deps, rounds [][]string, season string) (map[string]legacymodels.War, error) {
+	tags := []string{}
+	seen := map[string]struct{}{}
+	for _, round := range rounds {
+		for _, tag := range round {
+			if tag == "" || tag == "#0" {
+				continue
+			}
+			if _, exists := seen[tag]; !exists {
+				seen[tag] = struct{}{}
+				tags = append(tags, tag)
+			}
+		}
+	}
+	if len(tags) == 0 {
+		return map[string]legacymodels.War{}, nil
+	}
+	rows, err := deps.Store.SQL.Query(c.UserContext(), `
+		SELECT war_id::text, war_tag
+		FROM wars
+		WHERE war_type = 'cwl' AND war_tag = ANY($1)
+	`, tags)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := []string{}
+	tagsByID := map[string]string{}
+	for rows.Next() {
+		var id string
+		var tag pgtype.Text
+		if err := rows.Scan(&id, &tag); err != nil {
+			return nil, err
+		}
+		if tag.Valid {
+			ids = append(ids, id)
+			tagsByID[id] = tag.String
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	archived, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, ids)
+	if err != nil {
+		return nil, err
+	}
+	result := map[string]legacymodels.War{}
+	for id, source := range archived {
+		war := legacyWar(source, true)
+		war.Season = season
+		result[tagsByID[id]] = war
+	}
+	return result, nil
+}

--- a/internal/routes/legacy/cwl.go
+++ b/internal/routes/legacy/cwl.go
@@ -1,6 +1,7 @@
 package legacy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 
 	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/ClashKingInc/ClashKingAPI/internal/wararchive"
 	clashy "github.com/clashkinginc/clashy.go"
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
@@ -15,6 +17,8 @@ import (
 )
 
 const cwlSeasonDateCutoff = "2026-06-14"
+
+type cwlGroupLoader func(context.Context, string, string, bool) (*legacymodels.CWLGroup, error)
 
 // currentCWLGroup godoc
 // @Summary Current-season CWL group for a clan
@@ -25,9 +29,17 @@ const cwlSeasonDateCutoff = "2026-06-14"
 // @Success 200 {object} legacy.CWLGroupEnvelope
 // @Router /cwl/{clan_tag}/group [get]
 func currentCWLGroup(deps apptypes.Deps) fiber.Handler {
+	return currentCWLGroupHandler(func(ctx context.Context, tag, season string, hydrate bool) (*legacymodels.CWLGroup, error) {
+		return loadCWLGroup(ctx, deps.Store.SQL, func(ctx context.Context, ids []string) (map[string]wararchive.War, error) {
+			return deps.Store.WarArchive.LoadIDs(ctx, deps.Store.SQL, ids)
+		}, tag, season, hydrate)
+	})
+}
+
+func currentCWLGroupHandler(load cwlGroupLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		season := clashy.GetSeasonID()
-		group, err := loadCWLGroup(c, deps, fixTag(c.Params("clan_tag")), season, false)
+		group, err := load(c.UserContext(), fixTag(c.Params("clan_tag")), season, false)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apptypes.JSON(c, http.StatusOK, nil)
 		}
@@ -49,9 +61,17 @@ func currentCWLGroup(deps apptypes.Deps) fiber.Handler {
 // @Failure 404 {object} map[string]string
 // @Router /cwl/{clan_tag}/{season} [get]
 func cwlSeason(deps apptypes.Deps) fiber.Handler {
+	return cwlSeasonHandler(func(ctx context.Context, tag, season string, hydrate bool) (*legacymodels.CWLGroup, error) {
+		return loadCWLGroup(ctx, deps.Store.SQL, func(ctx context.Context, ids []string) (map[string]wararchive.War, error) {
+			return deps.Store.WarArchive.LoadIDs(ctx, deps.Store.SQL, ids)
+		}, tag, season, hydrate)
+	})
+}
+
+func cwlSeasonHandler(load cwlGroupLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		season := normalizeCWLSeason(c.Params("season"))
-		group, err := loadCWLGroup(c, deps, fixTag(c.Params("clan_tag")), season, true)
+		group, err := load(c.UserContext(), fixTag(c.Params("clan_tag")), season, true)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apptypes.JSON(c, http.StatusNotFound, map[string]string{"detail": "No CWL Data Found"})
 		}
@@ -78,10 +98,10 @@ func normalizeCWLSeason(season string) string {
 	return season
 }
 
-func loadCWLGroup(c *fiber.Ctx, deps apptypes.Deps, clanTag, season string, hydrateWars bool) (*legacymodels.CWLGroup, error) {
+func loadCWLGroup(ctx context.Context, db warQueryDB, loadArchive warArchiveLoader, clanTag, season string, hydrateWars bool) (*legacymodels.CWLGroup, error) {
 	var id, storedSeason, state string
 	var roundsRaw []byte
-	err := deps.Store.SQL.QueryRow(c.UserContext(), `
+	err := db.QueryRow(ctx, `
 		SELECT groups.cwl_id, groups.season, groups.state, groups.rounds
 		FROM cwl_groups AS groups
 		JOIN cwl_group_clans AS clan ON clan.cwl_id = groups.cwl_id
@@ -92,7 +112,7 @@ func loadCWLGroup(c *fiber.Ctx, deps apptypes.Deps, clanTag, season string, hydr
 	if err != nil {
 		return nil, err
 	}
-	clans, err := loadCWLClans(c, deps, id)
+	clans, err := loadCWLClans(ctx, db, id)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +128,7 @@ func loadCWLGroup(c *fiber.Ctx, deps apptypes.Deps, clanTag, season string, hydr
 		}
 		return response, nil
 	}
-	wars, err := loadCWLWars(c, deps, rounds, storedSeason)
+	wars, err := loadCWLWars(ctx, db, loadArchive, rounds, storedSeason)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +164,8 @@ func decodeCWLRounds(raw []byte) [][]string {
 	return direct
 }
 
-func loadCWLClans(c *fiber.Ctx, deps apptypes.Deps, id string) ([]legacymodels.CWLClan, error) {
-	rows, err := deps.Store.SQL.Query(c.UserContext(), `
+func loadCWLClans(ctx context.Context, db warQueryDB, id string) ([]legacymodels.CWLClan, error) {
+	rows, err := db.Query(ctx, `
 		SELECT clan.clan_tag, clan.name, clan.clan_level, clan.badge_token,
 		       member.tag, member.name, member.town_hall
 		FROM cwl_group_clans AS clan
@@ -181,7 +201,7 @@ func loadCWLClans(c *fiber.Ctx, deps apptypes.Deps, id string) ([]legacymodels.C
 	return clans, rows.Err()
 }
 
-func loadCWLWars(c *fiber.Ctx, deps apptypes.Deps, rounds [][]string, season string) (map[string]legacymodels.War, error) {
+func loadCWLWars(ctx context.Context, db warQueryDB, loadArchive warArchiveLoader, rounds [][]string, season string) (map[string]legacymodels.War, error) {
 	tags := []string{}
 	seen := map[string]struct{}{}
 	for _, round := range rounds {
@@ -198,7 +218,7 @@ func loadCWLWars(c *fiber.Ctx, deps apptypes.Deps, rounds [][]string, season str
 	if len(tags) == 0 {
 		return map[string]legacymodels.War{}, nil
 	}
-	rows, err := deps.Store.SQL.Query(c.UserContext(), `
+	rows, err := db.Query(ctx, `
 		SELECT war_id::text, war_tag
 		FROM wars
 		WHERE war_type = 'cwl' AND war_tag = ANY($1)
@@ -223,7 +243,7 @@ func loadCWLWars(c *fiber.Ctx, deps apptypes.Deps, rounds [][]string, season str
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	archived, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, ids)
+	archived, err := loadArchive(ctx, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/routes/legacy/handlers_test.go
+++ b/internal/routes/legacy/handlers_test.go
@@ -1,0 +1,417 @@
+package legacy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/ClashKingInc/ClashKingAPI/internal/wararchive"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type legacyTestRow struct {
+	values []any
+	err    error
+}
+
+func (row legacyTestRow) Scan(dest ...any) error {
+	if row.err != nil {
+		return row.err
+	}
+	return assignLegacyTestValues(dest, row.values)
+}
+
+type legacyTestRows struct {
+	pgx.Rows
+	values  [][]any
+	cursor  int
+	err     error
+	scanErr error
+}
+
+func (rows *legacyTestRows) Close() {}
+func (rows *legacyTestRows) Err() error {
+	return rows.err
+}
+func (rows *legacyTestRows) Next() bool {
+	if rows.cursor >= len(rows.values) {
+		return false
+	}
+	rows.cursor++
+	return true
+}
+func (rows *legacyTestRows) Scan(dest ...any) error {
+	if rows.scanErr != nil {
+		return rows.scanErr
+	}
+	return assignLegacyTestValues(dest, rows.values[rows.cursor-1])
+}
+
+func assignLegacyTestValues(dest, values []any) error {
+	if len(dest) != len(values) {
+		return errors.New("test scan arity mismatch")
+	}
+	for index := range dest {
+		target := reflect.ValueOf(dest[index])
+		if target.Kind() != reflect.Pointer || target.IsNil() {
+			return errors.New("test scan destination is not a pointer")
+		}
+		target.Elem().Set(reflect.ValueOf(values[index]))
+	}
+	return nil
+}
+
+type legacyTestDB struct {
+	row        pgx.Row
+	rows       []pgx.Rows
+	queryErr   error
+	queryIndex int
+	queries    []string
+	args       [][]any
+}
+
+func (db *legacyTestDB) Query(_ context.Context, query string, args ...any) (pgx.Rows, error) {
+	db.queries = append(db.queries, query)
+	db.args = append(db.args, args)
+	if db.queryErr != nil {
+		return nil, db.queryErr
+	}
+	if db.queryIndex >= len(db.rows) {
+		return &legacyTestRows{}, nil
+	}
+	rows := db.rows[db.queryIndex]
+	db.queryIndex++
+	return rows, nil
+}
+
+func (db *legacyTestDB) QueryRow(_ context.Context, query string, args ...any) pgx.Row {
+	db.queries = append(db.queries, query)
+	db.args = append(db.args, args)
+	if db.row == nil {
+		return legacyTestRow{err: pgx.ErrNoRows}
+	}
+	return db.row
+}
+
+func legacyTestRequest(t *testing.T, route, path string, handler fiber.Handler) (*http.Response, []byte) {
+	t.Helper()
+	app := fiber.New(fiber.Config{ErrorHandler: apptypes.ErrorHandler})
+	app.Get(route, handler)
+	response, err := app.Test(httptest.NewRequest(http.MethodGet, path, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response, body
+}
+
+func legacyTestWar() wararchive.War {
+	start := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	return wararchive.War{
+		Type: "random", State: "ended", TeamSize: 1, AttacksPerMember: 2,
+		PreparationStartTime: start.Add(-24 * time.Hour), StartTime: &start, EndTime: start.Add(24 * time.Hour),
+		Clan:     wararchive.Clan{Tag: "#CLAN", BadgeToken: "clan", Members: []wararchive.Member{{Tag: "#PLAYER", Attacks: []wararchive.Attack{{DefenderTag: "#ENEMY", Stars: 3, Order: 1}}}}},
+		Opponent: wararchive.Clan{Tag: "#OTHER", Members: []wararchive.Member{{Tag: "#ENEMY", Attacks: []wararchive.Attack{{DefenderTag: "#PLAYER", Stars: 2, Order: 2}}}}},
+	}
+}
+
+func TestLegacyWarHandlersValidateAndReturnContracts(t *testing.T) {
+	war := legacyTestWar()
+	query := func(_ context.Context, tag string, _ time.Time, _ time.Time, limit int) ([]string, error) {
+		if tag != "#CLAN" || limit != 50 {
+			t.Fatalf("query arguments: tag=%q limit=%d", tag, limit)
+		}
+		return []string{"1"}, nil
+	}
+	load := func(context.Context, []string) (map[string]wararchive.War, error) {
+		return map[string]wararchive.War{"1": war}, nil
+	}
+	response, body := legacyTestRequest(t, "/:clan_tag/previous", "/%23clan/previous", previousWarsHandler(query, load))
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), `"preparationStartTime"`) {
+		t.Fatalf("previous wars: status=%d body=%s", response.StatusCode, body)
+	}
+
+	for _, path := range []string{"/%23clan/previous?timestamp_start=nope", "/%23clan/previous?timestamp_end=nope", "/%23clan/previous?limit=nope"} {
+		response, _ = legacyTestRequest(t, "/:clan_tag/previous", path, previousWarsHandler(query, load))
+		if response.StatusCode != http.StatusUnprocessableEntity {
+			t.Fatalf("%s status = %d", path, response.StatusCode)
+		}
+	}
+	response, body = legacyTestRequest(t, "/:clan_tag/previous", "/%23clan/previous?limit=0", previousWarsHandler(query, load))
+	if response.StatusCode != http.StatusOK || string(body) != `{"items":[]}` {
+		t.Fatalf("zero previous limit: status=%d body=%s", response.StatusCode, body)
+	}
+
+	wantErr := errors.New("database unavailable")
+	response, _ = legacyTestRequest(t, "/:clan_tag/previous", "/%23clan/previous", previousWarsHandler(func(context.Context, string, time.Time, time.Time, int) ([]string, error) {
+		return nil, wantErr
+	}, load))
+	if response.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("previous query error status = %d", response.StatusCode)
+	}
+}
+
+func TestLegacyPreviousWarAtTimeHandler(t *testing.T) {
+	war := legacyTestWar()
+	find := func(_ context.Context, tag string, target time.Time) (string, error) {
+		if tag != "#CLAN" || target.Year() != 2026 {
+			t.Fatalf("find arguments: %q %v", tag, target)
+		}
+		return "1", nil
+	}
+	load := func(context.Context, []string) (map[string]wararchive.War, error) {
+		return map[string]wararchive.War{"1": war}, nil
+	}
+	response, body := legacyTestRequest(t, "/:clan_tag/:end_time", "/%23clan/20260803T000000.000Z", previousWarAtTimeHandler(find, load))
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), `"clan"`) {
+		t.Fatalf("previous at time: status=%d body=%s", response.StatusCode, body)
+	}
+	response, _ = legacyTestRequest(t, "/:clan_tag/:end_time", "/%23clan/not-a-time", previousWarAtTimeHandler(find, load))
+	if response.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("invalid time status = %d", response.StatusCode)
+	}
+	response, body = legacyTestRequest(t, "/:clan_tag/:end_time", "/%23clan/20260803T000000.000Z", previousWarAtTimeHandler(func(context.Context, string, time.Time) (string, error) {
+		return "", pgx.ErrNoRows
+	}, load))
+	if response.StatusCode != http.StatusNotFound || !strings.Contains(string(body), "War Not Found") {
+		t.Fatalf("missing war: status=%d body=%s", response.StatusCode, body)
+	}
+	response, _ = legacyTestRequest(t, "/:clan_tag/:end_time", "/%23clan/20260803T000000.000Z", previousWarAtTimeHandler(find, func(context.Context, []string) (map[string]wararchive.War, error) {
+		return map[string]wararchive.War{}, nil
+	}))
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing archive status = %d", response.StatusCode)
+	}
+}
+
+func TestLegacyPlayerWarHitsHandler(t *testing.T) {
+	war := legacyTestWar()
+	query := func(_ context.Context, tag string, _ time.Time, _ time.Time, limit int) ([]string, error) {
+		if tag != "#PLAYER" || limit != 100 {
+			t.Fatalf("warhits arguments: tag=%q limit=%d", tag, limit)
+		}
+		return []string{"1", "missing"}, nil
+	}
+	load := func(context.Context, []string) (map[string]wararchive.War, error) {
+		return map[string]wararchive.War{"1": war}, nil
+	}
+	response, body := legacyTestRequest(t, "/:player_tag/warhits", "/%23player/warhits?limit=200", playerWarHitsHandler(query, load))
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), `"war_data"`) {
+		t.Fatalf("warhits: status=%d body=%s", response.StatusCode, body)
+	}
+	for _, path := range []string{"/%23player/warhits?timestamp_start=x", "/%23player/warhits?timestamp_end=x", "/%23player/warhits?limit=x"} {
+		response, _ = legacyTestRequest(t, "/:player_tag/warhits", path, playerWarHitsHandler(query, load))
+		if response.StatusCode != http.StatusUnprocessableEntity {
+			t.Fatalf("%s status = %d", path, response.StatusCode)
+		}
+	}
+	response, body = legacyTestRequest(t, "/:player_tag/warhits", "/%23player/warhits?limit=0", playerWarHitsHandler(query, load))
+	if response.StatusCode != http.StatusOK || string(body) != `{"items":[]}` {
+		t.Fatalf("zero warhits limit: status=%d body=%s", response.StatusCode, body)
+	}
+}
+
+func TestLegacyWarQueries(t *testing.T) {
+	rows := &legacyTestRows{values: [][]any{{"2"}, {"1"}}}
+	db := &legacyTestDB{rows: []pgx.Rows{rows}, row: legacyTestRow{values: []any{"3"}}}
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	ids, err := queryWarIDs(context.Background(), db, "#CLAN", start, start.Add(time.Hour), 2)
+	if err != nil || !reflect.DeepEqual(ids, []string{"2", "1"}) || !strings.Contains(db.queries[0], "ORDER BY end_time DESC") {
+		t.Fatalf("queryWarIDs: ids=%v err=%v query=%q", ids, err, db.queries[0])
+	}
+	id, err := queryWarAtTime(context.Background(), db, "#CLAN", start)
+	if err != nil || id != "3" {
+		t.Fatalf("queryWarAtTime: id=%q err=%v", id, err)
+	}
+
+	db = &legacyTestDB{rows: []pgx.Rows{&legacyTestRows{values: [][]any{{"4"}}}}}
+	ids, err = queryPlayerWarIDs(context.Background(), db, "#PLAYER", start, start.Add(time.Hour), 1)
+	if err != nil || !reflect.DeepEqual(ids, []string{"4"}) || !strings.Contains(db.queries[0], "player_war_history") {
+		t.Fatalf("queryPlayerWarIDs: ids=%v err=%v query=%q", ids, err, db.queries[0])
+	}
+}
+
+func TestLegacyJoinLeaveHandlers(t *testing.T) {
+	when := time.Date(2026, 8, 1, 2, 3, 4, 5000000, time.UTC)
+	load := func(_ context.Context, tag string, _ time.Time, _ time.Time, limit int) ([]joinLeaveRow, error) {
+		if tag != "#CLAN" || limit != 250 {
+			t.Fatalf("join-leave arguments: tag=%q limit=%d", tag, limit)
+		}
+		return []joinLeaveRow{{Time: when, Type: "join", Clan: "#CLAN", Tag: "#P", Name: "Player", Townhall: 17, ClanName: "Clan"}}, nil
+	}
+	response, body := legacyTestRequest(t, "/:clan_tag/join-leave", "/%23clan/join-leave", clanJoinLeaveHandler(load))
+	if response.StatusCode != http.StatusOK || strings.Contains(string(body), "clan_name") || !strings.Contains(string(body), "2026-08-01T02:03:04.005000") {
+		t.Fatalf("clan join-leave: status=%d body=%s", response.StatusCode, body)
+	}
+	response, body = legacyTestRequest(t, "/:player_tag/join-leave", "/%23clan/join-leave", playerJoinLeaveHandler(load))
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), `"clan_name":"Clan"`) {
+		t.Fatalf("player join-leave: status=%d body=%s", response.StatusCode, body)
+	}
+	for _, path := range []string{"/%23clan/join-leave?timestamp_start=x", "/%23clan/join-leave?time_stamp_end=x", "/%23clan/join-leave?limit=x"} {
+		response, _ = legacyTestRequest(t, "/:clan_tag/join-leave", path, clanJoinLeaveHandler(load))
+		if response.StatusCode != http.StatusUnprocessableEntity {
+			t.Fatalf("%s status = %d", path, response.StatusCode)
+		}
+	}
+	response, body = legacyTestRequest(t, "/:clan_tag/join-leave", "/%23clan/join-leave?limit=0", clanJoinLeaveHandler(load))
+	if response.StatusCode != http.StatusOK || string(body) != `{"items":[]}` {
+		t.Fatalf("zero join-leave limit: status=%d body=%s", response.StatusCode, body)
+	}
+}
+
+func TestLegacyJoinLeaveLoaders(t *testing.T) {
+	when := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	name := pgtype.Text{String: "Player", Valid: true}
+	clanRows := &legacyTestRows{values: [][]any{{when, "join", "#CLAN", "#P", name, 17}}}
+	db := &legacyTestDB{rows: []pgx.Rows{clanRows}}
+	items, err := loadClanJoinLeave(context.Background(), db, "#CLAN", when, when.Add(time.Hour), 10)
+	if err != nil || len(items) != 1 || items[0].Name != "Player" || !strings.Contains(db.queries[0], `ORDER BY "time" DESC`) {
+		t.Fatalf("clan loader: items=%#v err=%v", items, err)
+	}
+
+	playerRows := &legacyTestRows{values: [][]any{{when, "leave", "#CLAN", "#P", name, 17, "Clan"}}}
+	db = &legacyTestDB{rows: []pgx.Rows{playerRows}}
+	items, err = loadPlayerJoinLeave(context.Background(), db, "#P", when, when.Add(time.Hour), 10)
+	if err != nil || len(items) != 1 || items[0].ClanName != "Clan" || !strings.Contains(db.queries[0], "JOIN basic_clan") {
+		t.Fatalf("player loader: items=%#v err=%v", items, err)
+	}
+}
+
+func TestLegacyCWLHandlers(t *testing.T) {
+	group := &legacymodels.CWLGroup{State: "ended", Season: "2026-05", Clans: []legacymodels.CWLClan{}, Rounds: []legacymodels.CWLRound{}}
+	load := func(_ context.Context, tag, season string, hydrate bool) (*legacymodels.CWLGroup, error) {
+		if tag != "#CLAN" {
+			t.Fatalf("CWL tag = %q", tag)
+		}
+		if season == "2026-05" && !hydrate {
+			t.Fatal("season endpoint did not request hydration")
+		}
+		return group, nil
+	}
+	response, body := legacyTestRequest(t, "/:clan_tag/:season", "/%23clan/2026-05", cwlSeasonHandler(load))
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), `"season":"2026-05"`) {
+		t.Fatalf("season CWL: status=%d body=%s", response.StatusCode, body)
+	}
+	response, body = legacyTestRequest(t, "/:clan_tag/group", "/%23clan/group", currentCWLGroupHandler(load))
+	if response.StatusCode != http.StatusOK || !strings.Contains(string(body), `"data"`) {
+		t.Fatalf("current CWL: status=%d body=%s", response.StatusCode, body)
+	}
+	response, body = legacyTestRequest(t, "/:clan_tag/group", "/%23clan/group", currentCWLGroupHandler(func(context.Context, string, string, bool) (*legacymodels.CWLGroup, error) {
+		return nil, pgx.ErrNoRows
+	}))
+	if response.StatusCode != http.StatusOK || string(body) != "null" {
+		t.Fatalf("missing current CWL: status=%d body=%s", response.StatusCode, body)
+	}
+	response, body = legacyTestRequest(t, "/:clan_tag/:season", "/%23clan/2026-05", cwlSeasonHandler(func(context.Context, string, string, bool) (*legacymodels.CWLGroup, error) {
+		return nil, pgx.ErrNoRows
+	}))
+	if response.StatusCode != http.StatusNotFound || !strings.Contains(string(body), "No CWL Data Found") {
+		t.Fatalf("missing season CWL: status=%d body=%s", response.StatusCode, body)
+	}
+}
+
+func TestLegacyCWLLoaders(t *testing.T) {
+	clanRows := &legacyTestRows{values: [][]any{
+		{"#A", "Alpha", 20, "badge", pgtype.Text{String: "#P", Valid: true}, pgtype.Text{String: "Player", Valid: true}, pgtype.Int2{Int16: 17, Valid: true}},
+		{"#B", "Beta", 19, "", pgtype.Text{}, pgtype.Text{}, pgtype.Int2{}},
+	}}
+	db := &legacyTestDB{rows: []pgx.Rows{clanRows}}
+	clans, err := loadCWLClans(context.Background(), db, "cwl-1")
+	if err != nil || len(clans) != 2 || len(clans[0].Members) != 1 || len(clans[1].Members) != 0 {
+		t.Fatalf("CWL clans: %#v err=%v", clans, err)
+	}
+
+	warRows := &legacyTestRows{values: [][]any{{"1", pgtype.Text{String: "#WAR", Valid: true}}}}
+	db = &legacyTestDB{rows: []pgx.Rows{warRows}}
+	wars, err := loadCWLWars(context.Background(), db, func(_ context.Context, ids []string) (map[string]wararchive.War, error) {
+		if !reflect.DeepEqual(ids, []string{"1"}) {
+			t.Fatalf("archive ids = %v", ids)
+		}
+		war := legacyTestWar()
+		war.Type = "cwl"
+		war.WarTag = "#WAR"
+		return map[string]wararchive.War{"1": war}, nil
+	}, [][]string{{"#WAR", "#0", "#WAR"}}, "2026-05")
+	if err != nil || wars["#WAR"].Season != "2026-05" || wars["#WAR"].Tag != "#WAR" {
+		t.Fatalf("CWL wars: %#v err=%v", wars, err)
+	}
+	empty, err := loadCWLWars(context.Background(), &legacyTestDB{}, nil, [][]string{{"#0", ""}}, "2026-05")
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty CWL wars: %#v err=%v", empty, err)
+	}
+}
+
+func TestLoadCWLGroupHydratesRounds(t *testing.T) {
+	groupRow := legacyTestRow{values: []any{"cwl-1", "2026-05", "ended", []byte(`[["#WAR","#MISSING"]]`)}}
+	clanRows := &legacyTestRows{values: [][]any{{"#CLAN", "Clan", 20, "badge", pgtype.Text{}, pgtype.Text{}, pgtype.Int2{}}}}
+	warRows := &legacyTestRows{values: [][]any{{"1", pgtype.Text{String: "#WAR", Valid: true}}}}
+	db := &legacyTestDB{row: groupRow, rows: []pgx.Rows{clanRows, warRows}}
+	group, err := loadCWLGroup(context.Background(), db, func(context.Context, []string) (map[string]wararchive.War, error) {
+		war := legacyTestWar()
+		war.Type, war.WarTag = "cwl", "#WAR"
+		return map[string]wararchive.War{"1": war}, nil
+	}, "#CLAN", "2026-05", true)
+	if err != nil || len(group.Rounds) != 1 || len(group.Rounds[0].WarTags) != 2 {
+		t.Fatalf("hydrated group: %#v err=%v", group, err)
+	}
+	payload, err := json.Marshal(group.Rounds[0].WarTags[1])
+	if err != nil || string(payload) != `{"tag":"#MISSING"}` {
+		t.Fatalf("missing war placeholder = %s err=%v", payload, err)
+	}
+}
+
+func TestLegacyHelpersAndRegistration(t *testing.T) {
+	if got := fixTag(" %23goO-2 "); got != "#G002" {
+		t.Fatalf("fixTag = %q", got)
+	}
+	if got := fixTag("---"); got != "" {
+		t.Fatalf("empty fixTag = %q", got)
+	}
+	if _, err := parseInt("bad", 1); err == nil {
+		t.Fatal("parseInt accepted invalid input")
+	}
+	if got, err := parseInt("", 7); err != nil || got != 7 {
+		t.Fatalf("parseInt fallback = %d, %v", got, err)
+	}
+	if _, err := parseInt64("bad", 1); err == nil {
+		t.Fatal("parseInt64 accepted invalid input")
+	}
+	if got := badgeURLs(""); got != (legacymodels.BadgeURLs{}) {
+		t.Fatalf("empty badges = %#v", got)
+	}
+	for input, expected := range map[string]string{"notinwar": "notInWar", "inwar": "inWar", "preparation": "preparation", "ended": "warEnded", "custom": "custom"} {
+		if got := normalizeWarState(input); got != expected {
+			t.Fatalf("normalizeWarState(%q) = %q", input, got)
+		}
+	}
+	weak := legacymodels.WarAttack{Stars: 1, DestructionPercentage: 50, Order: 2}
+	if !betterAttack(legacymodels.WarAttack{Stars: 2}, &weak) || !betterAttack(legacymodels.WarAttack{Stars: 1, DestructionPercentage: 60}, &weak) || !betterAttack(legacymodels.WarAttack{Stars: 1, DestructionPercentage: 50, Order: 1}, &weak) {
+		t.Fatal("betterAttack rejected a better candidate")
+	}
+
+	app := fiber.New()
+	Register(app, apptypes.Deps{})
+	getRoutes := 0
+	for _, route := range app.GetRoutes(true) {
+		if route.Method == fiber.MethodGet {
+			getRoutes++
+		}
+	}
+	if getRoutes != 7 {
+		t.Fatalf("legacy GET route count = %d", getRoutes)
+	}
+}

--- a/internal/routes/legacy/helpers.go
+++ b/internal/routes/legacy/helpers.go
@@ -1,0 +1,165 @@
+package legacy
+
+import (
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
+	"github.com/ClashKingInc/ClashKingAPI/internal/wararchive"
+)
+
+const badgeBaseURL = "https://api-assets.clashofclans.com/badges"
+
+var tagCharacters = regexp.MustCompile(`[^A-Z0-9]+`)
+
+func fixTag(raw string) string {
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		raw = decoded
+	}
+	raw = strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(raw)), "#")
+	raw = tagCharacters.ReplaceAllString(raw, "")
+	raw = strings.ReplaceAll(raw, "O", "0")
+	if raw == "" {
+		return ""
+	}
+	return "#" + raw
+}
+
+func parseInt(raw string, fallback int) (int, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	return strconv.Atoi(raw)
+}
+
+func parseInt64(raw string, fallback int64) (int64, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+func clashTime(value time.Time) string {
+	return value.UTC().Format("20060102T150405.000Z")
+}
+
+func legacyDateTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000")
+}
+
+func badgeURLs(token string) legacymodels.BadgeURLs {
+	token = strings.TrimSuffix(strings.TrimSpace(token), ".png")
+	if token == "" {
+		return legacymodels.BadgeURLs{}
+	}
+	return legacymodels.BadgeURLs{
+		Small:  badgeBaseURL + "/70/" + token + ".png",
+		Large:  badgeBaseURL + "/512/" + token + ".png",
+		Medium: badgeBaseURL + "/200/" + token + ".png",
+	}
+}
+
+func legacyWar(source wararchive.War, includeMembers bool) legacymodels.War {
+	war := legacymodels.War{
+		State: normalizeWarState(source.State), TeamSize: source.TeamSize,
+		BattleModifier:       source.BattleModifier,
+		PreparationStartTime: clashTime(source.PreparationStartTime), EndTime: clashTime(source.EndTime),
+		Clan:     legacyWarClan(source.Clan, source.Opponent, includeMembers),
+		Opponent: legacyWarClan(source.Opponent, source.Clan, includeMembers),
+	}
+	if source.Type == "cwl" {
+		war.Tag = source.WarTag
+		if source.StartTime != nil {
+			war.WarStartTime = clashTime(*source.StartTime)
+		}
+	} else {
+		attacksPerMember := source.AttacksPerMember
+		war.AttacksPerMember = &attacksPerMember
+		if source.StartTime != nil {
+			war.StartTime = clashTime(*source.StartTime)
+		}
+	}
+	return war
+}
+
+func legacyWarClan(clan, opponent wararchive.Clan, includeMembers bool) legacymodels.WarClan {
+	result := legacymodels.WarClan{
+		Tag: clan.Tag, Name: clan.Name, BadgeURLs: badgeURLs(clan.BadgeToken), ClanLevel: clan.ClanLevel,
+		Attacks: clan.Attacks, Stars: clan.Stars, DestructionPercentage: clan.DestructionPercentage,
+	}
+	if !includeMembers {
+		return result
+	}
+	result.Members = make([]legacymodels.WarMember, 0, len(clan.Members))
+	opponentAttacks := attacksByDefender(opponent)
+	for _, member := range clan.Members {
+		attacks := make([]legacymodels.WarAttack, 0, len(member.Attacks))
+		for _, attack := range member.Attacks {
+			attacks = append(attacks, legacyAttack(member.Tag, attack))
+		}
+		defenses := opponentAttacks[member.Tag]
+		count := len(defenses)
+		item := legacyMember(member, &count)
+		item.Attacks = attacks
+		for index := range defenses {
+			candidate := defenses[index]
+			if betterAttack(candidate, item.BestOpponentAttack) {
+				item.BestOpponentAttack = &candidate
+			}
+		}
+		result.Members = append(result.Members, item)
+	}
+	return result
+}
+
+func legacyMember(member wararchive.Member, opponentAttacks *int) legacymodels.WarMember {
+	return legacymodels.WarMember{
+		Tag: member.Tag, Name: member.Name, TownhallLevel: member.TownhallLevel,
+		MapPosition: member.MapPosition, OpponentAttacks: opponentAttacks,
+	}
+}
+
+func legacyAttack(attackerTag string, attack wararchive.Attack) legacymodels.WarAttack {
+	return legacymodels.WarAttack{
+		AttackerTag: attackerTag, DefenderTag: attack.DefenderTag, Stars: attack.Stars,
+		DestructionPercentage: attack.DestructionPercentage, Order: attack.Order, Duration: attack.Duration,
+	}
+}
+
+func attacksByDefender(clan wararchive.Clan) map[string][]legacymodels.WarAttack {
+	result := map[string][]legacymodels.WarAttack{}
+	for _, member := range clan.Members {
+		for _, attack := range member.Attacks {
+			result[attack.DefenderTag] = append(result[attack.DefenderTag], legacyAttack(member.Tag, attack))
+		}
+	}
+	return result
+}
+
+func betterAttack(candidate legacymodels.WarAttack, current *legacymodels.WarAttack) bool {
+	if current == nil || candidate.Stars != current.Stars {
+		return current == nil || candidate.Stars > current.Stars
+	}
+	if candidate.DestructionPercentage != current.DestructionPercentage {
+		return candidate.DestructionPercentage > current.DestructionPercentage
+	}
+	return candidate.Order < current.Order
+}
+
+func normalizeWarState(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "notinwar":
+		return "notInWar"
+	case "preparation":
+		return "preparation"
+	case "inwar":
+		return "inWar"
+	case "ended", "warended":
+		return "warEnded"
+	default:
+		return value
+	}
+}

--- a/internal/routes/legacy/join_leave.go
+++ b/internal/routes/legacy/join_leave.go
@@ -1,0 +1,197 @@
+package legacy
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type joinLeaveRow struct {
+	Time     time.Time
+	Type     string
+	Clan     string
+	Tag      string
+	Name     string
+	Townhall int
+	ClanName string
+}
+
+// clanJoinLeave godoc
+// @Summary Clan join and leave history
+// @Description Legacy v1-compatible tracked clan membership events.
+// @Tags Legacy
+// @Produce json
+// @Param clan_tag path string true "Clan tag"
+// @Param timestamp_start query int false "Inclusive Unix timestamp" default(0)
+// @Param time_stamp_end query int false "Inclusive Unix timestamp" default(9999999999)
+// @Param limit query int false "Maximum events" default(250)
+// @Success 200 {object} legacy.JoinLeaveResponse
+// @Router /clan/{clan_tag}/join-leave [get]
+func clanJoinLeave(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		start, end, limit, err := joinLeaveOptions(c)
+		if err != nil {
+			return err
+		}
+		if limit <= 0 {
+			return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: []legacymodels.JoinLeaveEvent{}})
+		}
+		rows, err := deps.Store.SQL.Query(c.UserContext(), `
+			SELECT "time", "type", clan_tag, player_tag, player_name, townhall_level
+			FROM join_leave_history
+			WHERE clan_tag = $1 AND "time" >= $2 AND "time" <= $3
+			ORDER BY "time" DESC
+			LIMIT $4
+		`, fixTag(c.Params("clan_tag")), start, end, limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		items := make([]legacymodels.JoinLeaveEvent, 0, limit)
+		for rows.Next() {
+			var row joinLeaveRow
+			var name pgtype.Text
+			if err := rows.Scan(&row.Time, &row.Type, &row.Clan, &row.Tag, &name, &row.Townhall); err != nil {
+				return err
+			}
+			if name.Valid {
+				row.Name = name.String
+			}
+			items = append(items, legacyJoinLeaveEvent(row, false))
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: items})
+	}
+}
+
+// playerJoinLeave godoc
+// @Summary Player join and leave history
+// @Description Legacy v1-compatible tracked player membership events.
+// @Tags Legacy
+// @Produce json
+// @Param player_tag path string true "Player tag"
+// @Param timestamp_start query int false "Inclusive Unix timestamp" default(0)
+// @Param time_stamp_end query int false "Inclusive Unix timestamp" default(9999999999)
+// @Param limit query int false "Maximum source events" default(250)
+// @Success 200 {object} legacy.JoinLeaveResponse
+// @Router /player/{player_tag}/join-leave [get]
+func playerJoinLeave(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		start, end, limit, err := joinLeaveOptions(c)
+		if err != nil {
+			return err
+		}
+		if limit <= 0 {
+			return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: []legacymodels.JoinLeaveEvent{}})
+		}
+		rows, err := deps.Store.SQL.Query(c.UserContext(), `
+			SELECT jl."time", jl."type", jl.clan_tag, jl.player_tag, jl.player_name,
+			       jl.townhall_level, clan.name
+			FROM join_leave_history AS jl
+			JOIN basic_clan AS clan ON clan.tag = jl.clan_tag
+			WHERE jl.player_tag = $1 AND jl."time" >= $2 AND jl."time" <= $3
+			ORDER BY jl."time" ASC
+			LIMIT $4
+		`, fixTag(c.Params("player_tag")), start, end, limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		events := make([]joinLeaveRow, 0, limit)
+		for rows.Next() {
+			var row joinLeaveRow
+			var name pgtype.Text
+			if err := rows.Scan(&row.Time, &row.Type, &row.Clan, &row.Tag, &name, &row.Townhall, &row.ClanName); err != nil {
+				return err
+			}
+			if name.Valid {
+				row.Name = name.String
+			}
+			events = append(events, row)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		events = processPlayerJoinLeave(events)
+		items := make([]legacymodels.JoinLeaveEvent, 0, len(events))
+		for index := len(events) - 1; index >= 0; index-- {
+			items = append(items, legacyJoinLeaveEvent(events[index], true))
+		}
+		return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: items})
+	}
+}
+
+func joinLeaveOptions(c *fiber.Ctx) (time.Time, time.Time, int, error) {
+	startUnix, err := parseInt64(c.Query("timestamp_start"), 0)
+	if err != nil {
+		return time.Time{}, time.Time{}, 0, fiber.NewError(http.StatusUnprocessableEntity, "timestamp_start must be an integer")
+	}
+	endUnix, err := parseInt64(c.Query("time_stamp_end"), 9999999999)
+	if err != nil {
+		return time.Time{}, time.Time{}, 0, fiber.NewError(http.StatusUnprocessableEntity, "time_stamp_end must be an integer")
+	}
+	limit, err := parseInt(c.Query("limit"), 250)
+	if err != nil {
+		return time.Time{}, time.Time{}, 0, fiber.NewError(http.StatusUnprocessableEntity, "limit must be an integer")
+	}
+	return time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit, nil
+}
+
+func legacyJoinLeaveEvent(row joinLeaveRow, includeClanName bool) legacymodels.JoinLeaveEvent {
+	item := legacymodels.JoinLeaveEvent{
+		Name: row.Name, Tag: row.Tag, Townhall: row.Townhall, Time: legacyDateTime(row.Time),
+		Clan: row.Clan, Type: row.Type,
+	}
+	if includeClanName {
+		item.ClanName = row.ClanName
+	}
+	return item
+}
+
+// processPlayerJoinLeave mirrors the ordering and timestamp correction in the
+// original Python endpoint before that endpoint reversed the result.
+func processPlayerJoinLeave(source []joinLeaveRow) []joinLeaveRow {
+	events := append([]joinLeaveRow(nil), source...)
+	corrected := make([]joinLeaveRow, 0, len(events))
+	for len(events) > 0 {
+		event := events[0]
+		events = events[1:]
+		corrected = append(corrected, event)
+		if event.Type != "join" {
+			continue
+		}
+		leaveIndex := -1
+		for index, candidate := range events {
+			if candidate.Type == "leave" && candidate.Tag == event.Tag && candidate.Clan == event.Clan {
+				leaveIndex = index
+				break
+			}
+		}
+		if leaveIndex < 0 {
+			continue
+		}
+		leave := events[leaveIndex]
+		events = append(events[:leaveIndex], events[leaveIndex+1:]...)
+		for _, candidate := range events {
+			if candidate.Type == "join" {
+				leave.Time = candidate.Time
+				break
+			}
+		}
+		corrected = append(corrected, leave)
+	}
+	sort.SliceStable(corrected, func(i, j int) bool {
+		if corrected[i].Time.Equal(corrected[j].Time) {
+			return corrected[i].Type == "leave" && corrected[j].Type != "leave"
+		}
+		return corrected[i].Time.Before(corrected[j].Time)
+	})
+	return corrected
+}

--- a/internal/routes/legacy/join_leave.go
+++ b/internal/routes/legacy/join_leave.go
@@ -1,6 +1,7 @@
 package legacy
 
 import (
+	"context"
 	"net/http"
 	"sort"
 	"time"
@@ -8,6 +9,7 @@ import (
 	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
 	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -19,6 +21,12 @@ type joinLeaveRow struct {
 	Name     string
 	Townhall int
 	ClanName string
+}
+
+type joinLeaveLoader func(context.Context, string, time.Time, time.Time, int) ([]joinLeaveRow, error)
+
+type joinLeaveDB interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
 }
 
 // clanJoinLeave godoc
@@ -33,6 +41,12 @@ type joinLeaveRow struct {
 // @Success 200 {object} legacy.JoinLeaveResponse
 // @Router /clan/{clan_tag}/join-leave [get]
 func clanJoinLeave(deps apptypes.Deps) fiber.Handler {
+	return clanJoinLeaveHandler(func(ctx context.Context, tag string, start, end time.Time, limit int) ([]joinLeaveRow, error) {
+		return loadClanJoinLeave(ctx, deps.Store.SQL, tag, start, end, limit)
+	})
+}
+
+func clanJoinLeaveHandler(load joinLeaveLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		start, end, limit, err := joinLeaveOptions(c)
 		if err != nil {
@@ -41,34 +55,46 @@ func clanJoinLeave(deps apptypes.Deps) fiber.Handler {
 		if limit <= 0 {
 			return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: []legacymodels.JoinLeaveEvent{}})
 		}
-		rows, err := deps.Store.SQL.Query(c.UserContext(), `
+		rows, err := load(c.UserContext(), fixTag(c.Params("clan_tag")), start, end, limit)
+		if err != nil {
+			return err
+		}
+		items := make([]legacymodels.JoinLeaveEvent, 0, len(rows))
+		for _, row := range rows {
+			items = append(items, legacyJoinLeaveEvent(row, false))
+		}
+		return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: items})
+	}
+}
+
+func loadClanJoinLeave(ctx context.Context, db joinLeaveDB, tag string, start, end time.Time, limit int) ([]joinLeaveRow, error) {
+	rows, err := db.Query(ctx, `
 			SELECT "time", "type", clan_tag, player_tag, player_name, townhall_level
 			FROM join_leave_history
 			WHERE clan_tag = $1 AND "time" >= $2 AND "time" <= $3
 			ORDER BY "time" DESC
 			LIMIT $4
-		`, fixTag(c.Params("clan_tag")), start, end, limit)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		items := make([]legacymodels.JoinLeaveEvent, 0, limit)
-		for rows.Next() {
-			var row joinLeaveRow
-			var name pgtype.Text
-			if err := rows.Scan(&row.Time, &row.Type, &row.Clan, &row.Tag, &name, &row.Townhall); err != nil {
-				return err
-			}
-			if name.Valid {
-				row.Name = name.String
-			}
-			items = append(items, legacyJoinLeaveEvent(row, false))
-		}
-		if err := rows.Err(); err != nil {
-			return err
-		}
-		return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: items})
+		`, tag, start, end, limit)
+	if err != nil {
+		return nil, err
 	}
+	defer rows.Close()
+	items := make([]joinLeaveRow, 0, limit)
+	for rows.Next() {
+		var row joinLeaveRow
+		var name pgtype.Text
+		if err := rows.Scan(&row.Time, &row.Type, &row.Clan, &row.Tag, &name, &row.Townhall); err != nil {
+			return nil, err
+		}
+		if name.Valid {
+			row.Name = name.String
+		}
+		items = append(items, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 // playerJoinLeave godoc
@@ -83,6 +109,12 @@ func clanJoinLeave(deps apptypes.Deps) fiber.Handler {
 // @Success 200 {object} legacy.JoinLeaveResponse
 // @Router /player/{player_tag}/join-leave [get]
 func playerJoinLeave(deps apptypes.Deps) fiber.Handler {
+	return playerJoinLeaveHandler(func(ctx context.Context, tag string, start, end time.Time, limit int) ([]joinLeaveRow, error) {
+		return loadPlayerJoinLeave(ctx, deps.Store.SQL, tag, start, end, limit)
+	})
+}
+
+func playerJoinLeaveHandler(load joinLeaveLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		start, end, limit, err := joinLeaveOptions(c)
 		if err != nil {
@@ -91,32 +123,8 @@ func playerJoinLeave(deps apptypes.Deps) fiber.Handler {
 		if limit <= 0 {
 			return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: []legacymodels.JoinLeaveEvent{}})
 		}
-		rows, err := deps.Store.SQL.Query(c.UserContext(), `
-			SELECT jl."time", jl."type", jl.clan_tag, jl.player_tag, jl.player_name,
-			       jl.townhall_level, clan.name
-			FROM join_leave_history AS jl
-			JOIN basic_clan AS clan ON clan.tag = jl.clan_tag
-			WHERE jl.player_tag = $1 AND jl."time" >= $2 AND jl."time" <= $3
-			ORDER BY jl."time" ASC
-			LIMIT $4
-		`, fixTag(c.Params("player_tag")), start, end, limit)
+		events, err := load(c.UserContext(), fixTag(c.Params("player_tag")), start, end, limit)
 		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		events := make([]joinLeaveRow, 0, limit)
-		for rows.Next() {
-			var row joinLeaveRow
-			var name pgtype.Text
-			if err := rows.Scan(&row.Time, &row.Type, &row.Clan, &row.Tag, &name, &row.Townhall, &row.ClanName); err != nil {
-				return err
-			}
-			if name.Valid {
-				row.Name = name.String
-			}
-			events = append(events, row)
-		}
-		if err := rows.Err(); err != nil {
 			return err
 		}
 		events = processPlayerJoinLeave(events)
@@ -126,6 +134,38 @@ func playerJoinLeave(deps apptypes.Deps) fiber.Handler {
 		}
 		return apptypes.JSON(c, http.StatusOK, legacymodels.JoinLeaveResponse{Items: items})
 	}
+}
+
+func loadPlayerJoinLeave(ctx context.Context, db joinLeaveDB, tag string, start, end time.Time, limit int) ([]joinLeaveRow, error) {
+	rows, err := db.Query(ctx, `
+			SELECT jl."time", jl."type", jl.clan_tag, jl.player_tag, jl.player_name,
+			       jl.townhall_level, clan.name
+			FROM join_leave_history AS jl
+			JOIN basic_clan AS clan ON clan.tag = jl.clan_tag
+			WHERE jl.player_tag = $1 AND jl."time" >= $2 AND jl."time" <= $3
+			ORDER BY jl."time" ASC
+			LIMIT $4
+		`, tag, start, end, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	events := make([]joinLeaveRow, 0, limit)
+	for rows.Next() {
+		var row joinLeaveRow
+		var name pgtype.Text
+		if err := rows.Scan(&row.Time, &row.Type, &row.Clan, &row.Tag, &name, &row.Townhall, &row.ClanName); err != nil {
+			return nil, err
+		}
+		if name.Valid {
+			row.Name = name.String
+		}
+		events = append(events, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
 }
 
 func joinLeaveOptions(c *fiber.Ctx) (time.Time, time.Time, int, error) {

--- a/internal/routes/legacy/register.go
+++ b/internal/routes/legacy/register.go
@@ -1,0 +1,17 @@
+package legacy
+
+import (
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
+)
+
+// Register mounts the intentionally isolated, removable legacy API surface.
+func Register(app *fiber.App, deps apptypes.Deps) {
+	app.Get("/player/:player_tag/warhits", playerWarHits(deps))
+	app.Get("/player/:player_tag/join-leave", playerJoinLeave(deps))
+	app.Get("/clan/:clan_tag/join-leave", clanJoinLeave(deps))
+	app.Get("/war/:clan_tag/previous", previousWars(deps))
+	app.Get("/war/:clan_tag/previous/:end_time", previousWarAtTime(deps))
+	app.Get("/cwl/:clan_tag/group", currentCWLGroup(deps))
+	app.Get("/cwl/:clan_tag/:season", cwlSeason(deps))
+}

--- a/internal/routes/legacy/war.go
+++ b/internal/routes/legacy/war.go
@@ -1,0 +1,273 @@
+package legacy
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"time"
+
+	legacymodels "github.com/ClashKingInc/ClashKingAPI/internal/models/legacy"
+	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/ClashKingInc/ClashKingAPI/internal/wararchive"
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
+)
+
+// previousWars godoc
+// @Summary Previous wars for a clan
+// @Description Legacy v1-compatible stored full-war history.
+// @Tags Legacy
+// @Produce json
+// @Param clan_tag path string true "Clan tag"
+// @Param timestamp_start query int false "Inclusive preparation-time start" default(0)
+// @Param timestamp_end query int false "Inclusive preparation-time end" default(9999999999)
+// @Param limit query int false "Maximum wars" default(50)
+// @Success 200 {object} legacy.WarListResponse
+// @Router /war/{clan_tag}/previous [get]
+func previousWars(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		startUnix, err := parseInt64(c.Query("timestamp_start"), 0)
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "timestamp_start must be an integer")
+		}
+		endUnix, err := parseInt64(c.Query("timestamp_end"), 9999999999)
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "timestamp_end must be an integer")
+		}
+		limit, err := parseInt(c.Query("limit"), 50)
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "limit must be an integer")
+		}
+		if limit <= 0 {
+			return apptypes.JSON(c, http.StatusOK, legacymodels.WarListResponse{Items: []legacymodels.War{}})
+		}
+		ids, err := queryWarIDs(c, deps, fixTag(c.Params("clan_tag")), time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit)
+		if err != nil {
+			return err
+		}
+		wars, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, ids)
+		if err != nil {
+			return err
+		}
+		items := make([]legacymodels.War, 0, len(ids))
+		for _, id := range ids {
+			if war, ok := wars[id]; ok {
+				items = append(items, legacyWar(war, true))
+			}
+		}
+		return apptypes.JSON(c, http.StatusOK, legacymodels.WarListResponse{Items: items})
+	}
+}
+
+func queryWarIDs(c *fiber.Ctx, deps apptypes.Deps, clanTag string, start, end time.Time, limit int) ([]string, error) {
+	rows, err := deps.Store.SQL.Query(c.UserContext(), `
+		SELECT war_id::text
+		FROM wars
+		WHERE (clan_tag = $1 OR opponent_tag = $1)
+		  AND prep_time >= $2 AND prep_time <= $3
+		ORDER BY end_time DESC
+		LIMIT $4
+	`, clanTag, start, end, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := make([]string, 0, limit)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// previousWarAtTime godoc
+// @Summary Previous war at an end time
+// @Description Legacy v1-compatible lookup within five minutes of the supplied Clash timestamp.
+// @Tags Legacy
+// @Produce json
+// @Param clan_tag path string true "Clan tag"
+// @Param end_time path string true "End time in Clash format"
+// @Success 200 {object} legacy.War
+// @Failure 404 {object} map[string]string
+// @Router /war/{clan_tag}/previous/{end_time} [get]
+func previousWarAtTime(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		target, err := time.Parse("20060102T150405.000Z", c.Params("end_time"))
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "invalid end_time")
+		}
+		var id string
+		err = deps.Store.SQL.QueryRow(c.UserContext(), `
+			SELECT war_id::text
+			FROM wars
+			WHERE (clan_tag = $1 OR opponent_tag = $1)
+			  AND end_time >= $2 - interval '5 minutes'
+			  AND end_time <= $2 + interval '5 minutes'
+			ORDER BY abs(extract(epoch FROM (end_time - $2))), war_id
+			LIMIT 1
+		`, fixTag(c.Params("clan_tag")), target).Scan(&id)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apptypes.JSON(c, http.StatusNotFound, map[string]string{"detail": "War Not Found"})
+		}
+		if err != nil {
+			return err
+		}
+		wars, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, []string{id})
+		if err != nil {
+			return err
+		}
+		war, ok := wars[id]
+		if !ok {
+			return apptypes.JSON(c, http.StatusNotFound, map[string]string{"detail": "War Not Found"})
+		}
+		return apptypes.JSON(c, http.StatusOK, legacyWar(war, true))
+	}
+}
+
+// playerWarHits godoc
+// @Summary War attacks and defenses for a player
+// @Description Legacy v1-compatible war-grouped player history.
+// @Tags Legacy
+// @Produce json
+// @Param player_tag path string true "Player tag"
+// @Param timestamp_start query int false "Inclusive preparation-time start" default(0)
+// @Param timestamp_end query int false "Inclusive preparation-time end" default(2527625513)
+// @Param limit query int false "Maximum wars" default(50) maximum(100)
+// @Success 200 {object} legacy.PlayerWarHitsResponse
+// @Router /player/{player_tag}/warhits [get]
+func playerWarHits(deps apptypes.Deps) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		startUnix, err := parseInt64(c.Query("timestamp_start"), 0)
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "timestamp_start must be an integer")
+		}
+		endUnix, err := parseInt64(c.Query("timestamp_end"), 2527625513)
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "timestamp_end must be an integer")
+		}
+		limit, err := parseInt(c.Query("limit"), 50)
+		if err != nil {
+			return fiber.NewError(http.StatusUnprocessableEntity, "limit must be an integer")
+		}
+		if limit <= 0 {
+			return apptypes.JSON(c, http.StatusOK, legacymodels.PlayerWarHitsResponse{Items: []legacymodels.PlayerWarHit{}})
+		}
+		if limit > 100 {
+			limit = 100
+		}
+		tag := fixTag(c.Params("player_tag"))
+		rows, err := deps.Store.SQL.Query(c.UserContext(), `
+			SELECT selected.war_id::text
+			FROM player_war_history AS history
+			CROSS JOIN LATERAL unnest(history.war_ids) AS selected(war_id)
+			JOIN wars AS war ON war.war_id = selected.war_id
+			WHERE history.player_tag = $1
+			  AND war.prep_time >= $2 AND war.prep_time <= $3
+			ORDER BY war.prep_time DESC, war.war_id DESC
+			LIMIT $4
+		`, tag, time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		ids := make([]string, 0, limit)
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			ids = append(ids, id)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		wars, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, ids)
+		if err != nil {
+			return err
+		}
+		items := make([]legacymodels.PlayerWarHit, 0, len(ids))
+		for _, id := range ids {
+			if war, ok := wars[id]; ok {
+				if item, ok := buildPlayerWarHit(tag, war); ok {
+					items = append(items, item)
+				}
+			}
+		}
+		return apptypes.JSON(c, http.StatusOK, legacymodels.PlayerWarHitsResponse{Items: items})
+	}
+}
+
+func buildPlayerWarHit(playerTag string, war wararchive.War) (legacymodels.PlayerWarHit, bool) {
+	own := war.Clan
+	member, found := archiveMember(war.Clan, playerTag)
+	opponent := war.Opponent
+	if !found {
+		member, found = archiveMember(war.Opponent, playerTag)
+		own = war.Opponent
+		opponent = war.Clan
+	}
+	if !found {
+		return legacymodels.PlayerWarHit{}, false
+	}
+
+	freshOrders := map[string]int{}
+	for _, fact := range wararchive.Attacks("", war) {
+		if current, exists := freshOrders[fact.DefenderTag]; !exists || fact.AttackOrder < current {
+			freshOrders[fact.DefenderTag] = fact.AttackOrder
+		}
+	}
+	defenders := archiveMembersByTag(opponent)
+	ownAttacksByDefender := attacksByDefender(own)
+	attacks := make([]legacymodels.WarHitAttack, 0, len(member.Attacks))
+	for _, attack := range member.Attacks {
+		defender := defenders[attack.DefenderTag]
+		opponentAttacks := len(ownAttacksByDefender[defender.Tag])
+		defenderData := legacyMember(defender, &opponentAttacks)
+		attacks = append(attacks, legacyWarHitAttack(member.Tag, attack, freshOrders[attack.DefenderTag] == attack.Order, &defenderData, nil))
+	}
+	defenses := []legacymodels.WarHitAttack{}
+	for _, attacker := range opponent.Members {
+		for _, attack := range attacker.Attacks {
+			if attack.DefenderTag != playerTag {
+				continue
+			}
+			opponentAttacks := len(ownAttacksByDefender[attacker.Tag])
+			attackerData := legacyMember(attacker, &opponentAttacks)
+			defenses = append(defenses, legacyWarHitAttack(attacker.Tag, attack, freshOrders[playerTag] == attack.Order, nil, &attackerData))
+		}
+	}
+	sort.SliceStable(defenses, func(i, j int) bool { return defenses[i].Order < defenses[j].Order })
+	defenseCount := len(defenses)
+	memberData := legacyMember(member, &defenseCount)
+	warData := legacyWar(war, false)
+	warData.Type = war.Type
+	return legacymodels.PlayerWarHit{WarData: warData, MemberData: memberData, Attacks: attacks, Defenses: defenses}, true
+}
+
+func legacyWarHitAttack(attackerTag string, attack wararchive.Attack, fresh bool, defender, attacker *legacymodels.WarMember) legacymodels.WarHitAttack {
+	return legacymodels.WarHitAttack{
+		AttackerTag: attackerTag, DefenderTag: attack.DefenderTag, Stars: attack.Stars,
+		DestructionPercentage: attack.DestructionPercentage, Order: attack.Order, Duration: attack.Duration,
+		Fresh: fresh, Defender: defender, Attacker: attacker, AttackOrder: attack.Order,
+	}
+}
+
+func archiveMember(clan wararchive.Clan, tag string) (wararchive.Member, bool) {
+	for _, member := range clan.Members {
+		if member.Tag == tag {
+			return member, true
+		}
+	}
+	return wararchive.Member{}, false
+}
+
+func archiveMembersByTag(clan wararchive.Clan) map[string]wararchive.Member {
+	result := make(map[string]wararchive.Member, len(clan.Members))
+	for _, member := range clan.Members {
+		result[member.Tag] = member
+	}
+	return result
+}

--- a/internal/routes/legacy/war.go
+++ b/internal/routes/legacy/war.go
@@ -1,6 +1,7 @@
 package legacy
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"sort"
@@ -12,6 +13,10 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
 )
+
+type warIDQuery func(context.Context, string, time.Time, time.Time, int) ([]string, error)
+type warArchiveLoader func(context.Context, []string) (map[string]wararchive.War, error)
+type warAtTimeQuery func(context.Context, string, time.Time) (string, error)
 
 // previousWars godoc
 // @Summary Previous wars for a clan
@@ -25,6 +30,17 @@ import (
 // @Success 200 {object} legacy.WarListResponse
 // @Router /war/{clan_tag}/previous [get]
 func previousWars(deps apptypes.Deps) fiber.Handler {
+	return previousWarsHandler(
+		func(ctx context.Context, tag string, start, end time.Time, limit int) ([]string, error) {
+			return queryWarIDs(ctx, deps.Store.SQL, tag, start, end, limit)
+		},
+		func(ctx context.Context, ids []string) (map[string]wararchive.War, error) {
+			return deps.Store.WarArchive.LoadIDs(ctx, deps.Store.SQL, ids)
+		},
+	)
+}
+
+func previousWarsHandler(queryIDs warIDQuery, loadWars warArchiveLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		startUnix, err := parseInt64(c.Query("timestamp_start"), 0)
 		if err != nil {
@@ -41,11 +57,11 @@ func previousWars(deps apptypes.Deps) fiber.Handler {
 		if limit <= 0 {
 			return apptypes.JSON(c, http.StatusOK, legacymodels.WarListResponse{Items: []legacymodels.War{}})
 		}
-		ids, err := queryWarIDs(c, deps, fixTag(c.Params("clan_tag")), time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit)
+		ids, err := queryIDs(c.UserContext(), fixTag(c.Params("clan_tag")), time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit)
 		if err != nil {
 			return err
 		}
-		wars, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, ids)
+		wars, err := loadWars(c.UserContext(), ids)
 		if err != nil {
 			return err
 		}
@@ -59,8 +75,13 @@ func previousWars(deps apptypes.Deps) fiber.Handler {
 	}
 }
 
-func queryWarIDs(c *fiber.Ctx, deps apptypes.Deps, clanTag string, start, end time.Time, limit int) ([]string, error) {
-	rows, err := deps.Store.SQL.Query(c.UserContext(), `
+type warQueryDB interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func queryWarIDs(ctx context.Context, db warQueryDB, clanTag string, start, end time.Time, limit int) ([]string, error) {
+	rows, err := db.Query(ctx, `
 		SELECT war_id::text
 		FROM wars
 		WHERE (clan_tag = $1 OR opponent_tag = $1)
@@ -94,28 +115,30 @@ func queryWarIDs(c *fiber.Ctx, deps apptypes.Deps, clanTag string, start, end ti
 // @Failure 404 {object} map[string]string
 // @Router /war/{clan_tag}/previous/{end_time} [get]
 func previousWarAtTime(deps apptypes.Deps) fiber.Handler {
+	return previousWarAtTimeHandler(
+		func(ctx context.Context, tag string, target time.Time) (string, error) {
+			return queryWarAtTime(ctx, deps.Store.SQL, tag, target)
+		},
+		func(ctx context.Context, ids []string) (map[string]wararchive.War, error) {
+			return deps.Store.WarArchive.LoadIDs(ctx, deps.Store.SQL, ids)
+		},
+	)
+}
+
+func previousWarAtTimeHandler(findWar warAtTimeQuery, loadWars warArchiveLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		target, err := time.Parse("20060102T150405.000Z", c.Params("end_time"))
 		if err != nil {
 			return fiber.NewError(http.StatusUnprocessableEntity, "invalid end_time")
 		}
-		var id string
-		err = deps.Store.SQL.QueryRow(c.UserContext(), `
-			SELECT war_id::text
-			FROM wars
-			WHERE (clan_tag = $1 OR opponent_tag = $1)
-			  AND end_time >= $2 - interval '5 minutes'
-			  AND end_time <= $2 + interval '5 minutes'
-			ORDER BY abs(extract(epoch FROM (end_time - $2))), war_id
-			LIMIT 1
-		`, fixTag(c.Params("clan_tag")), target).Scan(&id)
+		id, err := findWar(c.UserContext(), fixTag(c.Params("clan_tag")), target)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return apptypes.JSON(c, http.StatusNotFound, map[string]string{"detail": "War Not Found"})
 		}
 		if err != nil {
 			return err
 		}
-		wars, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, []string{id})
+		wars, err := loadWars(c.UserContext(), []string{id})
 		if err != nil {
 			return err
 		}
@@ -125,6 +148,20 @@ func previousWarAtTime(deps apptypes.Deps) fiber.Handler {
 		}
 		return apptypes.JSON(c, http.StatusOK, legacyWar(war, true))
 	}
+}
+
+func queryWarAtTime(ctx context.Context, db warQueryDB, clanTag string, target time.Time) (string, error) {
+	var id string
+	err := db.QueryRow(ctx, `
+			SELECT war_id::text
+			FROM wars
+			WHERE (clan_tag = $1 OR opponent_tag = $1)
+			  AND end_time >= $2 - interval '5 minutes'
+			  AND end_time <= $2 + interval '5 minutes'
+			ORDER BY abs(extract(epoch FROM (end_time - $2))), war_id
+			LIMIT 1
+		`, clanTag, target).Scan(&id)
+	return id, err
 }
 
 // playerWarHits godoc
@@ -139,6 +176,17 @@ func previousWarAtTime(deps apptypes.Deps) fiber.Handler {
 // @Success 200 {object} legacy.PlayerWarHitsResponse
 // @Router /player/{player_tag}/warhits [get]
 func playerWarHits(deps apptypes.Deps) fiber.Handler {
+	return playerWarHitsHandler(
+		func(ctx context.Context, tag string, start, end time.Time, limit int) ([]string, error) {
+			return queryPlayerWarIDs(ctx, deps.Store.SQL, tag, start, end, limit)
+		},
+		func(ctx context.Context, ids []string) (map[string]wararchive.War, error) {
+			return deps.Store.WarArchive.LoadIDs(ctx, deps.Store.SQL, ids)
+		},
+	)
+}
+
+func playerWarHitsHandler(queryIDs warIDQuery, loadWars warArchiveLoader) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		startUnix, err := parseInt64(c.Query("timestamp_start"), 0)
 		if err != nil {
@@ -159,32 +207,11 @@ func playerWarHits(deps apptypes.Deps) fiber.Handler {
 			limit = 100
 		}
 		tag := fixTag(c.Params("player_tag"))
-		rows, err := deps.Store.SQL.Query(c.UserContext(), `
-			SELECT selected.war_id::text
-			FROM player_war_history AS history
-			CROSS JOIN LATERAL unnest(history.war_ids) AS selected(war_id)
-			JOIN wars AS war ON war.war_id = selected.war_id
-			WHERE history.player_tag = $1
-			  AND war.prep_time >= $2 AND war.prep_time <= $3
-			ORDER BY war.prep_time DESC, war.war_id DESC
-			LIMIT $4
-		`, tag, time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit)
+		ids, err := queryIDs(c.UserContext(), tag, time.Unix(startUnix, 0).UTC(), time.Unix(endUnix, 0).UTC(), limit)
 		if err != nil {
 			return err
 		}
-		defer rows.Close()
-		ids := make([]string, 0, limit)
-		for rows.Next() {
-			var id string
-			if err := rows.Scan(&id); err != nil {
-				return err
-			}
-			ids = append(ids, id)
-		}
-		if err := rows.Err(); err != nil {
-			return err
-		}
-		wars, err := deps.Store.WarArchive.LoadIDs(c.UserContext(), deps.Store.SQL, ids)
+		wars, err := loadWars(c.UserContext(), ids)
 		if err != nil {
 			return err
 		}
@@ -198,6 +225,35 @@ func playerWarHits(deps apptypes.Deps) fiber.Handler {
 		}
 		return apptypes.JSON(c, http.StatusOK, legacymodels.PlayerWarHitsResponse{Items: items})
 	}
+}
+
+func queryPlayerWarIDs(ctx context.Context, db warQueryDB, tag string, start, end time.Time, limit int) ([]string, error) {
+	rows, err := db.Query(ctx, `
+			SELECT selected.war_id::text
+			FROM player_war_history AS history
+			CROSS JOIN LATERAL unnest(history.war_ids) AS selected(war_id)
+			JOIN wars AS war ON war.war_id = selected.war_id
+			WHERE history.player_tag = $1
+			  AND war.prep_time >= $2 AND war.prep_time <= $3
+			ORDER BY war.prep_time DESC, war.war_id DESC
+			LIMIT $4
+		`, tag, start, end, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := make([]string, 0, limit)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func buildPlayerWarHit(playerTag string, war wararchive.War) (legacymodels.PlayerWarHit, bool) {

--- a/internal/routes/legacy_clan.go
+++ b/internal/routes/legacy_clan.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
-	"time"
 
 	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
@@ -66,42 +65,6 @@ func clanRecordsHandler(a apptypes.Deps, load clanRecordsLoader) fiber.Handler {
 			records = &modelsv2.ClanBasicRecords{}
 		}
 		return apptypes.JSON(c, fiber.StatusOK, records)
-	}
-}
-
-// legacyClanJoinLeave godoc
-// @Summary Get clan join-leave history
-// @Description Returns tracked join and leave events for a clan.
-// @Tags Legacy Clans
-// @Produce json
-// @Param clan_tag path string true "Clan tag"
-// @Param timestamp_start query int false "Start Unix timestamp"
-// @Param time_stamp_end query int false "End Unix timestamp"
-// @Success 200 {object} map[string]interface{}
-// @Failure 500 {object} modelsv2.ErrorResponse
-func legacyClanJoinLeave(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		start := time.Unix(legacyClanParseInt64Default(c.Query("timestamp_start"), 0), 0).UTC()
-		end := time.Unix(legacyClanParseInt64Default(c.Query("time_stamp_end"), 9999999999), 0).UTC()
-		rows, err := a.Store.SQL.Query(c.UserContext(), `
-			SELECT "time", "type", clan_tag, player_tag, player_name, townhall_level
-			FROM join_leave_history
-			WHERE clan_tag = $1 AND "time" >= $2 AND "time" <= $3
-			ORDER BY "time" DESC
-		`, legacyClanFixTag(c.Params("clan_tag")), start, end)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		items := []map[string]any{}
-		for rows.Next() {
-			item, err := scanJoinLeaveRow(rows)
-			if err != nil {
-				return err
-			}
-			items = append(items, item)
-		}
-		return apptypes.JSON(c, fiber.StatusOK, map[string]any{"items": items})
 	}
 }
 
@@ -412,26 +375,6 @@ func v2BasicClanRecords(c *fiber.Ctx, a apptypes.Deps, tag string) (*modelsv2.Cl
 		return nil, nil
 	}
 	return &records, nil
-}
-
-func scanJoinLeaveRow(row basicClanScanner) (map[string]any, error) {
-	var eventTime time.Time
-	var eventType, clanTag, playerTag string
-	var playerName pgtype.Text
-	var townhall int16
-	if err := row.Scan(&eventTime, &eventType, &clanTag, &playerTag, &playerName, &townhall); err != nil {
-		return nil, err
-	}
-	item := map[string]any{}
-	item["time"] = eventTime
-	item["type"] = eventType
-	item["clan"] = clanTag
-	item["tag"] = playerTag
-	item["th"] = townhall
-	if playerName.Valid {
-		item["name"] = playerName.String
-	}
-	return item, nil
 }
 
 func memberTagsToList(tags []string) []map[string]any {

--- a/internal/routes/legacy_player.go
+++ b/internal/routes/legacy_player.go
@@ -3,13 +3,11 @@ package routes
 import (
 	"net/http"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
 	"github.com/gofiber/fiber/v2"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 var v1PlayerTagRe = regexp.MustCompile(`[^A-Z0-9]+`)
@@ -44,23 +42,6 @@ func parseYearMonth(yearStr, monthStr string, year, month *int) (bool, error) {
 	return true, nil
 }
 
-// legacyPlayerWarhits godoc
-// @Summary Get player war hits
-// @Description Returns recent war attacks and defenses for a player.
-// @Tags Legacy Player
-// @Produce json
-// @Param player_tag path string true "Player tag"
-// @Param timestamp_start query int false "Start Unix timestamp"
-// @Param timestamp_end query int false "End Unix timestamp"
-// @Param limit query int false "Maximum number of rows"
-// @Success 200 {object} map[string]interface{}
-// @Failure 500 {object} modelsv2.ErrorResponse
-func legacyPlayerWarhits(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		return playerWarAttacks(a)(c)
-	}
-}
-
 // playerWartimer godoc
 // @Summary Get player war timer
 // @Description Returns current war timer data for a player when available.
@@ -75,63 +56,6 @@ func playerWartimer(a apptypes.Deps) fiber.Handler {
 			return apptypes.JSON(c, http.StatusOK, nil)
 		}
 		return apptypes.JSON(c, http.StatusOK, result)
-	}
-}
-
-// legacyPlayerJoinLeave godoc
-// @Summary Get player join-leave history
-// @Description Returns tracked join and leave events for a player.
-// @Tags Legacy Player
-// @Produce json
-// @Param player_tag path string true "Player tag"
-// @Param timestamp_start query int false "Start Unix timestamp"
-// @Param time_stamp_end query int false "End Unix timestamp"
-// @Param limit query int false "Maximum number of rows"
-// @Success 200 {object} map[string]interface{}
-// @Failure 500 {object} modelsv2.ErrorResponse
-func legacyPlayerJoinLeave(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		tag := fixTag(c.Params("player_tag"))
-		start := time.Unix(queryInt64(c, "timestamp_start", 0), 0).UTC()
-		end := time.Unix(queryInt64(c, "time_stamp_end", 9999999999), 0).UTC()
-		limit := queryInt(c, "limit", 250)
-		rows, err := a.Store.SQL.Query(c.UserContext(), `
-			SELECT jl."time", jl."type", jl.clan_tag, jl.player_tag, jl.player_name, jl.townhall_level,
-				bc.name AS clan_name
-			FROM join_leave_history jl
-			LEFT JOIN basic_clan bc ON bc.tag = jl.clan_tag
-			WHERE jl.player_tag = $1 AND jl."time" >= $2 AND jl."time" <= $3
-			ORDER BY jl."time" DESC
-			LIMIT $4
-		`, tag, start, end, limit)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		items := []map[string]any{}
-		for rows.Next() {
-			var eventTime time.Time
-			var eventType, clanTag, playerTag string
-			var playerName, clanName pgtype.Text
-			var townhall int16
-			if err := rows.Scan(&eventTime, &eventType, &clanTag, &playerTag, &playerName, &townhall, &clanName); err != nil {
-				return err
-			}
-			item := map[string]any{}
-			item["time"] = eventTime
-			item["type"] = eventType
-			item["clan"] = clanTag
-			item["tag"] = playerTag
-			item["th"] = townhall
-			if playerName.Valid {
-				item["name"] = playerName.String
-			}
-			if clanName.Valid {
-				item["clan_name"] = clanName.String
-			}
-			items = append(items, item)
-		}
-		return apptypes.JSON(c, http.StatusOK, map[string]any{"items": items})
 	}
 }
 
@@ -163,19 +87,6 @@ func queryInt64(c *fiber.Ctx, key string, def int64) int64 {
 		v = v*10 + int64(ch-'0')
 	}
 	return v
-}
-
-func sortedJoin(a, b string) string {
-	if a < b {
-		return a + "-" + b
-	}
-	return b + "-" + a
-}
-
-func sortWarsByEndTime(wars []map[string]any) {
-	sort.SliceStable(wars, func(i, j int) bool {
-		return stringValue(wars[i]["endTime"]) > stringValue(wars[j]["endTime"])
-	})
 }
 
 const currentWarTimerQuery = `
@@ -215,39 +126,6 @@ func currentWarTimerResponse(row currentWarTimerScanner, tag string) (map[string
 		"unix_time": endTime.Unix(),
 		"time":      endTime.UTC().Format(time.RFC3339),
 	}, nil
-}
-
-func scanWarAttackRow(row interface{ Scan(dest ...any) error }, playerTag string) (map[string]any, error) {
-	var warID, warType, attackingClan, defendingClan, attacker, defender string
-	var warEnd time.Time
-	var warSize int
-	var attackerTH, defenderTH int16
-	var stars, destruction int16
-	var duration, order int
-	if err := row.Scan(&warID, &warEnd, &warType, &warSize, &attackingClan, &defendingClan, &attacker, &defender, &attackerTH, &defenderTH, &stars, &destruction, &duration, &order); err != nil {
-		return nil, err
-	}
-	attack := map[string]any{
-		"war_id": warID, "war_end_time": warEnd, "war_type": warType, "war_size": warSize,
-		"attackerTag": attacker, "defenderTag": defender, "stars": stars,
-		"destructionPercentage": destruction, "duration": duration, "order": order,
-	}
-	item := map[string]any{
-		"war_data": map[string]any{
-			"war_id": warID, "endTime": warEnd, "type": warType, "teamSize": warSize,
-			"clan": map[string]any{"tag": attackingClan}, "opponent": map[string]any{"tag": defendingClan},
-		},
-		"member_data": map[string]any{"tag": playerTag},
-		"attacks":     []map[string]any{},
-		"defenses":    []map[string]any{},
-	}
-	if attacker == playerTag {
-		item["attacks"] = []map[string]any{attack}
-	}
-	if defender == playerTag {
-		item["defenses"] = []map[string]any{attack}
-	}
-	return item, nil
 }
 
 func seasonBounds(season string) (time.Time, time.Time, error) {

--- a/internal/routes/register.go
+++ b/internal/routes/register.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	legacyroutes "github.com/ClashKingInc/ClashKingAPI/internal/routes/legacy"
 	serverroutes "github.com/ClashKingInc/ClashKingAPI/internal/routes/server"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
 	"github.com/gofiber/fiber/v2"
@@ -358,6 +359,7 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 }
 
 func registerCompatibilityRoutes(app *fiber.App, a apptypes.Deps) {
+	legacyroutes.Register(app, a)
 	app.Get("/global/counts", globalCounts(a))
 	app.Get("/builderbaseleagues", builderBaseLeagues())
 

--- a/internal/routes/register_test.go
+++ b/internal/routes/register_test.go
@@ -29,7 +29,6 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 		"/capital/:clan_tag",
 		"/clan/:clan_tag/basic",
 		"/clan/:clan_tag/wars",
-		"/clan/:clan_tag/join-leave",
 		"/clan/search",
 		"/clan/:clan_tag/historical",
 		"/legends/clan/:clan_tag/:date",
@@ -39,14 +38,12 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 		"/player/:player_tag/stats",
 		"/player/:player_tag/legends",
 		"/player/:player_tag/historical/:season",
-		"/player/:player_tag/warhits",
 		"/player/:player_tag/war/attacks",
 		"/player/:player_tag/war/stats",
 		"/player/:player_tag/raids",
 		"/player/to-do",
 		"/player/:player_tag/legend_rankings",
 		"/player/:player_tag/wartimer",
-		"/player/:player_tag/join-leave",
 		"/player/search/:name",
 		"/player/full-search/:name",
 		"/v2/capital/player-stats",
@@ -138,8 +135,6 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 		"/v2/player/:player_tag/stat-history",
 		"/global/war/townhall/:townhall_level/hitrate/weekly",
 		"/global/war/completed/daily",
-		"/war/:clan_tag/previous",
-		"/war/:clan_tag/previous/:end_time",
 		"/v2/war/:clan_tag/previous",
 		"/v2/cwl/leagues/:league_id/rankings",
 		"/v2/cwl/league-thresholds",
@@ -157,8 +152,6 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 		"/v2/search/player",
 		"/war/:clanTag/previous",
 		"/war/:clanTag/basic",
-		"/cwl/:clanTag/group",
-		"/cwl/:clanTag/:season",
 	} {
 		if paths[path] {
 			t.Fatalf("expected %s to be absent from registered routes", path)
@@ -166,6 +159,13 @@ func TestRegisterOmitsRemovedRoutesAndKeepsV2Routes(t *testing.T) {
 	}
 
 	for _, path := range []string{
+		"/clan/:clan_tag/join-leave",
+		"/player/:player_tag/join-leave",
+		"/player/:player_tag/warhits",
+		"/war/:clan_tag/previous",
+		"/war/:clan_tag/previous/:end_time",
+		"/cwl/:clan_tag/group",
+		"/cwl/:clan_tag/:season",
 		"/v2/clan/:clan_tag/join-leave",
 		"/v2/player/:player_tag/join-leave",
 		"/v2/player/:player_tag/war/attacks",

--- a/internal/swaggerdocs/openapi.json
+++ b/internal/swaggerdocs/openapi.json
@@ -1,6 +1,344 @@
 {
   "components": {
     "schemas": {
+      "legacy.BadgeURLs": {
+        "properties": {
+          "large": {
+            "type": "string"
+          },
+          "medium": {
+            "type": "string"
+          },
+          "small": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLClan": {
+        "properties": {
+          "badgeUrls": {
+            "$ref": "#/components/schemas/legacy.BadgeURLs"
+          },
+          "clanLevel": {
+            "type": "integer"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.CWLMember"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLGroup": {
+        "properties": {
+          "clans": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.CWLClan"
+            },
+            "type": "array"
+          },
+          "rounds": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.CWLRound"
+            },
+            "type": "array"
+          },
+          "season": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLGroupEnvelope": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/legacy.CWLGroup"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLMember": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "townHallLevel": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLRound": {
+        "properties": {
+          "warTags": {
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.JoinLeaveEvent": {
+        "properties": {
+          "clan": {
+            "type": "string"
+          },
+          "clan_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "th": {
+            "type": "integer"
+          },
+          "time": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.JoinLeaveResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.JoinLeaveEvent"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.PlayerWarHit": {
+        "properties": {
+          "attacks": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarHitAttack"
+            },
+            "type": "array"
+          },
+          "defenses": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarHitAttack"
+            },
+            "type": "array"
+          },
+          "member_data": {
+            "$ref": "#/components/schemas/legacy.WarMember"
+          },
+          "war_data": {
+            "$ref": "#/components/schemas/legacy.War"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.PlayerWarHitsResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.PlayerWarHit"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.War": {
+        "properties": {
+          "attacksPerMember": {
+            "type": "integer"
+          },
+          "battleModifier": {
+            "type": "string"
+          },
+          "clan": {
+            "$ref": "#/components/schemas/legacy.WarClan"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "opponent": {
+            "$ref": "#/components/schemas/legacy.WarClan"
+          },
+          "preparationStartTime": {
+            "type": "string"
+          },
+          "season": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "teamSize": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "warStartTime": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarAttack": {
+        "properties": {
+          "attackerTag": {
+            "type": "string"
+          },
+          "defenderTag": {
+            "type": "string"
+          },
+          "destructionPercentage": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "integer"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "stars": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarClan": {
+        "properties": {
+          "attacks": {
+            "type": "integer"
+          },
+          "badgeUrls": {
+            "$ref": "#/components/schemas/legacy.BadgeURLs"
+          },
+          "clanLevel": {
+            "type": "integer"
+          },
+          "destructionPercentage": {
+            "type": "number"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarMember"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "stars": {
+            "type": "integer"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarHitAttack": {
+        "properties": {
+          "attack_order": {
+            "type": "integer"
+          },
+          "attacker": {
+            "$ref": "#/components/schemas/legacy.WarMember"
+          },
+          "attackerTag": {
+            "type": "string"
+          },
+          "defender": {
+            "$ref": "#/components/schemas/legacy.WarMember"
+          },
+          "defenderTag": {
+            "type": "string"
+          },
+          "destructionPercentage": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "integer"
+          },
+          "fresh": {
+            "type": "boolean"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "stars": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.War"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarMember": {
+        "properties": {
+          "attacks": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarAttack"
+            },
+            "type": "array"
+          },
+          "bestOpponentAttack": {
+            "$ref": "#/components/schemas/legacy.WarAttack"
+          },
+          "mapPosition": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "opponentAttacks": {
+            "type": "integer"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "townhallLevel": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "modelsv2.AccountConflictErrorResponse": {
         "properties": {
           "account": {
@@ -9557,6 +9895,151 @@
         ]
       }
     },
+    "/clan/{clan_tag}/join-leave": {
+      "get": {
+        "description": "Legacy v1-compatible tracked clan membership events.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "time_stamp_end",
+            "schema": {
+              "default": 9999999999,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum events",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 250,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.JoinLeaveResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Clan join and leave history",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/cwl/{clan_tag}/group": {
+      "get": {
+        "description": "Legacy v1-compatible Mongo-style CWL group envelope. Returns null when unavailable.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.CWLGroupEnvelope"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Current-season CWL group for a clan",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/cwl/{clan_tag}/{season}": {
+      "get": {
+        "description": "Legacy v1-compatible CWL group with round war tags expanded into stored wars.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Season in YYYY-MM or date form",
+            "in": "path",
+            "name": "season",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.CWLGroup"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "CWL information for a clan in a season",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
     "/global/counts": {
       "get": {
         "description": "Returns global tracking counts used by legacy clients.",
@@ -9575,6 +10058,125 @@
         "summary": "Get global ClashKing counts",
         "tags": [
           "Global"
+        ]
+      }
+    },
+    "/player/{player_tag}/join-leave": {
+      "get": {
+        "description": "Legacy v1-compatible tracked player membership events.",
+        "parameters": [
+          {
+            "description": "Player tag",
+            "in": "path",
+            "name": "player_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "time_stamp_end",
+            "schema": {
+              "default": 9999999999,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum source events",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 250,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.JoinLeaveResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Player join and leave history",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/player/{player_tag}/warhits": {
+      "get": {
+        "description": "Legacy v1-compatible war-grouped player history.",
+        "parameters": [
+          {
+            "description": "Player tag",
+            "in": "path",
+            "name": "player_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time start",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time end",
+            "in": "query",
+            "name": "timestamp_end",
+            "schema": {
+              "default": 2527625513,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum wars",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 50,
+              "maximum": 100,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.PlayerWarHitsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "War attacks and defenses for a player",
+        "tags": [
+          "Legacy"
         ]
       }
     },
@@ -26282,6 +26884,119 @@
           "War \u0026 CWL"
         ]
       }
+    },
+    "/war/{clan_tag}/previous": {
+      "get": {
+        "description": "Legacy v1-compatible stored full-war history.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time start",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time end",
+            "in": "query",
+            "name": "timestamp_end",
+            "schema": {
+              "default": 9999999999,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum wars",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 50,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.WarListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Previous wars for a clan",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/war/{clan_tag}/previous/{end_time}": {
+      "get": {
+        "description": "Legacy v1-compatible lookup within five minutes of the supplied Clash timestamp.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End time in Clash format",
+            "in": "path",
+            "name": "end_time",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.War"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Previous war at an end time",
+        "tags": [
+          "Legacy"
+        ]
+      }
     }
   },
   "tags": [
@@ -26353,6 +27068,9 @@
     },
     {
       "name": "Global"
+    },
+    {
+      "name": "Legacy"
     },
     {
       "name": "Mobile App"

--- a/internal/swaggerdocs/openapi.scalar.json
+++ b/internal/swaggerdocs/openapi.scalar.json
@@ -1,6 +1,344 @@
 {
   "components": {
     "schemas": {
+      "legacy.BadgeURLs": {
+        "properties": {
+          "large": {
+            "type": "string"
+          },
+          "medium": {
+            "type": "string"
+          },
+          "small": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLClan": {
+        "properties": {
+          "badgeUrls": {
+            "$ref": "#/components/schemas/legacy.BadgeURLs"
+          },
+          "clanLevel": {
+            "type": "integer"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.CWLMember"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLGroup": {
+        "properties": {
+          "clans": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.CWLClan"
+            },
+            "type": "array"
+          },
+          "rounds": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.CWLRound"
+            },
+            "type": "array"
+          },
+          "season": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLGroupEnvelope": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/legacy.CWLGroup"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLMember": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "townHallLevel": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.CWLRound": {
+        "properties": {
+          "warTags": {
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.JoinLeaveEvent": {
+        "properties": {
+          "clan": {
+            "type": "string"
+          },
+          "clan_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "th": {
+            "type": "integer"
+          },
+          "time": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.JoinLeaveResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.JoinLeaveEvent"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.PlayerWarHit": {
+        "properties": {
+          "attacks": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarHitAttack"
+            },
+            "type": "array"
+          },
+          "defenses": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarHitAttack"
+            },
+            "type": "array"
+          },
+          "member_data": {
+            "$ref": "#/components/schemas/legacy.WarMember"
+          },
+          "war_data": {
+            "$ref": "#/components/schemas/legacy.War"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.PlayerWarHitsResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.PlayerWarHit"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.War": {
+        "properties": {
+          "attacksPerMember": {
+            "type": "integer"
+          },
+          "battleModifier": {
+            "type": "string"
+          },
+          "clan": {
+            "$ref": "#/components/schemas/legacy.WarClan"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "opponent": {
+            "$ref": "#/components/schemas/legacy.WarClan"
+          },
+          "preparationStartTime": {
+            "type": "string"
+          },
+          "season": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "teamSize": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "warStartTime": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarAttack": {
+        "properties": {
+          "attackerTag": {
+            "type": "string"
+          },
+          "defenderTag": {
+            "type": "string"
+          },
+          "destructionPercentage": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "integer"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "stars": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarClan": {
+        "properties": {
+          "attacks": {
+            "type": "integer"
+          },
+          "badgeUrls": {
+            "$ref": "#/components/schemas/legacy.BadgeURLs"
+          },
+          "clanLevel": {
+            "type": "integer"
+          },
+          "destructionPercentage": {
+            "type": "number"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarMember"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "stars": {
+            "type": "integer"
+          },
+          "tag": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarHitAttack": {
+        "properties": {
+          "attack_order": {
+            "type": "integer"
+          },
+          "attacker": {
+            "$ref": "#/components/schemas/legacy.WarMember"
+          },
+          "attackerTag": {
+            "type": "string"
+          },
+          "defender": {
+            "$ref": "#/components/schemas/legacy.WarMember"
+          },
+          "defenderTag": {
+            "type": "string"
+          },
+          "destructionPercentage": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "integer"
+          },
+          "fresh": {
+            "type": "boolean"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "stars": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.War"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "legacy.WarMember": {
+        "properties": {
+          "attacks": {
+            "items": {
+              "$ref": "#/components/schemas/legacy.WarAttack"
+            },
+            "type": "array"
+          },
+          "bestOpponentAttack": {
+            "$ref": "#/components/schemas/legacy.WarAttack"
+          },
+          "mapPosition": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "opponentAttacks": {
+            "type": "integer"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "townhallLevel": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "modelsv2.AccountConflictErrorResponse": {
         "properties": {
           "account": {
@@ -9557,6 +9895,151 @@
         ]
       }
     },
+    "/clan/{clan_tag}/join-leave": {
+      "get": {
+        "description": "Legacy v1-compatible tracked clan membership events.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "time_stamp_end",
+            "schema": {
+              "default": 9999999999,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum events",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 250,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.JoinLeaveResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Clan join and leave history",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/cwl/{clan_tag}/group": {
+      "get": {
+        "description": "Legacy v1-compatible Mongo-style CWL group envelope. Returns null when unavailable.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.CWLGroupEnvelope"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Current-season CWL group for a clan",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/cwl/{clan_tag}/{season}": {
+      "get": {
+        "description": "Legacy v1-compatible CWL group with round war tags expanded into stored wars.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Season in YYYY-MM or date form",
+            "in": "path",
+            "name": "season",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.CWLGroup"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "CWL information for a clan in a season",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
     "/global/counts": {
       "get": {
         "description": "Returns global tracking counts used by legacy clients.",
@@ -9575,6 +10058,125 @@
         "summary": "Get global ClashKing counts",
         "tags": [
           "Global"
+        ]
+      }
+    },
+    "/player/{player_tag}/join-leave": {
+      "get": {
+        "description": "Legacy v1-compatible tracked player membership events.",
+        "parameters": [
+          {
+            "description": "Player tag",
+            "in": "path",
+            "name": "player_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive Unix timestamp",
+            "in": "query",
+            "name": "time_stamp_end",
+            "schema": {
+              "default": 9999999999,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum source events",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 250,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.JoinLeaveResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Player join and leave history",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/player/{player_tag}/warhits": {
+      "get": {
+        "description": "Legacy v1-compatible war-grouped player history.",
+        "parameters": [
+          {
+            "description": "Player tag",
+            "in": "path",
+            "name": "player_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time start",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time end",
+            "in": "query",
+            "name": "timestamp_end",
+            "schema": {
+              "default": 2527625513,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum wars",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 50,
+              "maximum": 100,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.PlayerWarHitsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "War attacks and defenses for a player",
+        "tags": [
+          "Legacy"
         ]
       }
     },
@@ -26288,6 +26890,119 @@
           "War \u0026 CWL"
         ]
       }
+    },
+    "/war/{clan_tag}/previous": {
+      "get": {
+        "description": "Legacy v1-compatible stored full-war history.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time start",
+            "in": "query",
+            "name": "timestamp_start",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Inclusive preparation-time end",
+            "in": "query",
+            "name": "timestamp_end",
+            "schema": {
+              "default": 9999999999,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum wars",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 50,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.WarListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Previous wars for a clan",
+        "tags": [
+          "Legacy"
+        ]
+      }
+    },
+    "/war/{clan_tag}/previous/{end_time}": {
+      "get": {
+        "description": "Legacy v1-compatible lookup within five minutes of the supplied Clash timestamp.",
+        "parameters": [
+          {
+            "description": "Clan tag",
+            "in": "path",
+            "name": "clan_tag",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End time in Clash format",
+            "in": "path",
+            "name": "end_time",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/legacy.War"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "summary": "Previous war at an end time",
+        "tags": [
+          "Legacy"
+        ]
+      }
     }
   },
   "tags": [
@@ -26359,6 +27074,9 @@
     },
     {
       "name": "Global"
+    },
+    {
+      "name": "Legacy"
     },
     {
       "name": "Mobile App"

--- a/internal/swaggerdocs/openapi.yaml
+++ b/internal/swaggerdocs/openapi.yaml
@@ -1,5 +1,225 @@
 components:
     schemas:
+        legacy.BadgeURLs:
+            properties:
+                large:
+                    type: string
+                medium:
+                    type: string
+                small:
+                    type: string
+            type: object
+        legacy.CWLClan:
+            properties:
+                badgeUrls:
+                    $ref: '#/components/schemas/legacy.BadgeURLs'
+                clanLevel:
+                    type: integer
+                members:
+                    items:
+                        $ref: '#/components/schemas/legacy.CWLMember'
+                    type: array
+                name:
+                    type: string
+                tag:
+                    type: string
+            type: object
+        legacy.CWLGroup:
+            properties:
+                clans:
+                    items:
+                        $ref: '#/components/schemas/legacy.CWLClan'
+                    type: array
+                rounds:
+                    items:
+                        $ref: '#/components/schemas/legacy.CWLRound'
+                    type: array
+                season:
+                    type: string
+                state:
+                    type: string
+            type: object
+        legacy.CWLGroupEnvelope:
+            properties:
+                data:
+                    $ref: '#/components/schemas/legacy.CWLGroup'
+            type: object
+        legacy.CWLMember:
+            properties:
+                name:
+                    type: string
+                tag:
+                    type: string
+                townHallLevel:
+                    type: integer
+            type: object
+        legacy.CWLRound:
+            properties:
+                warTags:
+                    items:
+                        type: object
+                    type: array
+            type: object
+        legacy.JoinLeaveEvent:
+            properties:
+                clan:
+                    type: string
+                clan_name:
+                    type: string
+                name:
+                    type: string
+                tag:
+                    type: string
+                th:
+                    type: integer
+                time:
+                    type: string
+                type:
+                    type: string
+            type: object
+        legacy.JoinLeaveResponse:
+            properties:
+                items:
+                    items:
+                        $ref: '#/components/schemas/legacy.JoinLeaveEvent'
+                    type: array
+            type: object
+        legacy.PlayerWarHit:
+            properties:
+                attacks:
+                    items:
+                        $ref: '#/components/schemas/legacy.WarHitAttack'
+                    type: array
+                defenses:
+                    items:
+                        $ref: '#/components/schemas/legacy.WarHitAttack'
+                    type: array
+                member_data:
+                    $ref: '#/components/schemas/legacy.WarMember'
+                war_data:
+                    $ref: '#/components/schemas/legacy.War'
+            type: object
+        legacy.PlayerWarHitsResponse:
+            properties:
+                items:
+                    items:
+                        $ref: '#/components/schemas/legacy.PlayerWarHit'
+                    type: array
+            type: object
+        legacy.War:
+            properties:
+                attacksPerMember:
+                    type: integer
+                battleModifier:
+                    type: string
+                clan:
+                    $ref: '#/components/schemas/legacy.WarClan'
+                endTime:
+                    type: string
+                opponent:
+                    $ref: '#/components/schemas/legacy.WarClan'
+                preparationStartTime:
+                    type: string
+                season:
+                    type: string
+                startTime:
+                    type: string
+                state:
+                    type: string
+                tag:
+                    type: string
+                teamSize:
+                    type: integer
+                type:
+                    type: string
+                warStartTime:
+                    type: string
+            type: object
+        legacy.WarAttack:
+            properties:
+                attackerTag:
+                    type: string
+                defenderTag:
+                    type: string
+                destructionPercentage:
+                    type: integer
+                duration:
+                    type: integer
+                order:
+                    type: integer
+                stars:
+                    type: integer
+            type: object
+        legacy.WarClan:
+            properties:
+                attacks:
+                    type: integer
+                badgeUrls:
+                    $ref: '#/components/schemas/legacy.BadgeURLs'
+                clanLevel:
+                    type: integer
+                destructionPercentage:
+                    type: number
+                members:
+                    items:
+                        $ref: '#/components/schemas/legacy.WarMember'
+                    type: array
+                name:
+                    type: string
+                stars:
+                    type: integer
+                tag:
+                    type: string
+            type: object
+        legacy.WarHitAttack:
+            properties:
+                attack_order:
+                    type: integer
+                attacker:
+                    $ref: '#/components/schemas/legacy.WarMember'
+                attackerTag:
+                    type: string
+                defender:
+                    $ref: '#/components/schemas/legacy.WarMember'
+                defenderTag:
+                    type: string
+                destructionPercentage:
+                    type: integer
+                duration:
+                    type: integer
+                fresh:
+                    type: boolean
+                order:
+                    type: integer
+                stars:
+                    type: integer
+            type: object
+        legacy.WarListResponse:
+            properties:
+                items:
+                    items:
+                        $ref: '#/components/schemas/legacy.War'
+                    type: array
+            type: object
+        legacy.WarMember:
+            properties:
+                attacks:
+                    items:
+                        $ref: '#/components/schemas/legacy.WarAttack'
+                    type: array
+                bestOpponentAttack:
+                    $ref: '#/components/schemas/legacy.WarAttack'
+                mapPosition:
+                    type: integer
+                name:
+                    type: string
+                opponentAttacks:
+                    type: integer
+                tag:
+                    type: string
+                townhallLevel:
+                    type: integer
+            type: object
         modelsv2.AccountConflictErrorResponse:
             properties:
                 account:
@@ -6285,6 +6505,98 @@ paths:
             summary: Get builder base leagues
             tags:
                 - Other
+    /clan/{clan_tag}/join-leave:
+        get:
+            description: Legacy v1-compatible tracked clan membership events.
+            parameters:
+                - description: Clan tag
+                  in: path
+                  name: clan_tag
+                  required: true
+                  schema:
+                    type: string
+                - description: Inclusive Unix timestamp
+                  in: query
+                  name: timestamp_start
+                  schema:
+                    default: 0
+                    type: integer
+                - description: Inclusive Unix timestamp
+                  in: query
+                  name: time_stamp_end
+                  schema:
+                    default: 9.999999999e+09
+                    type: integer
+                - description: Maximum events
+                  in: query
+                  name: limit
+                  schema:
+                    default: 250
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.JoinLeaveResponse'
+                    description: OK
+            summary: Clan join and leave history
+            tags:
+                - Legacy
+    /cwl/{clan_tag}/{season}:
+        get:
+            description: Legacy v1-compatible CWL group with round war tags expanded into stored wars.
+            parameters:
+                - description: Clan tag
+                  in: path
+                  name: clan_tag
+                  required: true
+                  schema:
+                    type: string
+                - description: Season in YYYY-MM or date form
+                  in: path
+                  name: season
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.CWLGroup'
+                    description: OK
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties:
+                                    type: string
+                                type: object
+                    description: Not Found
+            summary: CWL information for a clan in a season
+            tags:
+                - Legacy
+    /cwl/{clan_tag}/group:
+        get:
+            description: Legacy v1-compatible Mongo-style CWL group envelope. Returns null when unavailable.
+            parameters:
+                - description: Clan tag
+                  in: path
+                  name: clan_tag
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.CWLGroupEnvelope'
+                    description: OK
+            summary: Current-season CWL group for a clan
+            tags:
+                - Legacy
     /global/counts:
         get:
             description: Returns global tracking counts used by legacy clients.
@@ -6298,6 +6610,83 @@ paths:
             summary: Get global ClashKing counts
             tags:
                 - Global
+    /player/{player_tag}/join-leave:
+        get:
+            description: Legacy v1-compatible tracked player membership events.
+            parameters:
+                - description: Player tag
+                  in: path
+                  name: player_tag
+                  required: true
+                  schema:
+                    type: string
+                - description: Inclusive Unix timestamp
+                  in: query
+                  name: timestamp_start
+                  schema:
+                    default: 0
+                    type: integer
+                - description: Inclusive Unix timestamp
+                  in: query
+                  name: time_stamp_end
+                  schema:
+                    default: 9.999999999e+09
+                    type: integer
+                - description: Maximum source events
+                  in: query
+                  name: limit
+                  schema:
+                    default: 250
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.JoinLeaveResponse'
+                    description: OK
+            summary: Player join and leave history
+            tags:
+                - Legacy
+    /player/{player_tag}/warhits:
+        get:
+            description: Legacy v1-compatible war-grouped player history.
+            parameters:
+                - description: Player tag
+                  in: path
+                  name: player_tag
+                  required: true
+                  schema:
+                    type: string
+                - description: Inclusive preparation-time start
+                  in: query
+                  name: timestamp_start
+                  schema:
+                    default: 0
+                    type: integer
+                - description: Inclusive preparation-time end
+                  in: query
+                  name: timestamp_end
+                  schema:
+                    default: 2.527625513e+09
+                    type: integer
+                - description: Maximum wars
+                  in: query
+                  name: limit
+                  schema:
+                    default: 50
+                    maximum: 100
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.PlayerWarHitsResponse'
+                    description: OK
+            summary: War attacks and defenses for a player
+            tags:
+                - Legacy
     /v2/achievements/check:
         post:
             description: Checks verified linked players for achievements that can currently be evaluated, awards new matches, and returns the full catalog.
@@ -16510,6 +16899,78 @@ paths:
             summary: Find a stored war by end time
             tags:
                 - War & CWL
+    /war/{clan_tag}/previous:
+        get:
+            description: Legacy v1-compatible stored full-war history.
+            parameters:
+                - description: Clan tag
+                  in: path
+                  name: clan_tag
+                  required: true
+                  schema:
+                    type: string
+                - description: Inclusive preparation-time start
+                  in: query
+                  name: timestamp_start
+                  schema:
+                    default: 0
+                    type: integer
+                - description: Inclusive preparation-time end
+                  in: query
+                  name: timestamp_end
+                  schema:
+                    default: 9.999999999e+09
+                    type: integer
+                - description: Maximum wars
+                  in: query
+                  name: limit
+                  schema:
+                    default: 50
+                    type: integer
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.WarListResponse'
+                    description: OK
+            summary: Previous wars for a clan
+            tags:
+                - Legacy
+    /war/{clan_tag}/previous/{end_time}:
+        get:
+            description: Legacy v1-compatible lookup within five minutes of the supplied Clash timestamp.
+            parameters:
+                - description: Clan tag
+                  in: path
+                  name: clan_tag
+                  required: true
+                  schema:
+                    type: string
+                - description: End time in Clash format
+                  in: path
+                  name: end_time
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/legacy.War'
+                    description: OK
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties:
+                                    type: string
+                                type: object
+                    description: Not Found
+            summary: Previous war at an end time
+            tags:
+                - Legacy
 tags:
     - name: Player
     - name: Clan
@@ -16534,6 +16995,7 @@ tags:
     - name: Dashboard Access
     - name: Enums
     - name: Global
+    - name: Legacy
     - name: Mobile App
     - name: Notifications
     - name: Public Rosters

--- a/test/api/swagger_test.go
+++ b/test/api/swagger_test.go
@@ -404,7 +404,6 @@ func TestBuildDocOmitsRemovedRoutesAndKeepsV2JoinLeave(t *testing.T) {
 		"/clan/{clan_tag}/badge",
 		"/clan/{clan_tag}/basic",
 		"/clan/{clan_tag}/wars",
-		"/clan/{clan_tag}/join-leave",
 		"/clan/search",
 		"/clan/{clan_tag}/historical",
 		"/capital",
@@ -422,14 +421,12 @@ func TestBuildDocOmitsRemovedRoutesAndKeepsV2JoinLeave(t *testing.T) {
 		"/player/search/{name}",
 		"/player/to-do",
 		"/player/{player_tag}/historical/{season}",
-		"/player/{player_tag}/join-leave",
 		"/player/{player_tag}/join-leave/totals",
 		"/player/{player_tag}/join-leave/shared",
 		"/player/{player_tag}/legend_rankings",
 		"/player/{player_tag}/legends",
 		"/player/{player_tag}/raids",
 		"/player/{player_tag}/stats",
-		"/player/{player_tag}/warhits",
 		"/player/{player_tag}/war/attacks",
 		"/player/{player_tag}/war/stats",
 		"/player/{player_tag}/wartimer",
@@ -485,10 +482,6 @@ func TestBuildDocOmitsRemovedRoutesAndKeepsV2JoinLeave(t *testing.T) {
 		"/v2/static/{category}/{item_id_or_name}",
 		"/v2/{category}",
 		"/v2/static/{category}",
-		"/war/{clan_tag}/previous",
-		"/war/{clan_tag}/previous/{end_time}",
-		"/cwl/{clan_tag}/group",
-		"/cwl/{clan_tag}/{season}",
 		"/war/{clanTag}/previous",
 		"/war/{clanTag}/basic",
 		"/cwl/{clanTag}/group",
@@ -512,6 +505,13 @@ func TestBuildDocOmitsRemovedRoutesAndKeepsV2JoinLeave(t *testing.T) {
 	}
 
 	for _, path := range []string{
+		"/clan/{clan_tag}/join-leave",
+		"/player/{player_tag}/join-leave",
+		"/player/{player_tag}/warhits",
+		"/war/{clan_tag}/previous",
+		"/war/{clan_tag}/previous/{end_time}",
+		"/cwl/{clan_tag}/group",
+		"/cwl/{clan_tag}/{season}",
 		"/v2/clan/{clan_tag}/join-leave",
 		"/v2/player/{player_tag}/join-leave",
 		"/v2/player/{player_tag}/join-leave/totals",
@@ -736,6 +736,35 @@ func TestBuildDocOmitsRemovedRoutesAndKeepsV2JoinLeave(t *testing.T) {
 		if _, exists := definitions[obsoleteDefinition]; exists {
 			t.Fatalf("expected %s definition to be removed", obsoleteDefinition)
 		}
+	}
+}
+
+func TestLegacyCompatibilityRoutesStayIsolatedAndTyped(t *testing.T) {
+	doc := buildSwaggerDoc(t)
+	paths := swaggerPaths(t, doc)
+
+	want := map[string]string{
+		"/clan/{clan_tag}/join-leave":         "#/components/schemas/legacy.JoinLeaveResponse",
+		"/player/{player_tag}/join-leave":     "#/components/schemas/legacy.JoinLeaveResponse",
+		"/player/{player_tag}/warhits":        "#/components/schemas/legacy.PlayerWarHitsResponse",
+		"/war/{clan_tag}/previous":            "#/components/schemas/legacy.WarListResponse",
+		"/war/{clan_tag}/previous/{end_time}": "#/components/schemas/legacy.War",
+		"/cwl/{clan_tag}/group":               "#/components/schemas/legacy.CWLGroupEnvelope",
+		"/cwl/{clan_tag}/{season}":            "#/components/schemas/legacy.CWLGroup",
+	}
+	for path, responseRef := range want {
+		operation := paths[path].(map[string]any)["get"].(map[string]any)
+		assertTags(t, operation, []string{"Legacy"})
+		response := operation["responses"].(map[string]any)["200"].(map[string]any)
+		content := response["content"].(map[string]any)["application/json"].(map[string]any)
+		assertRef(t, content["schema"], responseRef)
+	}
+
+	if got := swaggerQueryParams(t, paths, "/player/{player_tag}/warhits"); !reflect.DeepEqual(got, []string{"timestamp_start", "timestamp_end", "limit"}) {
+		t.Fatalf("legacy warhits query params = %v", got)
+	}
+	if got := swaggerQueryParams(t, paths, "/clan/{clan_tag}/join-leave"); !reflect.DeepEqual(got, []string{"timestamp_start", "time_stamp_end", "limit"}) {
+		t.Fatalf("legacy clan join-leave query params = %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add seven Postgres-backed v1-compatible endpoints in an isolated legacy route package
- preserve legacy war-hit, join/leave, previous-war, and CWL response contracts without changing v2 handlers or models
- publish dedicated Legacy OpenAPI schemas and contract coverage

## Verification
- `go test ./...`
- `git diff --check`