### PR TITLE
fix(tracking): refine operation health observability

### DIFF
--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -23230,7 +23230,12 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "targets": {
-                    "$ref": "#/definitions/modelsv2.TrackingTargetProgress"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/modelsv2.TrackingTargetProgress"
+                        }
+                    ],
+                    "x-nullable": true
                 },
                 "timestamp": {
                     "type": "string"
@@ -23297,7 +23302,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "latest_error": {
-                    "type": "string"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/modelsv2.TrackingLatestError"
+                        }
+                    ],
+                    "x-nullable": true
                 },
                 "processing_count": {
                     "type": "integer"
@@ -23318,24 +23328,18 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "targets": {
-                    "$ref": "#/definitions/modelsv2.TrackingTargetProgress"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/modelsv2.TrackingTargetProgress"
+                        }
+                    ],
+                    "x-nullable": true
                 },
                 "write_count": {
                     "type": "integer"
                 },
                 "writes_per_second": {
                     "type": "number"
-                }
-            }
-        },
-        "modelsv2.TrackingGlobalClansProgress": {
-            "type": "object",
-            "properties": {
-                "non_priority": {
-                    "$ref": "#/definitions/modelsv2.TrackingTargetProgress"
-                },
-                "priority": {
-                    "$ref": "#/definitions/modelsv2.TrackingTargetProgress"
                 }
             }
         },
@@ -23362,6 +23366,17 @@ const docTemplate = `{
                 }
             }
         },
+        "modelsv2.TrackingLatestError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
         "modelsv2.TrackingOperationsSummaryResponse": {
             "type": "object",
             "properties": {
@@ -23373,9 +23388,6 @@ const docTemplate = `{
                 },
                 "generated_at": {
                     "type": "string"
-                },
-                "globalclans": {
-                    "$ref": "#/definitions/modelsv2.TrackingGlobalClansProgress"
                 },
                 "processes": {
                     "type": "array",

--- a/internal/models/v2/tracking_operations.go
+++ b/internal/models/v2/tracking_operations.go
@@ -46,6 +46,12 @@ type TrackingTargetProgress struct {
 	EstimatedLoopCompletion   *time.Time `json:"estimated_loop_completion,omitempty"`
 }
 
+// TrackingLatestError is the most recently reported domain error and when it was observed.
+type TrackingLatestError struct {
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // TrackingDomainState is the latest operational observation for one script/domain pair.
 type TrackingDomainState struct {
 	Script                      string                  `json:"script"`
@@ -55,7 +61,7 @@ type TrackingDomainState struct {
 	IntervalEnd                 time.Time               `json:"interval_end"`
 	IntervalDurationSeconds     float64                 `json:"interval_duration_seconds"`
 	LastSuccess                 *time.Time              `json:"last_success,omitempty"`
-	LatestError                 *string                 `json:"latest_error,omitempty"`
+	LatestError                 *TrackingLatestError    `json:"latest_error" extensions:"x-nullable"`
 	RequestCount                int64                   `json:"request_count"`
 	RequestsPerSecond           float64                 `json:"requests_per_second"`
 	ErrorCount                  int64                   `json:"error_count"`
@@ -67,22 +73,15 @@ type TrackingDomainState struct {
 	AverageProcessingDurationMS float64                 `json:"average_processing_duration_ms"`
 	QueueDepth                  int                     `json:"queue_depth"`
 	Database                    TrackingDatabaseMetrics `json:"database"`
-	Targets                     TrackingTargetProgress  `json:"targets"`
+	Targets                     *TrackingTargetProgress `json:"targets" extensions:"x-nullable"`
 	Health                      TrackingHealth          `json:"health"`
 }
 
-// TrackingGlobalClansProgress keeps the two global clan loops directly addressable.
-type TrackingGlobalClansProgress struct {
-	Priority    *TrackingTargetProgress `json:"priority,omitempty"`
-	NonPriority *TrackingTargetProgress `json:"non_priority,omitempty"`
-}
-
 type TrackingOperationsSummaryResponse struct {
-	GeneratedAt       time.Time                   `json:"generated_at"`
-	StaleAfterSeconds int                         `json:"stale_after_seconds"`
-	Processes         []TrackingProcessState      `json:"processes"`
-	Domains           []TrackingDomainState       `json:"domains"`
-	GlobalClans       TrackingGlobalClansProgress `json:"globalclans"`
+	GeneratedAt       time.Time              `json:"generated_at"`
+	StaleAfterSeconds int                    `json:"stale_after_seconds"`
+	Processes         []TrackingProcessState `json:"processes"`
+	Domains           []TrackingDomainState  `json:"domains"`
 }
 
 // TrackingProcessPoint is one bounded chart bucket for a tracking process.
@@ -117,7 +116,7 @@ type TrackingDomainPoint struct {
 	AverageProcessingDurationMS float64                 `json:"average_processing_duration_ms"`
 	QueueDepth                  int                     `json:"queue_depth"`
 	Database                    TrackingDatabaseMetrics `json:"database"`
-	Targets                     TrackingTargetProgress  `json:"targets"`
+	Targets                     *TrackingTargetProgress `json:"targets" extensions:"x-nullable"`
 	ReportedHealthy             bool                    `json:"reported_healthy"`
 }
 

--- a/internal/routes/tracking_operations.go
+++ b/internal/routes/tracking_operations.go
@@ -17,10 +17,8 @@ import (
 )
 
 const (
-	trackingStaleAfter     = 2 * time.Minute
-	trackingQueryTimeout   = 10 * time.Second
-	globalClansPriority    = "globalclans.priority"
-	globalClansNonPriority = "globalclans.non_priority"
+	trackingStaleAfter   = 2 * time.Minute
+	trackingQueryTimeout = 10 * time.Second
 )
 
 var trackingSeriesNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$`)
@@ -44,6 +42,7 @@ type trackingRawDomain struct {
 	script, name                                 string
 	lastSuccess                                  *time.Time
 	lastError                                    *string
+	lastReadyChange                              *time.Time
 	requests, writes, errors                     int64
 	requestLatencyMS                             float64
 	queueDepth                                   int
@@ -80,7 +79,7 @@ const latestTrackingDomainsQuery = `
 	WITH latest AS (
 		SELECT DISTINCT ON (script, name)
 			interval_start, interval_end, run_id, script, name, last_success,
-			last_error, requests, writes, errors, request_latency_ms, queue_depth,
+			last_error, last_ready_change, requests, writes, errors, request_latency_ms, queue_depth,
 			healthy, processing_count, total_process_time_ms, store_batches,
 			store_rows_requested, store_rows_affected, store_duration_ms,
 			target_count, target_cycle, target_processed
@@ -88,7 +87,7 @@ const latestTrackingDomainsQuery = `
 		ORDER BY script, name, interval_end DESC, run_id DESC
 	)
 	SELECT latest.interval_start, latest.interval_end, latest.run_id,
-		latest.script, latest.name, latest.last_success, latest.last_error,
+		latest.script, latest.name, latest.last_success, latest.last_error, latest.last_ready_change,
 		latest.requests, latest.writes, latest.errors, latest.request_latency_ms,
 		latest.queue_depth, latest.healthy, latest.processing_count,
 		latest.total_process_time_ms, latest.store_batches,
@@ -178,26 +177,13 @@ func trackingOperationsSummary(a apptypes.Deps) fiber.Handler {
 		if err := group.Wait(); err != nil {
 			return err
 		}
+		rollUpTrackingProcessHealth(processes, domains)
 
 		response := modelsv2.TrackingOperationsSummaryResponse{
 			GeneratedAt:       now,
 			StaleAfterSeconds: int(trackingStaleAfter / time.Second),
 			Processes:         processes,
 			Domains:           domains,
-		}
-		for index := range domains {
-			domain := &domains[index]
-			if domain.Script != "globalclans" {
-				continue
-			}
-			switch domain.Domain {
-			case globalClansPriority:
-				progress := domain.Targets
-				response.GlobalClans.Priority = &progress
-			case globalClansNonPriority:
-				progress := domain.Targets
-				response.GlobalClans.NonPriority = &progress
-			}
 		}
 		return apptypes.JSON(c, http.StatusOK, response)
 	}
@@ -340,7 +326,7 @@ func loadLatestTrackingDomains(ctx context.Context, pool *pgxpool.Pool, now time
 		var raw trackingRawDomain
 		if err := rows.Scan(
 			&raw.intervalStart, &raw.intervalEnd, &raw.runID, &raw.script, &raw.name,
-			&raw.lastSuccess, &raw.lastError, &raw.requests, &raw.writes, &raw.errors,
+			&raw.lastSuccess, &raw.lastError, &raw.lastReadyChange, &raw.requests, &raw.writes, &raw.errors,
 			&raw.requestLatencyMS, &raw.queueDepth, &raw.reportedHealthy,
 			&raw.processingCount, &raw.totalProcessTimeMS, &raw.storeBatches,
 			&raw.storeRowsRequested, &raw.storeRowsAffected, &raw.storeDurationMS,
@@ -363,6 +349,14 @@ func buildTrackingDomainState(raw trackingRawDomain, now time.Time) modelsv2.Tra
 		previous = &trackingTargetSnapshot{runID: *raw.previousRunID, count: *raw.previousTargetCount, cycle: *raw.previousTargetCycle, processed: *raw.previousTargetProcessed}
 	}
 	targetRate := safeRate(float64(trackingTargetDelta(current, previous)), durationSeconds)
+	var latestError *modelsv2.TrackingLatestError
+	if raw.lastError != nil {
+		timestamp := raw.intervalEnd
+		if raw.lastReadyChange != nil {
+			timestamp = *raw.lastReadyChange
+		}
+		latestError = &modelsv2.TrackingLatestError{Message: *raw.lastError, Timestamp: timestamp}
+	}
 	return modelsv2.TrackingDomainState{
 		Script:                      raw.script,
 		Domain:                      raw.name,
@@ -371,7 +365,7 @@ func buildTrackingDomainState(raw trackingRawDomain, now time.Time) modelsv2.Tra
 		IntervalEnd:                 raw.intervalEnd,
 		IntervalDurationSeconds:     roundMetric(durationSeconds),
 		LastSuccess:                 raw.lastSuccess,
-		LatestError:                 raw.lastError,
+		LatestError:                 latestError,
 		RequestCount:                raw.requests,
 		RequestsPerSecond:           safeRate(float64(raw.requests), durationSeconds),
 		ErrorCount:                  raw.errors,
@@ -390,6 +384,27 @@ func buildTrackingDomainState(raw trackingRawDomain, now time.Time) modelsv2.Tra
 		},
 		Targets: trackingTargetProgress(current, targetRate, now, now.Sub(raw.intervalEnd) > trackingStaleAfter),
 		Health:  trackingHealth(raw.reportedHealthy, raw.intervalEnd, now),
+	}
+}
+
+func rollUpTrackingProcessHealth(processes []modelsv2.TrackingProcessState, domains []modelsv2.TrackingDomainState) {
+	domainsHealthy := make(map[string]bool, len(processes))
+	domainsReportedHealthy := make(map[string]bool, len(processes))
+	for _, process := range processes {
+		domainsHealthy[process.Script] = true
+		domainsReportedHealthy[process.Script] = true
+	}
+	for _, domain := range domains {
+		if _, ok := domainsHealthy[domain.Script]; !ok {
+			continue
+		}
+		domainsHealthy[domain.Script] = domainsHealthy[domain.Script] && domain.Health.Healthy
+		domainsReportedHealthy[domain.Script] = domainsReportedHealthy[domain.Script] && domain.Health.ReportedHealthy
+	}
+	for index := range processes {
+		process := &processes[index]
+		process.Health.ReportedHealthy = process.Health.ReportedHealthy && domainsReportedHealthy[process.Script]
+		process.Health.Healthy = !process.Health.Stale && process.Health.Healthy && domainsHealthy[process.Script]
 	}
 }
 
@@ -424,8 +439,11 @@ func trackingTargetDelta(current trackingTargetSnapshot, previous *trackingTarge
 	return int64(previousRemainder) + completedCycles*int64(current.count) + int64(current.processed)
 }
 
-func trackingTargetProgress(snapshot trackingTargetSnapshot, rate float64, now time.Time, stale bool) modelsv2.TrackingTargetProgress {
-	progress := modelsv2.TrackingTargetProgress{
+func trackingTargetProgress(snapshot trackingTargetSnapshot, rate float64, now time.Time, stale bool) *modelsv2.TrackingTargetProgress {
+	if snapshot.count <= 0 {
+		return nil
+	}
+	progress := &modelsv2.TrackingTargetProgress{
 		TargetCount:          snapshot.count,
 		CurrentCycle:         snapshot.cycle,
 		ProcessedTargets:     snapshot.processed,

--- a/internal/routes/tracking_operations_test.go
+++ b/internal/routes/tracking_operations_test.go
@@ -1,12 +1,14 @@
 package routes
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
 	"github.com/gofiber/fiber/v2"
 )
@@ -87,10 +89,11 @@ func TestTrackingDomainCalculationsStayInAPI(t *testing.T) {
 	previousCycle := int64(2)
 	previousProcessed := 40
 	latestError := "proxy timeout"
+	latestErrorAt := now.Add(-3 * time.Second)
 	raw := trackingRawDomain{
 		intervalStart: now.Add(-10 * time.Second), intervalEnd: now,
-		runID: 1, script: "globalclans", name: globalClansPriority,
-		lastError: &latestError, requests: 50, writes: 20, errors: 5,
+		runID: 1, script: "globalclans", name: "globalclans.priority",
+		lastError: &latestError, lastReadyChange: &latestErrorAt, requests: 50, writes: 20, errors: 5,
 		requestLatencyMS: 1_000, queueDepth: 7, reportedHealthy: true,
 		processingCount: 10, totalProcessTimeMS: 500,
 		storeBatches: 4, storeRowsRequested: 30, storeRowsAffected: 28, storeDurationMS: 200,
@@ -105,11 +108,76 @@ func TestTrackingDomainCalculationsStayInAPI(t *testing.T) {
 	if got.WritesPerSecond != 2 || got.Database.AverageStoreDurationMS != 50 {
 		t.Fatalf("write/store metrics = writes/s %v, store duration %v", got.WritesPerSecond, got.Database.AverageStoreDurationMS)
 	}
-	if got.Targets.TargetsPerSecond != 1 || got.Targets.CompletionPercentage != 50 {
+	if got.Targets == nil || got.Targets.TargetsPerSecond != 1 || got.Targets.CompletionPercentage != 50 {
 		t.Fatalf("target metrics = %+v", got.Targets)
 	}
 	if got.Targets.EstimatedSecondsRemaining == nil || *got.Targets.EstimatedSecondsRemaining != 50 {
 		t.Fatalf("target ETA = %+v", got.Targets)
+	}
+	if got.LatestError == nil || got.LatestError.Message != latestError || !got.LatestError.Timestamp.Equal(latestErrorAt) {
+		t.Fatalf("latest error = %+v", got.LatestError)
+	}
+}
+
+func TestTrackingQueueOnlyDomainHasMetricsWithoutTargetProgress(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	latestError := "queue worker timeout"
+	latestErrorAt := now.Add(-5 * time.Second)
+	raw := trackingRawDomain{
+		intervalStart: now.Add(-20 * time.Second), intervalEnd: now,
+		runID: 3, script: "reminders", name: "reminders.mobile-reconciliation",
+		requests: 40, writes: 10, errors: 2, requestLatencyMS: 800,
+		queueDepth: 12, reportedHealthy: false, processingCount: 5,
+		totalProcessTimeMS: 250, targetCount: 0, lastError: &latestError,
+		lastReadyChange: &latestErrorAt,
+	}
+	got := buildTrackingDomainState(raw, now)
+	if got.Domain != raw.name || got.Targets != nil {
+		t.Fatalf("queue domain = %+v; want arbitrary name and null target progress", got)
+	}
+	if got.QueueDepth != 12 || got.ProcessingCount != 5 || got.AverageProcessingDurationMS != 50 || got.RequestsPerSecond != 2 || got.WritesPerSecond != .5 || got.ErrorCount != 2 || got.AverageRequestLatencyMS != 20 {
+		t.Fatalf("queue metrics = %+v", got)
+	}
+	if got.Health.Stale || got.Health.Healthy || got.Health.AgeSeconds != 0 || got.LatestError == nil || !got.LatestError.Timestamp.Equal(latestErrorAt) {
+		t.Fatalf("queue freshness/error = health %+v, error %+v", got.Health, got.LatestError)
+	}
+	payload, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), `"targets":null`) {
+		t.Fatalf("queue domain JSON = %s; want explicit null target progress", payload)
+	}
+}
+
+func TestTrackingArbitraryDomainNameIsPreserved(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	for _, domain := range []string{
+		"globalclans.priority", "globalclans.non_priority",
+		"war-discovery.active", "war-discovery.dormant", "war-discovery.finalization",
+		"cwl.groups", "war-archiver",
+		"reminders.events", "reminders.war-jobs", "reminders.mobile-reconciliation", "reminders.raid", "reminders.fixed",
+		"mobilepush.events", "trackedplayers", "future-domain.with_any-name",
+	} {
+		raw := trackingRawDomain{intervalStart: now.Add(-time.Second), intervalEnd: now, script: "worker", name: domain, reportedHealthy: true}
+		if got := buildTrackingDomainState(raw, now); got.Domain != domain {
+			t.Errorf("domain %q became %q", domain, got.Domain)
+		}
+	}
+}
+
+func TestTrackingDomainFailureMakesFreshProcessUnhealthy(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	processes := []modelsv2.TrackingProcessState{{
+		Script: "reminders", Health: trackingHealth(true, now, now),
+	}}
+	domains := []modelsv2.TrackingDomainState{
+		{Script: "reminders", Domain: "reminders.events", Health: trackingHealth(true, now, now)},
+		{Script: "reminders", Domain: "reminders.raid", Health: trackingHealth(false, now, now)},
+	}
+	rollUpTrackingProcessHealth(processes, domains)
+	if processes[0].Health.Healthy || processes[0].Health.Stale || processes[0].Health.ReportedHealthy {
+		t.Fatalf("fresh process with failed domain should be unhealthy: %+v", processes[0].Health)
 	}
 }
 

--- a/internal/swaggerdocs/openapi.json
+++ b/internal/swaggerdocs/openapi.json
@@ -9045,7 +9045,15 @@
             "type": "number"
           },
           "targets": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+              }
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "timestamp": {
             "type": "string"
@@ -9112,7 +9120,15 @@
             "type": "string"
           },
           "latest_error": {
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/modelsv2.TrackingLatestError"
+              }
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "processing_count": {
             "type": "integer"
@@ -9133,24 +9149,21 @@
             "type": "string"
           },
           "targets": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+              }
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "write_count": {
             "type": "integer"
           },
           "writes_per_second": {
             "type": "number"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.TrackingGlobalClansProgress": {
-        "properties": {
-          "non_priority": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
-          },
-          "priority": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
           }
         },
         "type": "object"
@@ -9178,6 +9191,17 @@
         },
         "type": "object"
       },
+      "modelsv2.TrackingLatestError": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "modelsv2.TrackingOperationsSummaryResponse": {
         "properties": {
           "domains": {
@@ -9188,9 +9212,6 @@
           },
           "generated_at": {
             "type": "string"
-          },
-          "globalclans": {
-            "$ref": "#/components/schemas/modelsv2.TrackingGlobalClansProgress"
           },
           "processes": {
             "items": {

--- a/internal/swaggerdocs/openapi.scalar.json
+++ b/internal/swaggerdocs/openapi.scalar.json
@@ -9045,7 +9045,15 @@
             "type": "number"
           },
           "targets": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+              }
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "timestamp": {
             "type": "string"
@@ -9112,7 +9120,15 @@
             "type": "string"
           },
           "latest_error": {
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/modelsv2.TrackingLatestError"
+              }
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "processing_count": {
             "type": "integer"
@@ -9133,24 +9149,21 @@
             "type": "string"
           },
           "targets": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
+              }
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "write_count": {
             "type": "integer"
           },
           "writes_per_second": {
             "type": "number"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.TrackingGlobalClansProgress": {
-        "properties": {
-          "non_priority": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
-          },
-          "priority": {
-            "$ref": "#/components/schemas/modelsv2.TrackingTargetProgress"
           }
         },
         "type": "object"
@@ -9178,6 +9191,17 @@
         },
         "type": "object"
       },
+      "modelsv2.TrackingLatestError": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "modelsv2.TrackingOperationsSummaryResponse": {
         "properties": {
           "domains": {
@@ -9188,9 +9212,6 @@
           },
           "generated_at": {
             "type": "string"
-          },
-          "globalclans": {
-            "$ref": "#/components/schemas/modelsv2.TrackingGlobalClansProgress"
           },
           "processes": {
             "items": {

--- a/internal/swaggerdocs/openapi.yaml
+++ b/internal/swaggerdocs/openapi.yaml
@@ -5949,7 +5949,11 @@ components:
                 requests_per_second:
                     type: number
                 targets:
-                    $ref: '#/components/schemas/modelsv2.TrackingTargetProgress'
+                    allOf:
+                        - $ref: '#/components/schemas/modelsv2.TrackingTargetProgress'
+                    type:
+                        - object
+                        - "null"
                 timestamp:
                     type: string
                 write_count:
@@ -5993,7 +5997,11 @@ components:
                 last_success:
                     type: string
                 latest_error:
-                    type: string
+                    allOf:
+                        - $ref: '#/components/schemas/modelsv2.TrackingLatestError'
+                    type:
+                        - object
+                        - "null"
                 processing_count:
                     type: integer
                 queue_depth:
@@ -6007,18 +6015,15 @@ components:
                 script:
                     type: string
                 targets:
-                    $ref: '#/components/schemas/modelsv2.TrackingTargetProgress'
+                    allOf:
+                        - $ref: '#/components/schemas/modelsv2.TrackingTargetProgress'
+                    type:
+                        - object
+                        - "null"
                 write_count:
                     type: integer
                 writes_per_second:
                     type: number
-            type: object
-        modelsv2.TrackingGlobalClansProgress:
-            properties:
-                non_priority:
-                    $ref: '#/components/schemas/modelsv2.TrackingTargetProgress'
-                priority:
-                    $ref: '#/components/schemas/modelsv2.TrackingTargetProgress'
             type: object
         modelsv2.TrackingHealth:
             properties:
@@ -6035,6 +6040,13 @@ components:
                 stale_after_seconds:
                     type: integer
             type: object
+        modelsv2.TrackingLatestError:
+            properties:
+                message:
+                    type: string
+                timestamp:
+                    type: string
+            type: object
         modelsv2.TrackingOperationsSummaryResponse:
             properties:
                 domains:
@@ -6043,8 +6055,6 @@ components:
                     type: array
                 generated_at:
                     type: string
-                globalclans:
-                    $ref: '#/components/schemas/modelsv2.TrackingGlobalClansProgress'
                 processes:
                     items:
                         $ref: '#/components/schemas/modelsv2.TrackingProcessState'


### PR DESCRIPTION
## Summary
- Add timestamps to latest tracking errors.
- Represent target progress as nullable for queue-only domains.
- Roll domain health failures into process health.
- Remove the global clan progress summary and preserve arbitrary domain names.
- Update generated OpenAPI documentation and coverage for the revised tracking contracts.

## Testing
- Not run (no test execution results provided).