### PR TITLE
feat(api): simplify shared link access

### DIFF
--- a/example.env
+++ b/example.env
@@ -20,7 +20,6 @@ ELASTICSEARCH_CLANS_ALIAS=clashking_clans
 # ClashKing service origins. Origins never include API path prefixes.
 CLASHKING_LANDING_ORIGIN=https://clashk.ing
 CLASHKING_DASHBOARD_ORIGIN=https://dash.clashk.ing
-CLASHKING_CONNECT_ORIGIN=https://connect.clashk.ing
 CLASHKING_APP_ORIGIN=https://app.clashk.ing
 CLASHKING_PROXY_INTERNAL_ORIGIN=http://clashking-proxy:8011
 WAR_ARCHIVE_ORIGIN=https://wars.clashk.ing

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -4299,10 +4299,10 @@ const docTemplate = `{
             "post": {
                 "security": [
                     {
-                        "ApiKeyAuth": []
+                        "DeveloperToken": []
                     }
                 ],
-                "description": "Returns Discord ID and player-tag pairs with current verification and visibility metadata when covered by active grants for the authenticated developer application. Unauthorized and nonexistent identifiers are omitted identically.",
+                "description": "Returns visible Discord ID and player-tag pairs for the requested Discord IDs, player tags, or both. Hidden and nonexistent links are omitted identically. Results include both verified and unverified links.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4310,7 +4310,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Shared Links"
+                    "Links"
                 ],
                 "summary": "Look up shared Discord links",
                 "parameters": [
@@ -4345,260 +4345,6 @@ const docTemplate = `{
                     },
                     "429": {
                         "description": "Too Many Requests",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/v2/links/shared/applications/{application_id}": {
-            "get": {
-                "description": "Returns the public application identity used by the connected-app consent page. When redirect_uri is supplied, it must exactly match the application's registered URI.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Shared Links"
-                ],
-                "summary": "Get a shared-links application",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Application ID",
-                        "name": "application_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Exact registered redirect URI",
-                        "name": "redirect_uri",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.SharedLinksApplicationResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/v2/links/shared/grants": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Returns the authenticated user's active read-only application grants.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Shared Links"
-                ],
-                "summary": "List connected shared-links applications",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.SharedLinksConnectionsResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/v2/links/shared/grants/{application_id}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Returns the active application, the authenticated user's linked accounts with verification and visibility metadata, and any current read-only grant.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Shared Links"
-                ],
-                "summary": "Get shared-links consent details",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Application ID",
-                        "name": "application_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.SharedLinksConsentResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Grants an application read access to selected linked accounts or all current and future linked accounts.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Shared Links"
-                ],
-                "summary": "Grant shared-links access",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Application ID",
-                        "name": "application_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Grant selection",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.SharedLinksGrantRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.SharedLinksGrant"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "503": {
-                        "description": "Service Unavailable",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Revokes the current user's grant and removes its stored selected-account rows. The operation is idempotent.",
-                "tags": [
-                    "Shared Links"
-                ],
-                "summary": "Revoke shared-links access",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Application ID",
-                        "name": "application_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/modelsv2.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/modelsv2.ErrorResponse"
                         }
@@ -22687,145 +22433,14 @@ const docTemplate = `{
         "modelsv2.SharedLink": {
             "type": "object",
             "properties": {
-                "discord_id": {
-                    "type": "string"
-                },
-                "hidden": {
-                    "type": "boolean"
-                },
                 "is_verified": {
                     "type": "boolean"
                 },
                 "player_tag": {
                     "type": "string"
-                }
-            }
-        },
-        "modelsv2.SharedLinksAccount": {
-            "type": "object",
-            "properties": {
-                "hidden": {
-                    "type": "boolean"
                 },
-                "is_verified": {
-                    "type": "boolean"
-                },
-                "name": {
+                "user_id": {
                     "type": "string"
-                },
-                "player_tag": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.SharedLinksApplication": {
-            "type": "object",
-            "properties": {
-                "developer_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.SharedLinksApplicationResponse": {
-            "type": "object",
-            "properties": {
-                "application": {
-                    "$ref": "#/definitions/modelsv2.SharedLinksApplication"
-                },
-                "redirect_uri": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.SharedLinksConnection": {
-            "type": "object",
-            "properties": {
-                "application": {
-                    "$ref": "#/definitions/modelsv2.SharedLinksApplication"
-                },
-                "grant": {
-                    "$ref": "#/definitions/modelsv2.SharedLinksGrant"
-                }
-            }
-        },
-        "modelsv2.SharedLinksConnectionsResponse": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/modelsv2.SharedLinksConnection"
-                    }
-                }
-            }
-        },
-        "modelsv2.SharedLinksConsentResponse": {
-            "type": "object",
-            "properties": {
-                "accounts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/modelsv2.SharedLinksAccount"
-                    }
-                },
-                "application": {
-                    "$ref": "#/definitions/modelsv2.SharedLinksApplication"
-                },
-                "grant": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/modelsv2.SharedLinksGrant"
-                        }
-                    ],
-                    "x-nullable": true
-                }
-            }
-        },
-        "modelsv2.SharedLinksGrant": {
-            "type": "object",
-            "properties": {
-                "access_mode": {
-                    "type": "string",
-                    "enum": [
-                        "selected",
-                        "all_current_and_future"
-                    ]
-                },
-                "connected_at": {
-                    "type": "string"
-                },
-                "selected_player_tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
-        },
-        "modelsv2.SharedLinksGrantRequest": {
-            "type": "object",
-            "properties": {
-                "access_mode": {
-                    "type": "string",
-                    "enum": [
-                        "selected",
-                        "all_current_and_future"
-                    ]
-                },
-                "player_tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         },
@@ -22849,7 +22464,7 @@ const docTemplate = `{
         "modelsv2.SharedLinksLookupResponse": {
             "type": "object",
             "properties": {
-                "links": {
+                "items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/modelsv2.SharedLink"
@@ -24531,6 +24146,11 @@ const docTemplate = `{
     },
     "securityDefinitions": {
         "ApiKeyAuth": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        },
+        "DeveloperToken": {
             "type": "apiKey",
             "name": "Authorization",
             "in": "header"

--- a/internal/models/v2/shared_links.go
+++ b/internal/models/v2/shared_links.go
@@ -1,69 +1,16 @@
 package modelsv2
 
-import "time"
-
-const (
-	SharedLinksAccessSelected            = "selected"
-	SharedLinksAccessAllCurrentAndFuture = "all_current_and_future"
-)
-
-type SharedLinksApplication struct {
-	ID            string  `json:"id"`
-	Name          string  `json:"name"`
-	DeveloperName *string `json:"developer_name,omitempty"`
-}
-
-type SharedLinksApplicationResponse struct {
-	Application SharedLinksApplication `json:"application"`
-	RedirectURI *string                `json:"redirect_uri,omitempty"`
-}
-
-type SharedLinksAccount struct {
-	PlayerTag  string `json:"player_tag"`
-	Name       string `json:"name"`
-	IsVerified bool   `json:"is_verified"`
-	Hidden     bool   `json:"hidden"`
-}
-
-type SharedLinksGrant struct {
-	AccessMode         string    `json:"access_mode" enums:"selected,all_current_and_future"`
-	SelectedPlayerTags []string  `json:"selected_player_tags"`
-	ConnectedAt        time.Time `json:"connected_at"`
-	UpdatedAt          time.Time `json:"updated_at"`
-}
-
-type SharedLinksConsentResponse struct {
-	Application SharedLinksApplication `json:"application"`
-	Accounts    []SharedLinksAccount   `json:"accounts"`
-	Grant       *SharedLinksGrant      `json:"grant" extensions:"x-nullable"`
-}
-
-type SharedLinksGrantRequest struct {
-	AccessMode string   `json:"access_mode" enums:"selected,all_current_and_future"`
-	PlayerTags []string `json:"player_tags,omitempty"`
-}
-
-type SharedLinksConnection struct {
-	Application SharedLinksApplication `json:"application"`
-	Grant       SharedLinksGrant       `json:"grant"`
-}
-
-type SharedLinksConnectionsResponse struct {
-	Items []SharedLinksConnection `json:"items"`
-}
-
 type SharedLinksLookupRequest struct {
 	DiscordIDs []string `json:"discord_ids,omitempty"`
 	PlayerTags []string `json:"player_tags,omitempty"`
 }
 
 type SharedLink struct {
-	DiscordID  string `json:"discord_id"`
-	PlayerTag  string `json:"player_tag"`
 	IsVerified bool   `json:"is_verified"`
-	Hidden     bool   `json:"hidden"`
+	PlayerTag  string `json:"player_tag"`
+	UserID     string `json:"user_id"`
 }
 
 type SharedLinksLookupResponse struct {
-	Links []SharedLink `json:"links"`
+	Items []SharedLink `json:"items"`
 }

--- a/internal/models/v2/shared_links_test.go
+++ b/internal/models/v2/shared_links_test.go
@@ -6,41 +6,32 @@ import (
 	"testing"
 )
 
-func TestSharedLinksResponsesKeepStableEmptyListsAndNullableGrant(t *testing.T) {
-	payload, err := json.Marshal(SharedLinksConsentResponse{
-		Application: SharedLinksApplication{ID: "app-id", Name: "Example"},
-		Accounts:    []SharedLinksAccount{},
-		Grant:       nil,
-	})
+func TestSharedLinksResponseUsesItemsEnvelopeWithoutVisibilityMetadata(t *testing.T) {
+	payload, err := json.Marshal(SharedLinksLookupResponse{Items: []SharedLink{}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	body := string(payload)
-	for _, required := range []string{`"accounts":[]`, `"grant":null`} {
-		if !strings.Contains(body, required) {
-			t.Fatalf("response missing %s: %s", required, body)
-		}
+	if string(payload) != `{"items":[]}` {
+		t.Fatalf("empty response = %s", payload)
 	}
 
-	lookup, err := json.Marshal(SharedLinksLookupResponse{Links: []SharedLink{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(lookup) != `{"links":[]}` {
-		t.Fatalf("lookup response = %s", lookup)
-	}
-
-	lookup, err = json.Marshal(SharedLinksLookupResponse{Links: []SharedLink{{
-		DiscordID: "123456789012345678",
-		PlayerTag: "#2PP",
-		Hidden:    true,
+	payload, err = json.Marshal(SharedLinksLookupResponse{Items: []SharedLink{{
+		IsVerified: true,
+		PlayerTag:  "#2PP",
+		UserID:     "123456789012345678",
 	}}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, required := range []string{`"is_verified":false`, `"hidden":true`} {
-		if !strings.Contains(string(lookup), required) {
-			t.Fatalf("lookup response missing %s: %s", required, lookup)
+	body := string(payload)
+	for _, required := range []string{`"is_verified":true`, `"player_tag":"#2PP"`, `"user_id":"123456789012345678"`} {
+		if !strings.Contains(body, required) {
+			t.Fatalf("response missing %s: %s", required, body)
+		}
+	}
+	for _, forbidden := range []string{`"hidden"`, `"discord_id"`, `"links"`} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("response exposes obsolete field %s: %s", forbidden, body)
 		}
 	}
 }

--- a/internal/openapigen/openapigen.go
+++ b/internal/openapigen/openapigen.go
@@ -457,7 +457,14 @@ func convertSecuritySchemes(source map[string]any) map[string]any {
 		default:
 			copyKeys(scheme, converted, "type", "name", "in")
 		}
-		if name == "ApiKeyAuth" && converted["description"] == nil {
+		if name == "DeveloperToken" {
+			converted = map[string]any{
+				"type":         "http",
+				"scheme":       "bearer",
+				"bearerFormat": "ck_dev_...",
+				"description":  "Developer API token issued by ClashKing.",
+			}
+		} else if name == "ApiKeyAuth" && converted["description"] == nil {
 			converted["description"] = "Enter `Bearer <access_token>`."
 		}
 		out[name] = converted

--- a/internal/routes/privacy.go
+++ b/internal/routes/privacy.go
@@ -40,22 +40,6 @@ func privacyExport(a apptypes.Deps) fiber.Handler {
 			{"notification_devices", `SELECT device_id, provider, platform, environment, app_version, locale, authorization_status, enabled, war_attacks_enabled, war_state_enabled, war_reminders_enabled, raid_reminders_enabled, events_enabled, announcements_enabled, monthly_support_enabled, reminder_timings, raid_reminder_timings, last_seen_at FROM mobile_push_devices WHERE user_id = $1`, true},
 			{"billing_subscription", `SELECT provider, provider_subscription_id, provider_price_id, status, current_period_end, cancel_at_period_end, created_at, updated_at FROM billing_subscriptions WHERE user_id = $1`, true},
 			{"subscription_entitlements", `SELECT active, bookmark_notifications_limit, roster_assistant_monthly_credit_usd, updated_at FROM subscription_entitlements WHERE user_id = $1`, true},
-			{"connected_applications", `
-				SELECT grants.application_id, applications.application_name, grants.access_mode,
-					grants.created_at AS connected_at, grants.updated_at, grants.revoked_at,
-					COALESCE(
-						array_agg(accounts.player_tag ORDER BY accounts.player_tag)
-							FILTER (WHERE accounts.player_tag IS NOT NULL),
-						ARRAY[]::text[]
-					) AS selected_player_tags
-				FROM developer_link_grants AS grants
-				JOIN developer_applications AS applications ON applications.application_id = grants.application_id
-				LEFT JOIN developer_link_grant_accounts AS accounts ON accounts.grant_id = grants.grant_id
-				WHERE grants.user_id = $1
-				GROUP BY grants.application_id, applications.application_name, grants.access_mode,
-					grants.created_at, grants.updated_at, grants.revoked_at
-				ORDER BY grants.updated_at DESC
-			`, true},
 		}
 		for _, item := range queries {
 			rows, err := privacyQuery(c.UserContext(), a, item.optional, item.query, userID)
@@ -89,7 +73,6 @@ func privacyDelete(a apptypes.Deps) fiber.Handler {
 			{"user_recent_searches", `DELETE FROM user_recent_searches WHERE user_id = $1`},
 			{"user_bookmarks", `DELETE FROM user_bookmarks WHERE user_id = $1`},
 			{"user_settings", `DELETE FROM user_settings WHERE user_id = $1`},
-			{"developer_link_grants", `DELETE FROM developer_link_grants WHERE user_id = $1`},
 			{"player_links", `DELETE FROM player_links WHERE user_id = $1`},
 			{"auth_discord_tokens", `DELETE FROM auth_discord_tokens WHERE user_id = $1`},
 			{"auth_refresh_tokens", `DELETE FROM auth_refresh_tokens WHERE user_id = $1`},

--- a/internal/routes/register.go
+++ b/internal/routes/register.go
@@ -36,11 +36,6 @@ func Register(app *fiber.App, a apptypes.Deps, wrap func(fiber.Handler) fiber.Ha
 
 	// Register shared-link routes before /v2/links/:id so the developer batch
 	// endpoint is not interpreted as a personal link subject named "shared".
-	app.Get("/v2/links/shared/applications/:application_id", getSharedLinksApplication(a))
-	app.Get("/v2/links/shared/grants", wrap(listSharedLinksConnections(a)))
-	app.Get("/v2/links/shared/grants/:application_id", wrap(getSharedLinksConsent(a)))
-	app.Put("/v2/links/shared/grants/:application_id", wrap(putSharedLinksGrant(a)))
-	app.Delete("/v2/links/shared/grants/:application_id", wrap(deleteSharedLinksGrant(a)))
 	app.Post("/v2/links/shared", postSharedLinks(a))
 
 	// Register the static server path before the generic two-parameter link paths.

--- a/internal/routes/register_test.go
+++ b/internal/routes/register_test.go
@@ -302,8 +302,8 @@ func TestSharedLinksDeveloperRouteIsRegisteredBeforeGenericPersonalLinks(t *test
 		{fiber.MethodPut, "/v2/links/shared/grants/:application_id"},
 		{fiber.MethodDelete, "/v2/links/shared/grants/:application_id"},
 	} {
-		if registeredRouteIndex(app, route.method, route.path) < 0 {
-			t.Fatalf("expected %s %s to be registered", route.method, route.path)
+		if registeredRouteIndex(app, route.method, route.path) >= 0 {
+			t.Fatalf("obsolete connected-app route is still registered: %s %s", route.method, route.path)
 		}
 	}
 }

--- a/internal/routes/shared_links.go
+++ b/internal/routes/shared_links.go
@@ -29,7 +29,6 @@ type sharedLinksDB interface {
 	Query(context.Context, string, ...any) (pgx.Rows, error)
 	QueryRow(context.Context, string, ...any) pgx.Row
 	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
-	Begin(context.Context) (pgx.Tx, error)
 }
 
 type sharedLinksRateWindow struct {
@@ -42,195 +41,14 @@ var sharedLinksRateLimits = struct {
 	windows map[string]sharedLinksRateWindow
 }{windows: make(map[string]sharedLinksRateWindow)}
 
-// getSharedLinksApplication returns the public identity for an active developer application.
-//
-// @Summary Get a shared-links application
-// @Description Returns the public application identity used by the connected-app consent page. When redirect_uri is supplied, it must exactly match the application's registered URI.
-// @Tags Shared Links
-// @Produce json
-// @Param application_id path string true "Application ID"
-// @Param redirect_uri query string false "Exact registered redirect URI"
-// @Success 200 {object} modelsv2.SharedLinksApplicationResponse
-// @Failure 400 {object} modelsv2.ErrorResponse
-// @Failure 404 {object} modelsv2.ErrorResponse
-// @Failure 503 {object} modelsv2.ErrorResponse
-// @Router /v2/links/shared/applications/{application_id} [get]
-func getSharedLinksApplication(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		db, err := sharedLinksSQL(a)
-		if err != nil {
-			return err
-		}
-		applicationID, err := sharedLinksApplicationUUID(c.Params("application_id"))
-		if err != nil {
-			return err
-		}
-		application, configuredRedirectURI, err := loadSharedLinksApplication(c.UserContext(), db, applicationID)
-		if err != nil {
-			return err
-		}
-
-		var redirectURI *string
-		requestedRedirectURI := c.Query("redirect_uri")
-		if requestedRedirectURI != "" {
-			if configuredRedirectURI == nil || requestedRedirectURI != *configuredRedirectURI {
-				return apptypes.Error(http.StatusBadRequest, "redirect_uri is not registered for this application")
-			}
-			redirectURI = &requestedRedirectURI
-		}
-		c.Set(fiber.HeaderCacheControl, "no-store")
-		return apptypes.JSON(c, http.StatusOK, modelsv2.SharedLinksApplicationResponse{
-			Application: application,
-			RedirectURI: redirectURI,
-		})
-	}
-}
-
-// getSharedLinksConsent returns the current user's linked accounts and existing grant.
-//
-// @Summary Get shared-links consent details
-// @Description Returns the active application, the authenticated user's linked accounts with verification and visibility metadata, and any current read-only grant.
-// @Tags Shared Links
-// @Produce json
-// @Security ApiKeyAuth
-// @Param application_id path string true "Application ID"
-// @Success 200 {object} modelsv2.SharedLinksConsentResponse
-// @Failure 401 {object} modelsv2.ErrorResponse
-// @Failure 404 {object} modelsv2.ErrorResponse
-// @Failure 503 {object} modelsv2.ErrorResponse
-// @Router /v2/links/shared/grants/{application_id} [get]
-func getSharedLinksConsent(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		db, err := sharedLinksSQL(a)
-		if err != nil {
-			return err
-		}
-		applicationID, err := sharedLinksApplicationUUID(c.Params("application_id"))
-		if err != nil {
-			return err
-		}
-		response, err := loadSharedLinksConsent(c.UserContext(), db, applicationID, apptypes.UserID(c.UserContext()))
-		if err != nil {
-			return err
-		}
-		c.Set(fiber.HeaderCacheControl, "no-store")
-		return apptypes.JSON(c, http.StatusOK, response)
-	}
-}
-
-// putSharedLinksGrant creates or replaces the current user's read-only grant.
-//
-// @Summary Grant shared-links access
-// @Description Grants an application read access to selected linked accounts or all current and future linked accounts.
-// @Tags Shared Links
-// @Accept json
-// @Produce json
-// @Security ApiKeyAuth
-// @Param application_id path string true "Application ID"
-// @Param body body modelsv2.SharedLinksGrantRequest true "Grant selection"
-// @Success 200 {object} modelsv2.SharedLinksGrant
-// @Failure 400 {object} modelsv2.ErrorResponse
-// @Failure 401 {object} modelsv2.ErrorResponse
-// @Failure 404 {object} modelsv2.ErrorResponse
-// @Failure 503 {object} modelsv2.ErrorResponse
-// @Router /v2/links/shared/grants/{application_id} [put]
-func putSharedLinksGrant(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		db, err := sharedLinksSQL(a)
-		if err != nil {
-			return err
-		}
-		applicationID, err := sharedLinksApplicationUUID(c.Params("application_id"))
-		if err != nil {
-			return err
-		}
-		var request modelsv2.SharedLinksGrantRequest
-		if err := apptypes.DecodeJSON(c, &request); err != nil {
-			return err
-		}
-		playerTags, err := validateSharedLinksGrantRequest(request)
-		if err != nil {
-			return err
-		}
-		userID := apptypes.UserID(c.UserContext())
-		if err := replaceSharedLinksGrant(c.UserContext(), db, applicationID, userID, request.AccessMode, playerTags); err != nil {
-			return err
-		}
-		grant, err := loadSharedLinksGrant(c.UserContext(), db, applicationID, userID)
-		if err != nil {
-			return err
-		}
-		if grant == nil {
-			return errors.New("shared-links grant was not persisted")
-		}
-		c.Set(fiber.HeaderCacheControl, "no-store")
-		return apptypes.JSON(c, http.StatusOK, grant)
-	}
-}
-
-// deleteSharedLinksGrant revokes the current user's grant immediately.
-//
-// @Summary Revoke shared-links access
-// @Description Revokes the current user's grant and removes its stored selected-account rows. The operation is idempotent.
-// @Tags Shared Links
-// @Security ApiKeyAuth
-// @Param application_id path string true "Application ID"
-// @Success 204
-// @Failure 400 {object} modelsv2.ErrorResponse
-// @Failure 401 {object} modelsv2.ErrorResponse
-// @Failure 503 {object} modelsv2.ErrorResponse
-// @Router /v2/links/shared/grants/{application_id} [delete]
-func deleteSharedLinksGrant(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		db, err := sharedLinksSQL(a)
-		if err != nil {
-			return err
-		}
-		applicationID, err := sharedLinksApplicationUUID(c.Params("application_id"))
-		if err != nil {
-			return err
-		}
-		if err := revokeSharedLinksGrant(c.UserContext(), db, applicationID, apptypes.UserID(c.UserContext())); err != nil {
-			return err
-		}
-		return c.SendStatus(http.StatusNoContent)
-	}
-}
-
-// listSharedLinksConnections lists the current user's active connected applications.
-//
-// @Summary List connected shared-links applications
-// @Description Returns the authenticated user's active read-only application grants.
-// @Tags Shared Links
-// @Produce json
-// @Security ApiKeyAuth
-// @Success 200 {object} modelsv2.SharedLinksConnectionsResponse
-// @Failure 401 {object} modelsv2.ErrorResponse
-// @Failure 503 {object} modelsv2.ErrorResponse
-// @Router /v2/links/shared/grants [get]
-func listSharedLinksConnections(a apptypes.Deps) fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		db, err := sharedLinksSQL(a)
-		if err != nil {
-			return err
-		}
-		items, err := loadSharedLinksConnections(c.UserContext(), db, apptypes.UserID(c.UserContext()))
-		if err != nil {
-			return err
-		}
-		c.Set(fiber.HeaderCacheControl, "no-store")
-		return apptypes.JSON(c, http.StatusOK, modelsv2.SharedLinksConnectionsResponse{Items: items})
-	}
-}
-
-// postSharedLinks looks up links covered by active user grants.
+// postSharedLinks looks up visible Discord links for a developer application.
 //
 // @Summary Look up shared Discord links
-// @Description Returns Discord ID and player-tag pairs with current verification and visibility metadata when covered by active grants for the authenticated developer application. Unauthorized and nonexistent identifiers are omitted identically.
-// @Tags Shared Links
+// @Description Returns visible Discord ID and player-tag pairs for the requested Discord IDs, player tags, or both. Hidden and nonexistent links are omitted identically. Results include both verified and unverified links.
+// @Tags Links
 // @Accept json
 // @Produce json
-// @Security ApiKeyAuth
+// @Security DeveloperToken
 // @Param body body modelsv2.SharedLinksLookupRequest true "Discord IDs and player tags"
 // @Success 200 {object} modelsv2.SharedLinksLookupResponse
 // @Failure 400 {object} modelsv2.ErrorResponse
@@ -260,12 +78,15 @@ func postSharedLinks(a apptypes.Deps) fiber.Handler {
 		if err != nil {
 			return err
 		}
-		links, err := querySharedLinks(c.UserContext(), db, applicationID, discordIDs, playerTags)
+		if err := recordSharedLinksLookup(c.UserContext(), db, applicationID, len(discordIDs)+len(playerTags)); err != nil {
+			return err
+		}
+		items, err := querySharedLinks(c.UserContext(), db, discordIDs, playerTags)
 		if err != nil {
 			return err
 		}
 		c.Set(fiber.HeaderCacheControl, "no-store")
-		return apptypes.JSON(c, http.StatusOK, modelsv2.SharedLinksLookupResponse{Links: links})
+		return apptypes.JSON(c, http.StatusOK, modelsv2.SharedLinksLookupResponse{Items: items})
 	}
 }
 
@@ -274,262 +95,6 @@ func sharedLinksSQL(a apptypes.Deps) (sharedLinksDB, error) {
 		return nil, apptypes.Error(http.StatusServiceUnavailable, "SQL store is not configured")
 	}
 	return a.Store.SQL, nil
-}
-
-func sharedLinksApplicationUUID(raw string) (uuid.UUID, error) {
-	applicationID, err := uuid.Parse(strings.TrimSpace(raw))
-	if err != nil {
-		return uuid.Nil, apptypes.Error(http.StatusBadRequest, "Invalid application_id")
-	}
-	return applicationID, nil
-}
-
-func loadSharedLinksApplication(ctx context.Context, db sharedLinksDB, applicationID uuid.UUID) (modelsv2.SharedLinksApplication, *string, error) {
-	var (
-		id                 uuid.UUID
-		name               string
-		developerName      *string
-		configuredRedirect *string
-	)
-	err := db.QueryRow(ctx, `
-		SELECT application_id, application_name, developer_name, redirect_uri
-		FROM developer_applications
-		WHERE application_id = $1 AND revoked_at IS NULL
-	`, applicationID).Scan(&id, &name, &developerName, &configuredRedirect)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return modelsv2.SharedLinksApplication{}, nil, apptypes.Error(http.StatusNotFound, "Application not found")
-	}
-	if err != nil {
-		return modelsv2.SharedLinksApplication{}, nil, err
-	}
-	return modelsv2.SharedLinksApplication{ID: id.String(), Name: name, DeveloperName: developerName}, configuredRedirect, nil
-}
-
-func loadSharedLinksConsent(ctx context.Context, db sharedLinksDB, applicationID uuid.UUID, userID string) (modelsv2.SharedLinksConsentResponse, error) {
-	application, _, err := loadSharedLinksApplication(ctx, db, applicationID)
-	if err != nil {
-		return modelsv2.SharedLinksConsentResponse{}, err
-	}
-
-	accounts := make([]modelsv2.SharedLinksAccount, 0)
-	rows, err := db.Query(ctx, `
-		SELECT links.tag, COALESCE(players.name, links.tag), links.is_verified, links.hidden
-		FROM player_links AS links
-		LEFT JOIN basic_player AS players ON players.tag = links.tag
-		WHERE links.user_id = $1
-		ORDER BY links.order_index ASC, links.added_at ASC, links.tag ASC
-	`, userID)
-	if err != nil {
-		return modelsv2.SharedLinksConsentResponse{}, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var account modelsv2.SharedLinksAccount
-		if err := rows.Scan(&account.PlayerTag, &account.Name, &account.IsVerified, &account.Hidden); err != nil {
-			return modelsv2.SharedLinksConsentResponse{}, err
-		}
-		accounts = append(accounts, account)
-	}
-	if err := rows.Err(); err != nil {
-		return modelsv2.SharedLinksConsentResponse{}, err
-	}
-
-	grant, err := loadSharedLinksGrant(ctx, db, applicationID, userID)
-	if err != nil {
-		return modelsv2.SharedLinksConsentResponse{}, err
-	}
-	return modelsv2.SharedLinksConsentResponse{Application: application, Accounts: accounts, Grant: grant}, nil
-}
-
-func loadSharedLinksGrant(ctx context.Context, db sharedLinksDB, applicationID uuid.UUID, userID string) (*modelsv2.SharedLinksGrant, error) {
-	var (
-		grantID uuid.UUID
-		grant   modelsv2.SharedLinksGrant
-	)
-	err := db.QueryRow(ctx, `
-		SELECT grant_id, access_mode, created_at, updated_at
-		FROM developer_link_grants
-		WHERE application_id = $1 AND user_id = $2 AND revoked_at IS NULL
-	`, applicationID, userID).Scan(&grantID, &grant.AccessMode, &grant.ConnectedAt, &grant.UpdatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	grant.SelectedPlayerTags = make([]string, 0)
-	rows, err := db.Query(ctx, `
-		SELECT player_tag
-		FROM developer_link_grant_accounts
-		WHERE grant_id = $1
-		ORDER BY player_tag ASC
-	`, grantID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var playerTag string
-		if err := rows.Scan(&playerTag); err != nil {
-			return nil, err
-		}
-		grant.SelectedPlayerTags = append(grant.SelectedPlayerTags, playerTag)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return &grant, nil
-}
-
-func validateSharedLinksGrantRequest(request modelsv2.SharedLinksGrantRequest) ([]string, error) {
-	switch request.AccessMode {
-	case modelsv2.SharedLinksAccessSelected:
-		playerTags, err := normalizeSharedLinksPlayerTags(request.PlayerTags)
-		if err != nil {
-			return nil, err
-		}
-		if len(playerTags) == 0 {
-			return nil, apptypes.Error(http.StatusBadRequest, "selected access requires at least one player_tag")
-		}
-		return playerTags, nil
-	case modelsv2.SharedLinksAccessAllCurrentAndFuture:
-		if len(request.PlayerTags) != 0 {
-			return nil, apptypes.Error(http.StatusBadRequest, "player_tags must be empty for all_current_and_future access")
-		}
-		return []string{}, nil
-	default:
-		return nil, apptypes.Error(http.StatusBadRequest, "access_mode must be selected or all_current_and_future")
-	}
-}
-
-func replaceSharedLinksGrant(ctx context.Context, db sharedLinksDB, applicationID uuid.UUID, userID, accessMode string, playerTags []string) error {
-	tx, err := db.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	var activeApplicationID uuid.UUID
-	if err := tx.QueryRow(ctx, `
-		SELECT application_id
-		FROM developer_applications
-		WHERE application_id = $1 AND revoked_at IS NULL
-		FOR SHARE
-	`, applicationID).Scan(&activeApplicationID); errors.Is(err, pgx.ErrNoRows) {
-		return apptypes.Error(http.StatusNotFound, "Application not found")
-	} else if err != nil {
-		return err
-	}
-
-	if accessMode == modelsv2.SharedLinksAccessSelected {
-		var ownedCount int
-		if err := tx.QueryRow(ctx, `
-			SELECT count(*)
-			FROM player_links
-			WHERE user_id = $1 AND tag = ANY($2::text[])
-		`, userID, playerTags).Scan(&ownedCount); err != nil {
-			return err
-		}
-		if ownedCount != len(playerTags) {
-			return apptypes.Error(http.StatusBadRequest, "player_tags must be linked accounts owned by the current user")
-		}
-	}
-
-	var grantID uuid.UUID
-	if err := tx.QueryRow(ctx, `
-		INSERT INTO developer_link_grants (
-			application_id, user_id, access_mode, created_at, updated_at, revoked_at
-		)
-		VALUES ($1, $2, $3, now(), now(), NULL)
-		ON CONFLICT (application_id, user_id) WHERE revoked_at IS NULL DO UPDATE
-		SET access_mode = EXCLUDED.access_mode,
-			updated_at = now(),
-			revoked_at = NULL
-		RETURNING grant_id
-	`, applicationID, userID, accessMode).Scan(&grantID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM developer_link_grant_accounts WHERE grant_id = $1`, grantID); err != nil {
-		return err
-	}
-	if len(playerTags) != 0 {
-		if _, err := tx.Exec(ctx, `
-			INSERT INTO developer_link_grant_accounts (grant_id, player_tag, created_at)
-			SELECT $1, player_tag, now()
-			FROM unnest($2::text[]) AS player_tag
-		`, grantID, playerTags); err != nil {
-			return err
-		}
-	}
-	return tx.Commit(ctx)
-}
-
-func revokeSharedLinksGrant(ctx context.Context, db sharedLinksDB, applicationID uuid.UUID, userID string) error {
-	_, err := db.Exec(ctx, `
-		WITH revoked AS (
-			UPDATE developer_link_grants
-			SET revoked_at = now(), updated_at = now()
-			WHERE application_id = $1 AND user_id = $2 AND revoked_at IS NULL
-			RETURNING grant_id
-		)
-		DELETE FROM developer_link_grant_accounts AS accounts
-		USING revoked
-		WHERE accounts.grant_id = revoked.grant_id
-	`, applicationID, userID)
-	return err
-}
-
-func loadSharedLinksConnections(ctx context.Context, db sharedLinksDB, userID string) ([]modelsv2.SharedLinksConnection, error) {
-	rows, err := db.Query(ctx, `
-		SELECT applications.application_id, applications.application_name, applications.developer_name,
-			grants.access_mode, grants.created_at, grants.updated_at,
-			COALESCE(
-				array_agg(accounts.player_tag ORDER BY accounts.player_tag)
-					FILTER (WHERE accounts.player_tag IS NOT NULL),
-				ARRAY[]::text[]
-			)
-		FROM developer_link_grants AS grants
-		JOIN developer_applications AS applications ON applications.application_id = grants.application_id
-		LEFT JOIN developer_link_grant_accounts AS accounts ON accounts.grant_id = grants.grant_id
-		WHERE grants.user_id = $1
-			AND grants.revoked_at IS NULL
-			AND applications.revoked_at IS NULL
-		GROUP BY applications.application_id, applications.application_name, applications.developer_name,
-			grants.access_mode, grants.created_at, grants.updated_at
-		ORDER BY grants.updated_at DESC, applications.application_name ASC
-	`, userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := make([]modelsv2.SharedLinksConnection, 0)
-	for rows.Next() {
-		var (
-			applicationID uuid.UUID
-			item          modelsv2.SharedLinksConnection
-		)
-		if err := rows.Scan(
-			&applicationID,
-			&item.Application.Name,
-			&item.Application.DeveloperName,
-			&item.Grant.AccessMode,
-			&item.Grant.ConnectedAt,
-			&item.Grant.UpdatedAt,
-			&item.Grant.SelectedPlayerTags,
-		); err != nil {
-			return nil, err
-		}
-		item.Application.ID = applicationID.String()
-		if item.Grant.SelectedPlayerTags == nil {
-			item.Grant.SelectedPlayerTags = []string{}
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 func authenticateSharedLinksApplication(ctx context.Context, db sharedLinksDB, authorization string) (string, error) {
@@ -541,7 +106,8 @@ func authenticateSharedLinksApplication(ctx context.Context, db sharedLinksDB, a
 	var applicationID uuid.UUID
 	err := db.QueryRow(ctx, `
 		UPDATE developer_applications
-		SET token_last_used_at = now()
+		SET token_last_used_at = now(),
+			api_request_count = api_request_count + 1
 		WHERE token_hash = $1 AND revoked_at IS NULL
 		RETURNING application_id
 	`, hash[:]).Scan(&applicationID)
@@ -552,6 +118,21 @@ func authenticateSharedLinksApplication(ctx context.Context, db sharedLinksDB, a
 		return "", err
 	}
 	return applicationID.String(), nil
+}
+
+func recordSharedLinksLookup(ctx context.Context, db sharedLinksDB, applicationID string, identifiers int) error {
+	result, err := db.Exec(ctx, `
+		UPDATE developer_applications
+		SET links_lookup_count = links_lookup_count + $2
+		WHERE application_id = $1 AND revoked_at IS NULL
+	`, applicationID, identifiers)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return apptypes.Error(http.StatusUnauthorized, "Invalid developer API token")
+	}
+	return nil
 }
 
 func sharedLinksBearerToken(authorization string) string {
@@ -617,46 +198,31 @@ func normalizeSharedLinksPlayerTags(rawTags []string) ([]string, error) {
 	return playerTags, nil
 }
 
-func querySharedLinks(ctx context.Context, db sharedLinksDB, applicationID string, discordIDs, playerTags []string) ([]modelsv2.SharedLink, error) {
+func querySharedLinks(ctx context.Context, db sharedLinksDB, discordIDs, playerTags []string) ([]modelsv2.SharedLink, error) {
 	rows, err := db.Query(ctx, `
-		SELECT DISTINCT links.user_id, links.tag, links.is_verified, links.hidden
+		SELECT links.is_verified, links.tag, links.user_id
 		FROM player_links AS links
-		JOIN developer_link_grants AS grants
-			ON grants.application_id = $1::uuid
-			AND grants.user_id = links.user_id
-			AND grants.revoked_at IS NULL
-		WHERE links.user_id ~ '^[1-9][0-9]{14,19}$'
-			AND (links.user_id = ANY($2::text[]) OR links.tag = ANY($3::text[]))
-			AND (
-				grants.access_mode = 'all_current_and_future'
-				OR (
-					grants.access_mode = 'selected'
-					AND EXISTS (
-						SELECT 1
-						FROM developer_link_grant_accounts AS accounts
-						WHERE accounts.grant_id = grants.grant_id
-							AND accounts.player_tag = links.tag
-					)
-				)
-			)
-		ORDER BY links.user_id ASC, links.tag ASC
-	`, applicationID, discordIDs, playerTags)
+		WHERE links.hidden = false
+			AND links.user_id ~ '^[1-9][0-9]{14,19}$'
+			AND (links.user_id = ANY($1::text[]) OR links.tag = ANY($2::text[]))
+		ORDER BY links.user_id ASC, links.order_index ASC, links.tag ASC
+	`, discordIDs, playerTags)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	links := make([]modelsv2.SharedLink, 0)
+	items := make([]modelsv2.SharedLink, 0)
 	for rows.Next() {
-		var link modelsv2.SharedLink
-		if err := rows.Scan(&link.DiscordID, &link.PlayerTag, &link.IsVerified, &link.Hidden); err != nil {
+		var item modelsv2.SharedLink
+		if err := rows.Scan(&item.IsVerified, &item.PlayerTag, &item.UserID); err != nil {
 			return nil, err
 		}
-		links = append(links, link)
+		items = append(items, item)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return links, nil
+	return items, nil
 }
 
 func allowSharedLinksRequest(applicationID string, now time.Time) bool {

--- a/internal/routes/shared_links.go
+++ b/internal/routes/shared_links.go
@@ -21,6 +21,7 @@ import (
 const (
 	sharedLinksMaxIdentifiers    = 100
 	sharedLinksRequestsPerMinute = 120
+	sharedLinksInvalidToken      = "Invalid developer API token"
 )
 
 var sharedLinksDiscordIDPattern = regexp.MustCompile(`^[1-9][0-9]{14,19}$`)
@@ -62,32 +63,36 @@ func postSharedLinks(a apptypes.Deps) fiber.Handler {
 		if err != nil {
 			return err
 		}
-		applicationID, err := authenticateSharedLinksApplication(c.UserContext(), db, c.Get(fiber.HeaderAuthorization))
-		if err != nil {
-			return err
-		}
-		if !allowSharedLinksRequest(applicationID, time.Now().UTC()) {
-			return apptypes.Error(http.StatusTooManyRequests, "Shared-links request limit exceeded")
-		}
-
-		var request modelsv2.SharedLinksLookupRequest
-		if err := apptypes.DecodeJSON(c, &request); err != nil {
-			return err
-		}
-		discordIDs, playerTags, err := validateSharedLinksLookupRequest(request)
-		if err != nil {
-			return err
-		}
-		if err := recordSharedLinksLookup(c.UserContext(), db, applicationID, len(discordIDs)+len(playerTags)); err != nil {
-			return err
-		}
-		items, err := querySharedLinks(c.UserContext(), db, discordIDs, playerTags)
-		if err != nil {
-			return err
-		}
-		c.Set(fiber.HeaderCacheControl, "no-store")
-		return apptypes.JSON(c, http.StatusOK, modelsv2.SharedLinksLookupResponse{Items: items})
+		return executeSharedLinksLookup(c, db)
 	}
+}
+
+func executeSharedLinksLookup(c *fiber.Ctx, db sharedLinksDB) error {
+	applicationID, err := authenticateSharedLinksApplication(c.UserContext(), db, c.Get(fiber.HeaderAuthorization))
+	if err != nil {
+		return err
+	}
+	if !allowSharedLinksRequest(applicationID, time.Now().UTC()) {
+		return apptypes.Error(http.StatusTooManyRequests, "Shared-links request limit exceeded")
+	}
+
+	var request modelsv2.SharedLinksLookupRequest
+	if err := apptypes.DecodeJSON(c, &request); err != nil {
+		return err
+	}
+	discordIDs, playerTags, err := validateSharedLinksLookupRequest(request)
+	if err != nil {
+		return err
+	}
+	if err := recordSharedLinksLookup(c.UserContext(), db, applicationID, len(discordIDs)+len(playerTags)); err != nil {
+		return err
+	}
+	items, err := querySharedLinks(c.UserContext(), db, discordIDs, playerTags)
+	if err != nil {
+		return err
+	}
+	c.Set(fiber.HeaderCacheControl, "no-store")
+	return apptypes.JSON(c, http.StatusOK, modelsv2.SharedLinksLookupResponse{Items: items})
 }
 
 func sharedLinksSQL(a apptypes.Deps) (sharedLinksDB, error) {
@@ -100,7 +105,7 @@ func sharedLinksSQL(a apptypes.Deps) (sharedLinksDB, error) {
 func authenticateSharedLinksApplication(ctx context.Context, db sharedLinksDB, authorization string) (string, error) {
 	token := sharedLinksBearerToken(authorization)
 	if token == "" || len(token) > 512 {
-		return "", apptypes.Error(http.StatusUnauthorized, "Invalid developer API token")
+		return "", apptypes.Error(http.StatusUnauthorized, sharedLinksInvalidToken)
 	}
 	hash := sha256.Sum256([]byte(token))
 	var applicationID uuid.UUID
@@ -112,7 +117,7 @@ func authenticateSharedLinksApplication(ctx context.Context, db sharedLinksDB, a
 		RETURNING application_id
 	`, hash[:]).Scan(&applicationID)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return "", apptypes.Error(http.StatusUnauthorized, "Invalid developer API token")
+		return "", apptypes.Error(http.StatusUnauthorized, sharedLinksInvalidToken)
 	}
 	if err != nil {
 		return "", err
@@ -130,7 +135,7 @@ func recordSharedLinksLookup(ctx context.Context, db sharedLinksDB, applicationI
 		return err
 	}
 	if result.RowsAffected() == 0 {
-		return apptypes.Error(http.StatusUnauthorized, "Invalid developer API token")
+		return apptypes.Error(http.StatusUnauthorized, sharedLinksInvalidToken)
 	}
 	return nil
 }

--- a/internal/routes/shared_links_test.go
+++ b/internal/routes/shared_links_test.go
@@ -33,6 +33,10 @@ func TestValidateSharedLinksLookupRequestNormalizesAndDeduplicates(t *testing.T)
 }
 
 func TestValidateSharedLinksLookupRequestRejectsInvalidIdentifiers(t *testing.T) {
+	tooMany := make([]string, sharedLinksMaxIdentifiers+1)
+	for index := range tooMany {
+		tooMany[index] = "123456789012345678"
+	}
 	for _, test := range []struct {
 		name    string
 		request modelsv2.SharedLinksLookupRequest
@@ -42,41 +46,13 @@ func TestValidateSharedLinksLookupRequestRejectsInvalidIdentifiers(t *testing.T)
 		{name: "leading-zero Discord ID", request: modelsv2.SharedLinksLookupRequest{DiscordIDs: []string{"012345678901234567"}}},
 		{name: "invalid player alphabet", request: modelsv2.SharedLinksLookupRequest{PlayerTags: []string{"#ABC"}}},
 		{name: "short player tag", request: modelsv2.SharedLinksLookupRequest{PlayerTags: []string{"#2P"}}},
+		{name: "too many identifiers", request: modelsv2.SharedLinksLookupRequest{DiscordIDs: tooMany}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, err := validateSharedLinksLookupRequest(test.request)
 			assertSharedLinksAppErrorStatus(t, err, 400)
 		})
 	}
-}
-
-func TestValidateSharedLinksGrantRequestKeepsReadModesExplicit(t *testing.T) {
-	selected, err := validateSharedLinksGrantRequest(modelsv2.SharedLinksGrantRequest{
-		AccessMode: modelsv2.SharedLinksAccessSelected,
-		PlayerTags: []string{"#2PP", "2pp", "#P0Y"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := []string{"#2PP", "#P0Y"}; !reflect.DeepEqual(selected, want) {
-		t.Fatalf("selected tags = %#v, want %#v", selected, want)
-	}
-
-	all, err := validateSharedLinksGrantRequest(modelsv2.SharedLinksGrantRequest{
-		AccessMode: modelsv2.SharedLinksAccessAllCurrentAndFuture,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if all == nil || len(all) != 0 {
-		t.Fatalf("dynamic grant tags = %#v, want non-nil empty list", all)
-	}
-
-	_, err = validateSharedLinksGrantRequest(modelsv2.SharedLinksGrantRequest{
-		AccessMode: modelsv2.SharedLinksAccessAllCurrentAndFuture,
-		PlayerTags: []string{"#2PP"},
-	})
-	assertSharedLinksAppErrorStatus(t, err, 400)
 }
 
 func TestSharedLinksBearerTokenRequiresBearerScheme(t *testing.T) {
@@ -90,7 +66,7 @@ func TestSharedLinksBearerTokenRequiresBearerScheme(t *testing.T) {
 	}
 }
 
-func TestAuthenticateSharedLinksApplicationHashesTokenAndRejectsRevokedApps(t *testing.T) {
+func TestAuthenticateSharedLinksApplicationRecordsRequestUsage(t *testing.T) {
 	applicationID := uuid.MustParse("019d0000-0000-7000-8000-000000000001")
 	wantHash := sha256.Sum256([]byte("ck_dev_secret"))
 	var query string
@@ -112,105 +88,99 @@ func TestAuthenticateSharedLinksApplicationHashesTokenAndRejectsRevokedApps(t *t
 	if got != applicationID.String() {
 		t.Fatalf("application ID = %q, want %q", got, applicationID)
 	}
-	if !strings.Contains(query, "token_last_used_at = now()") || !strings.Contains(query, "revoked_at IS NULL") {
-		t.Fatalf("authentication query does not atomically enforce active app and last use: %s", query)
+	for _, required := range []string{"token_last_used_at = now()", "api_request_count = api_request_count + 1", "revoked_at IS NULL"} {
+		if !strings.Contains(query, required) {
+			t.Fatalf("authentication query missing %q: %s", required, query)
+		}
 	}
 	if len(args) != 1 || !reflect.DeepEqual(args[0], wantHash[:]) {
 		t.Fatalf("token hash argument = %#v, want SHA-256 digest", args)
 	}
 }
 
-func TestReplaceSharedLinksGrantChecksCurrentOwnershipWithoutRequiringVerification(t *testing.T) {
-	applicationID := uuid.MustParse("019d0000-0000-7000-8000-000000000001")
-	grantID := uuid.MustParse("019d0000-0000-7000-8000-000000000002")
-	tx := &sharedLinksTestTx{
-		queryRows: []pgx.Row{
-			sharedLinksTestRow{scan: func(dest ...any) error {
-				*dest[0].(*uuid.UUID) = applicationID
-				return nil
-			}},
-			sharedLinksTestRow{scan: func(dest ...any) error {
-				*dest[0].(*int) = 2
-				return nil
-			}},
-			sharedLinksTestRow{scan: func(dest ...any) error {
-				*dest[0].(*uuid.UUID) = grantID
-				return nil
-			}},
+func TestAuthenticateSharedLinksApplicationRejectsUnknownOrRevokedToken(t *testing.T) {
+	db := &sharedLinksTestDB{
+		queryRow: func(context.Context, string, ...any) pgx.Row {
+			return sharedLinksTestRow{scan: func(...any) error { return pgx.ErrNoRows }}
 		},
 	}
-	db := &sharedLinksTestDB{begin: func(context.Context) (pgx.Tx, error) { return tx, nil }}
-	err := replaceSharedLinksGrant(
-		context.Background(), db, applicationID, "123456789012345678",
-		modelsv2.SharedLinksAccessSelected, []string{"#2PP", "#P0Y"},
-	)
-	if err != nil {
+	_, err := authenticateSharedLinksApplication(context.Background(), db, "Bearer ck_dev_revoked")
+	assertSharedLinksAppErrorStatus(t, err, 401)
+}
+
+func TestRecordSharedLinksLookupAddsAcceptedIdentifierCount(t *testing.T) {
+	var query string
+	var args []any
+	db := &sharedLinksTestDB{
+		exec: func(_ context.Context, sql string, values ...any) (pgconn.CommandTag, error) {
+			query = sql
+			args = values
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+	if err := recordSharedLinksLookup(context.Background(), db, "019d0000-0000-7000-8000-000000000001", 3); err != nil {
 		t.Fatal(err)
 	}
-	if !tx.committed {
-		t.Fatal("grant transaction was not committed")
+	if !strings.Contains(query, "links_lookup_count = links_lookup_count + $2") || !strings.Contains(query, "revoked_at IS NULL") {
+		t.Fatalf("lookup usage query = %s", query)
 	}
-	if len(tx.querySQL) < 2 || !strings.Contains(tx.querySQL[1], "user_id = $1") || strings.Contains(tx.querySQL[1], "is_verified = true") {
-		t.Fatalf("ownership query must require the current user without requiring verification: %#v", tx.querySQL)
-	}
-	if len(tx.execSQL) != 2 || !strings.Contains(tx.execSQL[0], "DELETE FROM developer_link_grant_accounts") || !strings.Contains(tx.execSQL[1], "INSERT INTO developer_link_grant_accounts") {
-		t.Fatalf("selected rows were not replaced transactionally: %#v", tx.execSQL)
+	if want := []any{"019d0000-0000-7000-8000-000000000001", 3}; !reflect.DeepEqual(args, want) {
+		t.Fatalf("lookup usage args = %#v, want %#v", args, want)
 	}
 }
 
-func TestQuerySharedLinksReturnsVerificationAndVisibilityForGrantedLinks(t *testing.T) {
-	var query string
+func TestRecordSharedLinksLookupRejectsApplicationRevokedAfterAuthentication(t *testing.T) {
 	db := &sharedLinksTestDB{
-		query: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
-			query = sql
-			return &sharedLinksTestRows{links: []modelsv2.SharedLink{{DiscordID: "123456789012345678", PlayerTag: "#2PP", IsVerified: false, Hidden: true}}}, nil
+		exec: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 0"), nil
 		},
 	}
-	links, err := querySharedLinks(
-		context.Background(), db, "019d0000-0000-7000-8000-000000000001",
+	err := recordSharedLinksLookup(context.Background(), db, "019d0000-0000-7000-8000-000000000001", 1)
+	assertSharedLinksAppErrorStatus(t, err, 401)
+}
+
+func TestQuerySharedLinksReturnsOnlyVisibleLinks(t *testing.T) {
+	var query string
+	var args []any
+	db := &sharedLinksTestDB{
+		query: func(_ context.Context, sql string, values ...any) (pgx.Rows, error) {
+			query = sql
+			args = values
+			return &sharedLinksTestRows{items: []modelsv2.SharedLink{{
+				IsVerified: false,
+				PlayerTag:  "#2PP",
+				UserID:     "123456789012345678",
+			}}}, nil
+		},
+	}
+	items, err := querySharedLinks(
+		context.Background(), db,
 		[]string{"123456789012345678"}, []string{"#2PP"},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(links) != 1 || links[0].PlayerTag != "#2PP" || links[0].IsVerified || !links[0].Hidden {
-		t.Fatalf("links = %#v", links)
+	if len(items) != 1 || items[0].PlayerTag != "#2PP" || items[0].IsVerified || items[0].UserID != "123456789012345678" {
+		t.Fatalf("items = %#v", items)
 	}
 	for _, required := range []string{
-		"grants.revoked_at IS NULL",
+		"links.hidden = false",
 		"links.is_verified",
-		"links.hidden",
-		"grants.access_mode = 'all_current_and_future'",
-		"developer_link_grant_accounts",
-		"accounts.player_tag = links.tag",
+		"links.user_id = ANY($1::text[])",
+		"links.tag = ANY($2::text[])",
+		"links.order_index ASC",
 	} {
 		if !strings.Contains(query, required) {
 			t.Fatalf("shared lookup query missing %q: %s", required, query)
 		}
 	}
-	if strings.Contains(query, "links.is_verified = true") || strings.Contains(query, "links.hidden = false") {
-		t.Fatal("explicit connected-app consent should return verification and visibility metadata without filtering on either")
+	for _, forbidden := range []string{"developer_link_grants", "developer_link_grant_accounts", "links.hidden,"} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("shared lookup query contains obsolete or exposed field %q: %s", forbidden, query)
+		}
 	}
-}
-
-func TestRevokeSharedLinksGrantDeletesRowsForRevokedGrantIDs(t *testing.T) {
-	var query string
-	db := &sharedLinksTestDB{
-		exec: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
-			query = sql
-			return pgconn.NewCommandTag("DELETE 2"), nil
-		},
-	}
-	err := revokeSharedLinksGrant(
-		context.Background(), db,
-		uuid.MustParse("019d0000-0000-7000-8000-000000000001"),
-		"123456789012345678",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(query, "RETURNING grant_id") || !strings.Contains(query, "accounts.grant_id = revoked.grant_id") {
-		t.Fatalf("revocation does not delete selected rows by returned grant ID: %s", query)
+	if want := []any{[]string{"123456789012345678"}, []string{"#2PP"}}; !reflect.DeepEqual(args, want) {
+		t.Fatalf("lookup args = %#v, want %#v", args, want)
 	}
 }
 
@@ -250,7 +220,6 @@ type sharedLinksTestDB struct {
 	query    func(context.Context, string, ...any) (pgx.Rows, error)
 	queryRow func(context.Context, string, ...any) pgx.Row
 	exec     func(context.Context, string, ...any) (pgconn.CommandTag, error)
-	begin    func(context.Context) (pgx.Tx, error)
 }
 
 func (db *sharedLinksTestDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
@@ -274,13 +243,6 @@ func (db *sharedLinksTestDB) Exec(ctx context.Context, sql string, args ...any) 
 	return db.exec(ctx, sql, args...)
 }
 
-func (db *sharedLinksTestDB) Begin(ctx context.Context) (pgx.Tx, error) {
-	if db.begin == nil {
-		return nil, errors.New("unexpected Begin")
-	}
-	return db.begin(ctx)
-}
-
 type sharedLinksTestRow struct {
 	scan func(...any) error
 }
@@ -289,58 +251,23 @@ func (row sharedLinksTestRow) Scan(dest ...any) error { return row.scan(dest...)
 
 type sharedLinksTestRows struct {
 	pgx.Rows
-	links  []modelsv2.SharedLink
+	items  []modelsv2.SharedLink
 	cursor int
 }
 
 func (rows *sharedLinksTestRows) Close()     {}
 func (rows *sharedLinksTestRows) Err() error { return nil }
 func (rows *sharedLinksTestRows) Next() bool {
-	if rows.cursor >= len(rows.links) {
+	if rows.cursor >= len(rows.items) {
 		return false
 	}
 	rows.cursor++
 	return true
 }
 func (rows *sharedLinksTestRows) Scan(dest ...any) error {
-	link := rows.links[rows.cursor-1]
-	*dest[0].(*string) = link.DiscordID
-	*dest[1].(*string) = link.PlayerTag
-	*dest[2].(*bool) = link.IsVerified
-	*dest[3].(*bool) = link.Hidden
-	return nil
-}
-
-type sharedLinksTestTx struct {
-	pgx.Tx
-	queryRows  []pgx.Row
-	querySQL   []string
-	execSQL    []string
-	committed  bool
-	rolledBack bool
-}
-
-func (tx *sharedLinksTestTx) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
-	tx.querySQL = append(tx.querySQL, sql)
-	if len(tx.queryRows) == 0 {
-		return sharedLinksTestRow{scan: func(...any) error { return errors.New("unexpected QueryRow") }}
-	}
-	row := tx.queryRows[0]
-	tx.queryRows = tx.queryRows[1:]
-	return row
-}
-
-func (tx *sharedLinksTestTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
-	tx.execSQL = append(tx.execSQL, sql)
-	return pgconn.NewCommandTag("INSERT 1"), nil
-}
-
-func (tx *sharedLinksTestTx) Commit(context.Context) error {
-	tx.committed = true
-	return nil
-}
-
-func (tx *sharedLinksTestTx) Rollback(context.Context) error {
-	tx.rolledBack = true
+	item := rows.items[rows.cursor-1]
+	*dest[0].(*bool) = item.IsVerified
+	*dest[1].(*string) = item.PlayerTag
+	*dest[2].(*string) = item.UserID
 	return nil
 }

--- a/internal/routes/shared_links_test.go
+++ b/internal/routes/shared_links_test.go
@@ -3,7 +3,10 @@ package routes
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -11,10 +14,65 @@ import (
 
 	modelsv2 "github.com/ClashKingInc/ClashKingAPI/internal/models/v2"
 	apptypes "github.com/ClashKingInc/ClashKingAPI/internal/utils"
+	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
+
+func TestExecuteSharedLinksLookupReturnsCombinedItems(t *testing.T) {
+	applicationID := uuid.MustParse("019d0000-0000-7000-8000-000000000001")
+	resetSharedLinksRateLimits()
+	db := &sharedLinksTestDB{
+		queryRow: func(context.Context, string, ...any) pgx.Row {
+			return sharedLinksTestRow{scan: func(dest ...any) error {
+				*dest[0].(*uuid.UUID) = applicationID
+				return nil
+			}}
+		},
+		exec: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+		query: func(context.Context, string, ...any) (pgx.Rows, error) {
+			return &sharedLinksTestRows{items: []modelsv2.SharedLink{{
+				IsVerified: true,
+				PlayerTag:  "#2PP",
+				UserID:     "123456789012345678",
+			}}}, nil
+		},
+	}
+	app := fiber.New()
+	app.Post("/", func(c *fiber.Ctx) error { return executeSharedLinksLookup(c, db) })
+	request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{
+		"discord_ids":["123456789012345678"],
+		"player_tags":["#2PP"]
+	}`))
+	request.Header.Set(fiber.HeaderAuthorization, "Bearer ck_dev_secret")
+	request.Header.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	response, err := app.Test(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+	if got := response.Header.Get(fiber.HeaderCacheControl); got != "no-store" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	var payload modelsv2.SharedLinksLookupResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].PlayerTag != "#2PP" || !payload.Items[0].IsVerified {
+		t.Fatalf("response = %#v", payload)
+	}
+}
+
+func TestSharedLinksSQLRequiresConfiguredStore(t *testing.T) {
+	_, err := sharedLinksSQL(apptypes.Deps{})
+	assertSharedLinksAppErrorStatus(t, err, http.StatusServiceUnavailable)
+}
 
 func TestValidateSharedLinksLookupRequestNormalizesAndDeduplicates(t *testing.T) {
 	discordIDs, playerTags, err := validateSharedLinksLookupRequest(modelsv2.SharedLinksLookupRequest{
@@ -185,9 +243,7 @@ func TestQuerySharedLinksReturnsOnlyVisibleLinks(t *testing.T) {
 }
 
 func TestSharedLinksRateLimitIsPerApplicationAndResets(t *testing.T) {
-	sharedLinksRateLimits.Lock()
-	sharedLinksRateLimits.windows = make(map[string]sharedLinksRateWindow)
-	sharedLinksRateLimits.Unlock()
+	resetSharedLinksRateLimits()
 	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	for index := 0; index < sharedLinksRequestsPerMinute; index++ {
 		if !allowSharedLinksRequest("app-one", now) {
@@ -203,6 +259,12 @@ func TestSharedLinksRateLimitIsPerApplicationAndResets(t *testing.T) {
 	if !allowSharedLinksRequest("app-one", now.Add(time.Minute)) {
 		t.Fatal("application limit did not reset after one minute")
 	}
+}
+
+func resetSharedLinksRateLimits() {
+	sharedLinksRateLimits.Lock()
+	sharedLinksRateLimits.windows = make(map[string]sharedLinksRateWindow)
+	sharedLinksRateLimits.Unlock()
 }
 
 func assertSharedLinksAppErrorStatus(t *testing.T, err error, status int) {

--- a/internal/swaggerdocs/openapi.json
+++ b/internal/swaggerdocs/openapi.json
@@ -8185,148 +8185,14 @@
       },
       "modelsv2.SharedLink": {
         "properties": {
-          "discord_id": {
-            "type": "string"
-          },
-          "hidden": {
-            "type": "boolean"
-          },
           "is_verified": {
             "type": "boolean"
           },
           "player_tag": {
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksAccount": {
-        "properties": {
-          "hidden": {
-            "type": "boolean"
           },
-          "is_verified": {
-            "type": "boolean"
-          },
-          "name": {
+          "user_id": {
             "type": "string"
-          },
-          "player_tag": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksApplication": {
-        "properties": {
-          "developer_name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksApplicationResponse": {
-        "properties": {
-          "application": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksApplication"
-          },
-          "redirect_uri": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksConnection": {
-        "properties": {
-          "application": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksApplication"
-          },
-          "grant": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksGrant"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksConnectionsResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.SharedLinksConnection"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksConsentResponse": {
-        "properties": {
-          "accounts": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.SharedLinksAccount"
-            },
-            "type": "array"
-          },
-          "application": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksApplication"
-          },
-          "grant": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/modelsv2.SharedLinksGrant"
-              }
-            ],
-            "type": [
-              "object",
-              "null"
-            ]
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksGrant": {
-        "properties": {
-          "access_mode": {
-            "enum": [
-              "selected",
-              "all_current_and_future"
-            ],
-            "type": "string"
-          },
-          "connected_at": {
-            "type": "string"
-          },
-          "selected_player_tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "updated_at": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksGrantRequest": {
-        "properties": {
-          "access_mode": {
-            "enum": [
-              "selected",
-              "all_current_and_future"
-            ],
-            "type": "string"
-          },
-          "player_tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "type": "object"
@@ -8350,7 +8216,7 @@
       },
       "modelsv2.SharedLinksLookupResponse": {
         "properties": {
-          "links": {
+          "items": {
             "items": {
               "$ref": "#/components/schemas/modelsv2.SharedLink"
             },
@@ -10050,6 +9916,12 @@
         "in": "header",
         "name": "Authorization",
         "type": "apiKey"
+      },
+      "DeveloperToken": {
+        "bearerFormat": "ck_dev_...",
+        "description": "Developer API token issued by ClashKing.",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },
@@ -15215,7 +15087,7 @@
     },
     "/v2/links/shared": {
       "post": {
-        "description": "Returns Discord ID and player-tag pairs with current verification and visibility metadata when covered by active grants for the authenticated developer application. Unauthorized and nonexistent identifiers are omitted identically.",
+        "description": "Returns visible Discord ID and player-tag pairs for the requested Discord IDs, player tags, or both. Hidden and nonexistent links are omitted identically. Results include both verified and unverified links.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -15281,339 +15153,12 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "DeveloperToken": []
           }
         ],
         "summary": "Look up shared Discord links",
         "tags": [
-          "Shared Links"
-        ]
-      }
-    },
-    "/v2/links/shared/applications/{application_id}": {
-      "get": {
-        "description": "Returns the public application identity used by the connected-app consent page. When redirect_uri is supplied, it must exactly match the application's registered URI.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Exact registered redirect URI",
-            "in": "query",
-            "name": "redirect_uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksApplicationResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "summary": "Get a shared-links application",
-        "tags": [
-          "Shared Links"
-        ]
-      }
-    },
-    "/v2/links/shared/grants": {
-      "get": {
-        "description": "Returns the authenticated user's active read-only application grants.",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksConnectionsResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "List connected shared-links applications",
-        "tags": [
-          "Shared Links"
-        ]
-      }
-    },
-    "/v2/links/shared/grants/{application_id}": {
-      "delete": {
-        "description": "Revokes the current user's grant and removes its stored selected-account rows. The operation is idempotent.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "Revoke shared-links access",
-        "tags": [
-          "Shared Links"
-        ]
-      },
-      "get": {
-        "description": "Returns the active application, the authenticated user's linked accounts with verification and visibility metadata, and any current read-only grant.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksConsentResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "Get shared-links consent details",
-        "tags": [
-          "Shared Links"
-        ]
-      },
-      "put": {
-        "description": "Grants an application read access to selected linked accounts or all current and future linked accounts.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/modelsv2.SharedLinksGrantRequest"
-              }
-            }
-          },
-          "description": "Grant selection",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksGrant"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "Grant shared-links access",
-        "tags": [
-          "Shared Links"
+          "Links"
         ]
       }
     },
@@ -27729,9 +27274,6 @@
     },
     {
       "name": "Server Tickets"
-    },
-    {
-      "name": "Shared Links"
     },
     {
       "name": "Web Authentication"

--- a/internal/swaggerdocs/openapi.scalar.json
+++ b/internal/swaggerdocs/openapi.scalar.json
@@ -8185,148 +8185,14 @@
       },
       "modelsv2.SharedLink": {
         "properties": {
-          "discord_id": {
-            "type": "string"
-          },
-          "hidden": {
-            "type": "boolean"
-          },
           "is_verified": {
             "type": "boolean"
           },
           "player_tag": {
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksAccount": {
-        "properties": {
-          "hidden": {
-            "type": "boolean"
           },
-          "is_verified": {
-            "type": "boolean"
-          },
-          "name": {
+          "user_id": {
             "type": "string"
-          },
-          "player_tag": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksApplication": {
-        "properties": {
-          "developer_name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksApplicationResponse": {
-        "properties": {
-          "application": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksApplication"
-          },
-          "redirect_uri": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksConnection": {
-        "properties": {
-          "application": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksApplication"
-          },
-          "grant": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksGrant"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksConnectionsResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.SharedLinksConnection"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksConsentResponse": {
-        "properties": {
-          "accounts": {
-            "items": {
-              "$ref": "#/components/schemas/modelsv2.SharedLinksAccount"
-            },
-            "type": "array"
-          },
-          "application": {
-            "$ref": "#/components/schemas/modelsv2.SharedLinksApplication"
-          },
-          "grant": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/modelsv2.SharedLinksGrant"
-              }
-            ],
-            "type": [
-              "object",
-              "null"
-            ]
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksGrant": {
-        "properties": {
-          "access_mode": {
-            "enum": [
-              "selected",
-              "all_current_and_future"
-            ],
-            "type": "string"
-          },
-          "connected_at": {
-            "type": "string"
-          },
-          "selected_player_tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "updated_at": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "modelsv2.SharedLinksGrantRequest": {
-        "properties": {
-          "access_mode": {
-            "enum": [
-              "selected",
-              "all_current_and_future"
-            ],
-            "type": "string"
-          },
-          "player_tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           }
         },
         "type": "object"
@@ -8350,7 +8216,7 @@
       },
       "modelsv2.SharedLinksLookupResponse": {
         "properties": {
-          "links": {
+          "items": {
             "items": {
               "$ref": "#/components/schemas/modelsv2.SharedLink"
             },
@@ -10050,6 +9916,12 @@
         "in": "header",
         "name": "Authorization",
         "type": "apiKey"
+      },
+      "DeveloperToken": {
+        "bearerFormat": "ck_dev_...",
+        "description": "Developer API token issued by ClashKing.",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },
@@ -15216,7 +15088,7 @@
     },
     "/v2/links/shared": {
       "post": {
-        "description": "Returns Discord ID and player-tag pairs with current verification and visibility metadata when covered by active grants for the authenticated developer application. Unauthorized and nonexistent identifiers are omitted identically.",
+        "description": "Returns visible Discord ID and player-tag pairs for the requested Discord IDs, player tags, or both. Hidden and nonexistent links are omitted identically. Results include both verified and unverified links.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -15282,339 +15154,12 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "DeveloperToken": []
           }
         ],
         "summary": "Look up shared Discord links",
         "tags": [
-          "Shared Links"
-        ]
-      }
-    },
-    "/v2/links/shared/applications/{application_id}": {
-      "get": {
-        "description": "Returns the public application identity used by the connected-app consent page. When redirect_uri is supplied, it must exactly match the application's registered URI.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Exact registered redirect URI",
-            "in": "query",
-            "name": "redirect_uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksApplicationResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "summary": "Get a shared-links application",
-        "tags": [
-          "Shared Links"
-        ]
-      }
-    },
-    "/v2/links/shared/grants": {
-      "get": {
-        "description": "Returns the authenticated user's active read-only application grants.",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksConnectionsResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "List connected shared-links applications",
-        "tags": [
-          "Shared Links"
-        ]
-      }
-    },
-    "/v2/links/shared/grants/{application_id}": {
-      "delete": {
-        "description": "Revokes the current user's grant and removes its stored selected-account rows. The operation is idempotent.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "Revoke shared-links access",
-        "tags": [
-          "Shared Links"
-        ]
-      },
-      "get": {
-        "description": "Returns the active application, the authenticated user's linked accounts with verification and visibility metadata, and any current read-only grant.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksConsentResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "Get shared-links consent details",
-        "tags": [
-          "Shared Links"
-        ]
-      },
-      "put": {
-        "description": "Grants an application read access to selected linked accounts or all current and future linked accounts.",
-        "parameters": [
-          {
-            "description": "Application ID",
-            "in": "path",
-            "name": "application_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/modelsv2.SharedLinksGrantRequest"
-              }
-            }
-          },
-          "description": "Grant selection",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.SharedLinksGrant"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/modelsv2.ErrorResponse"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "summary": "Grant shared-links access",
-        "tags": [
-          "Shared Links"
+          "Links"
         ]
       }
     },
@@ -27735,9 +27280,6 @@
     },
     {
       "name": "Server Tickets"
-    },
-    {
-      "name": "Shared Links"
     },
     {
       "name": "Web Authentication"

--- a/internal/swaggerdocs/openapi.yaml
+++ b/internal/swaggerdocs/openapi.yaml
@@ -5371,98 +5371,12 @@ components:
             type: object
         modelsv2.SharedLink:
             properties:
-                discord_id:
-                    type: string
-                hidden:
-                    type: boolean
                 is_verified:
                     type: boolean
                 player_tag:
                     type: string
-            type: object
-        modelsv2.SharedLinksAccount:
-            properties:
-                hidden:
-                    type: boolean
-                is_verified:
-                    type: boolean
-                name:
+                user_id:
                     type: string
-                player_tag:
-                    type: string
-            type: object
-        modelsv2.SharedLinksApplication:
-            properties:
-                developer_name:
-                    type: string
-                id:
-                    type: string
-                name:
-                    type: string
-            type: object
-        modelsv2.SharedLinksApplicationResponse:
-            properties:
-                application:
-                    $ref: '#/components/schemas/modelsv2.SharedLinksApplication'
-                redirect_uri:
-                    type: string
-            type: object
-        modelsv2.SharedLinksConnection:
-            properties:
-                application:
-                    $ref: '#/components/schemas/modelsv2.SharedLinksApplication'
-                grant:
-                    $ref: '#/components/schemas/modelsv2.SharedLinksGrant'
-            type: object
-        modelsv2.SharedLinksConnectionsResponse:
-            properties:
-                items:
-                    items:
-                        $ref: '#/components/schemas/modelsv2.SharedLinksConnection'
-                    type: array
-            type: object
-        modelsv2.SharedLinksConsentResponse:
-            properties:
-                accounts:
-                    items:
-                        $ref: '#/components/schemas/modelsv2.SharedLinksAccount'
-                    type: array
-                application:
-                    $ref: '#/components/schemas/modelsv2.SharedLinksApplication'
-                grant:
-                    allOf:
-                        - $ref: '#/components/schemas/modelsv2.SharedLinksGrant'
-                    type:
-                        - object
-                        - "null"
-            type: object
-        modelsv2.SharedLinksGrant:
-            properties:
-                access_mode:
-                    enum:
-                        - selected
-                        - all_current_and_future
-                    type: string
-                connected_at:
-                    type: string
-                selected_player_tags:
-                    items:
-                        type: string
-                    type: array
-                updated_at:
-                    type: string
-            type: object
-        modelsv2.SharedLinksGrantRequest:
-            properties:
-                access_mode:
-                    enum:
-                        - selected
-                        - all_current_and_future
-                    type: string
-                player_tags:
-                    items:
-                        type: string
-                    type: array
             type: object
         modelsv2.SharedLinksLookupRequest:
             properties:
@@ -5477,7 +5391,7 @@ components:
             type: object
         modelsv2.SharedLinksLookupResponse:
             properties:
-                links:
+                items:
                     items:
                         $ref: '#/components/schemas/modelsv2.SharedLink'
                     type: array
@@ -6602,6 +6516,11 @@ components:
             in: header
             name: Authorization
             type: apiKey
+        DeveloperToken:
+            bearerFormat: ck_dev_...
+            description: Developer API token issued by ClashKing.
+            scheme: bearer
+            type: http
 info:
     contact: {}
     description: "### Clash of Clans Based API \U0001F451\n- No Auth Required, Free to Use\n- Please credit if using these stats in your project, Creator Code: ClashKing\n- Ratelimit is largely 30 req/sec, 5 req/sec on post & large requests\n- Largely 300 second cache\n- Not perfect, stats are collected by polling the Official API\n- [ClashKing Discord](https://discord.gg/mCQkUBpUta) | [API Developers](https://discord.gg/clashapi)\n\nThis content is not affiliated with, endorsed, sponsored, or specifically approved by Supercell and Supercell is not responsible for it.\nFor more information see [Supercell's Fan Content Policy](https://supercell.com/fan-content-policy)"
@@ -10480,7 +10399,7 @@ paths:
                 - Links
     /v2/links/shared:
         post:
-            description: Returns Discord ID and player-tag pairs with current verification and visibility metadata when covered by active grants for the authenticated developer application. Unauthorized and nonexistent identifiers are omitted identically.
+            description: Returns visible Discord ID and player-tag pairs for the requested Discord IDs, player tags, or both. Hidden and nonexistent links are omitted identically. Results include both verified and unverified links.
             requestBody:
                 content:
                     application/json:
@@ -10520,207 +10439,10 @@ paths:
                                 $ref: '#/components/schemas/modelsv2.ErrorResponse'
                     description: Service Unavailable
             security:
-                - ApiKeyAuth: []
+                - DeveloperToken: []
             summary: Look up shared Discord links
             tags:
-                - Shared Links
-    /v2/links/shared/applications/{application_id}:
-        get:
-            description: Returns the public application identity used by the connected-app consent page. When redirect_uri is supplied, it must exactly match the application's registered URI.
-            parameters:
-                - description: Application ID
-                  in: path
-                  name: application_id
-                  required: true
-                  schema:
-                    type: string
-                - description: Exact registered redirect URI
-                  in: query
-                  name: redirect_uri
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.SharedLinksApplicationResponse'
-                    description: OK
-                "400":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Bad Request
-                "404":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Not Found
-                "503":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Service Unavailable
-            summary: Get a shared-links application
-            tags:
-                - Shared Links
-    /v2/links/shared/grants:
-        get:
-            description: Returns the authenticated user's active read-only application grants.
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.SharedLinksConnectionsResponse'
-                    description: OK
-                "401":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Unauthorized
-                "503":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Service Unavailable
-            security:
-                - ApiKeyAuth: []
-            summary: List connected shared-links applications
-            tags:
-                - Shared Links
-    /v2/links/shared/grants/{application_id}:
-        delete:
-            description: Revokes the current user's grant and removes its stored selected-account rows. The operation is idempotent.
-            parameters:
-                - description: Application ID
-                  in: path
-                  name: application_id
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "204":
-                    description: No Content
-                "400":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Bad Request
-                "401":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Unauthorized
-                "503":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Service Unavailable
-            security:
-                - ApiKeyAuth: []
-            summary: Revoke shared-links access
-            tags:
-                - Shared Links
-        get:
-            description: Returns the active application, the authenticated user's linked accounts with verification and visibility metadata, and any current read-only grant.
-            parameters:
-                - description: Application ID
-                  in: path
-                  name: application_id
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.SharedLinksConsentResponse'
-                    description: OK
-                "401":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Unauthorized
-                "404":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Not Found
-                "503":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Service Unavailable
-            security:
-                - ApiKeyAuth: []
-            summary: Get shared-links consent details
-            tags:
-                - Shared Links
-        put:
-            description: Grants an application read access to selected linked accounts or all current and future linked accounts.
-            parameters:
-                - description: Application ID
-                  in: path
-                  name: application_id
-                  required: true
-                  schema:
-                    type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/modelsv2.SharedLinksGrantRequest'
-                description: Grant selection
-                required: true
-            responses:
-                "200":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.SharedLinksGrant'
-                    description: OK
-                "400":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Bad Request
-                "401":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Unauthorized
-                "404":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Not Found
-                "503":
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/modelsv2.ErrorResponse'
-                    description: Service Unavailable
-            security:
-                - ApiKeyAuth: []
-            summary: Grant shared-links access
-            tags:
-                - Shared Links
+                - Links
     /v2/me:
         get:
             description: Returns the authenticated user's current profile information.
@@ -17381,6 +17103,5 @@ tags:
     - name: Server Settings
     - name: Server Strikes
     - name: Server Tickets
-    - name: Shared Links
     - name: Web Authentication
     - name: Other

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -35,7 +35,6 @@ type Config struct {
 	WebTokenAudience             string
 	LandingOrigin                string
 	DashboardOrigin              string
-	ConnectOrigin                string
 	AppOrigin                    string
 	WebAllowedOrigins            []string
 	DiscordRedirectURI           string
@@ -71,7 +70,7 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
-	landingOrigin, dashboardOrigin, connectOrigin, appOrigin := webOrigins(os.Getenv)
+	landingOrigin, dashboardOrigin, appOrigin := webOrigins(os.Getenv)
 	cfg := Config{
 		TimescaleURL:                 buildTimescaleURL(os.Getenv),
 		ValkeyAddress:                buildValkeyAddress(os.Getenv),
@@ -95,9 +94,8 @@ func Load() (Config, error) {
 		WebTokenAudience:             firstNonEmpty(os.Getenv("WEB_TOKEN_AUDIENCE"), "clashking-web"),
 		LandingOrigin:                landingOrigin,
 		DashboardOrigin:              dashboardOrigin,
-		ConnectOrigin:                connectOrigin,
 		AppOrigin:                    appOrigin,
-		WebAllowedOrigins:            nonEmptyStrings(landingOrigin, dashboardOrigin, connectOrigin, appOrigin),
+		WebAllowedOrigins:            nonEmptyStrings(landingOrigin, dashboardOrigin, appOrigin),
 		DiscordRedirectURI:           appendOriginPath(dashboardOrigin, "/auth/callback"),
 		DiscordClientID:              os.Getenv("DISCORD_CLIENT_ID"),
 		DiscordClientSecret:          os.Getenv("DISCORD_CLIENT_SECRET"),
@@ -145,12 +143,11 @@ func Load() (Config, error) {
 	return cfg, nil
 }
 
-func webOrigins(getenv func(string) string) (landing, dashboard, connect, app string) {
+func webOrigins(getenv func(string) string) (landing, dashboard, app string) {
 	landing = normalizeOrigin(getenv("CLASHKING_LANDING_ORIGIN"))
 	dashboard = normalizeOrigin(getenv("CLASHKING_DASHBOARD_ORIGIN"))
-	connect = normalizeOrigin(firstNonEmpty(getenv("CLASHKING_CONNECT_ORIGIN"), "https://connect.clashk.ing"))
 	app = normalizeOrigin(firstNonEmpty(getenv("CLASHKING_APP_ORIGIN"), "https://app.clashk.ing"))
-	return landing, dashboard, connect, app
+	return landing, dashboard, app
 }
 
 func (c Config) Addr() string {
@@ -169,7 +166,6 @@ func (c Config) validate() error {
 		"CLASHKING_PROXY_INTERNAL_ORIGIN": c.ProxyOrigin,
 		"CLASHKING_LANDING_ORIGIN":        c.LandingOrigin,
 		"CLASHKING_DASHBOARD_ORIGIN":      c.DashboardOrigin,
-		"CLASHKING_CONNECT_ORIGIN":        c.ConnectOrigin,
 	}
 	var missing []string
 	for key, value := range required {

--- a/internal/utils/config_test.go
+++ b/internal/utils/config_test.go
@@ -5,18 +5,15 @@ import (
 	"testing"
 )
 
-func TestWebOriginsIncludeStandaloneConnectHost(t *testing.T) {
+func TestWebOriginsIncludeLandingDashboardAndAppHosts(t *testing.T) {
 	values := map[string]string{
 		"CLASHKING_LANDING_ORIGIN":   "https://clashk.ing/",
 		"CLASHKING_DASHBOARD_ORIGIN": "https://dash.clashk.ing/",
 	}
 
-	landing, dashboard, connect, app := webOrigins(func(key string) string { return values[key] })
+	landing, dashboard, app := webOrigins(func(key string) string { return values[key] })
 	if landing != "https://clashk.ing" || dashboard != "https://dash.clashk.ing" {
-		t.Fatalf("webOrigins() = %q, %q, %q, %q", landing, dashboard, connect, app)
-	}
-	if connect != "https://connect.clashk.ing" {
-		t.Fatalf("connect origin = %q, want https://connect.clashk.ing", connect)
+		t.Fatalf("webOrigins() = %q, %q, %q", landing, dashboard, app)
 	}
 	if app != "https://app.clashk.ing" {
 		t.Fatalf("app origin = %q, want https://app.clashk.ing", app)
@@ -28,7 +25,7 @@ func TestWebOriginsNormalizeExplicitAppOrigin(t *testing.T) {
 		"CLASHKING_APP_ORIGIN": " https://staging-app.clashk.ing/ ",
 	}
 
-	_, _, _, app := webOrigins(func(key string) string { return values[key] })
+	_, _, app := webOrigins(func(key string) string { return values[key] })
 	if app != "https://staging-app.clashk.ing" {
 		t.Fatalf("app origin = %q, want https://staging-app.clashk.ing", app)
 	}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,9 @@ import (
 // @securityDefinitions.apikey ApiKeyAuth
 // @in header
 // @name Authorization
+// @securityDefinitions.apikey DeveloperToken
+// @in header
+// @name Authorization
 type App struct {
 	utils.Deps
 	StartedAt time.Time

--- a/test/api/swagger_test.go
+++ b/test/api/swagger_test.go
@@ -192,6 +192,13 @@ func TestBuildDocIncludesPublicAndAuthenticatedOperations(t *testing.T) {
 func TestSharedLinksDocUsesLinksTagDeveloperTokenAndItemsEnvelope(t *testing.T) {
 	doc := buildSwaggerDoc(t)
 	paths := swaggerPaths(t, doc)
+	assertSharedLinksOperationDoc(t, paths)
+	assertSharedLinksSchemaDoc(t, swaggerDefinitions(t, doc))
+	assertConnectedAppPathsRemoved(t, paths)
+}
+
+func assertSharedLinksOperationDoc(t *testing.T, paths map[string]any) {
+	t.Helper()
 	path, ok := paths["/v2/links/shared"].(map[string]any)
 	if !ok {
 		t.Fatal("expected /v2/links/shared path")
@@ -212,8 +219,10 @@ func TestSharedLinksDocUsesLinksTagDeveloperTokenAndItemsEnvelope(t *testing.T) 
 	if _, ok := requirement["DeveloperToken"]; !ok {
 		t.Fatalf("shared links security = %#v", security)
 	}
+}
 
-	definitions := swaggerDefinitions(t, doc)
+func assertSharedLinksSchemaDoc(t *testing.T, definitions map[string]any) {
+	t.Helper()
 	response := definitions["modelsv2.SharedLinksLookupResponse"].(map[string]any)
 	properties := response["properties"].(map[string]any)
 	if _, ok := properties["items"]; !ok {
@@ -234,7 +243,10 @@ func TestSharedLinksDocUsesLinksTagDeveloperTokenAndItemsEnvelope(t *testing.T) 
 			t.Fatalf("shared link schema exposes obsolete %s: %#v", name, itemProperties)
 		}
 	}
+}
 
+func assertConnectedAppPathsRemoved(t *testing.T, paths map[string]any) {
+	t.Helper()
 	for _, obsolete := range []string{
 		"/v2/links/shared/applications/{application_id}",
 		"/v2/links/shared/grants",

--- a/test/api/swagger_test.go
+++ b/test/api/swagger_test.go
@@ -31,6 +31,13 @@ func TestOpenAPIDocumentIncludesAuthorizationScheme(t *testing.T) {
 	if apiKey["name"] != "Authorization" {
 		t.Fatalf("expected Authorization header name, got %v", apiKey["name"])
 	}
+	developerToken, ok := securitySchemes["DeveloperToken"].(map[string]any)
+	if !ok {
+		t.Fatal("expected DeveloperToken definition")
+	}
+	if developerToken["type"] != "http" || developerToken["scheme"] != "bearer" {
+		t.Fatalf("DeveloperToken scheme = %#v", developerToken)
+	}
 }
 
 func TestScalarUIHandlerServesDefaultDocs(t *testing.T) {
@@ -179,6 +186,63 @@ func TestBuildDocIncludesPublicAndAuthenticatedOperations(t *testing.T) {
 	security, ok := get["security"].([]any)
 	if !ok || len(security) == 0 {
 		t.Fatal("expected /v2/me to preserve ApiKeyAuth security marker")
+	}
+}
+
+func TestSharedLinksDocUsesLinksTagDeveloperTokenAndItemsEnvelope(t *testing.T) {
+	doc := buildSwaggerDoc(t)
+	paths := swaggerPaths(t, doc)
+	path, ok := paths["/v2/links/shared"].(map[string]any)
+	if !ok {
+		t.Fatal("expected /v2/links/shared path")
+	}
+	operation, ok := path["post"].(map[string]any)
+	if !ok {
+		t.Fatal("expected POST /v2/links/shared operation")
+	}
+	tags, _ := operation["tags"].([]any)
+	if !reflect.DeepEqual(tags, []any{"Links"}) {
+		t.Fatalf("shared links tags = %#v", tags)
+	}
+	security, _ := operation["security"].([]any)
+	if len(security) != 1 {
+		t.Fatalf("shared links security = %#v", security)
+	}
+	requirement, _ := security[0].(map[string]any)
+	if _, ok := requirement["DeveloperToken"]; !ok {
+		t.Fatalf("shared links security = %#v", security)
+	}
+
+	definitions := swaggerDefinitions(t, doc)
+	response := definitions["modelsv2.SharedLinksLookupResponse"].(map[string]any)
+	properties := response["properties"].(map[string]any)
+	if _, ok := properties["items"]; !ok {
+		t.Fatalf("shared links response properties = %#v", properties)
+	}
+	if _, ok := properties["links"]; ok {
+		t.Fatalf("shared links response still exposes links envelope: %#v", properties)
+	}
+	item := definitions["modelsv2.SharedLink"].(map[string]any)
+	itemProperties := item["properties"].(map[string]any)
+	for _, name := range []string{"is_verified", "player_tag", "user_id"} {
+		if _, ok := itemProperties[name]; !ok {
+			t.Fatalf("shared link schema missing %s: %#v", name, itemProperties)
+		}
+	}
+	for _, name := range []string{"hidden", "discord_id"} {
+		if _, ok := itemProperties[name]; ok {
+			t.Fatalf("shared link schema exposes obsolete %s: %#v", name, itemProperties)
+		}
+	}
+
+	for _, obsolete := range []string{
+		"/v2/links/shared/applications/{application_id}",
+		"/v2/links/shared/grants",
+		"/v2/links/shared/grants/{application_id}",
+	} {
+		if _, ok := paths[obsolete]; ok {
+			t.Fatalf("obsolete connected-app path remains documented: %s", obsolete)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace connected-app grants with one developer-token `POST /v2/links/shared` lookup
- accept Discord IDs and player tags together, exclude hidden links, and return the unified `items` envelope
- record authenticated API calls and normalized identifier lookups on `developer_applications`
- remove consent routes, privacy grant references, and the standalone connect origin
- document the route under Links with a dedicated Bearer-token security scheme

## Contract
```json
{
  "discord_ids": ["706149153431879760"],
  "player_tags": ["#2PP"]
}
```

```json
{
  "items": [
    {
      "is_verified": true,
      "player_tag": "#2PP",
      "user_id": "706149153431879760"
    }
  ]
}
```

## Validation
- `go generate ./...`
- `go test ./...`
- `git diff --check`

## Deployment dependency
This API expects the DevKit migration that adds `api_request_count` and `links_lookup_count`. Deploy the compatible schema before this API change; do not deploy this PR against the current `developer_applications` shape.