### PR TITLE
fix(api): align proxy series contract

### DIFF
--- a/packages/api-contracts/src/admin.test.ts
+++ b/packages/api-contracts/src/admin.test.ts
@@ -1,7 +1,7 @@
 import { Schema } from "effect"
 import { describe, expect, it } from "vitest"
 
-import { AdminUser } from "./admin.js"
+import { AdminUser, ProxyStatsResponse } from "./admin.js"
 
 describe("Admin identity contract", () => {
   it("accepts the original Access profile without account timestamps", () => {
@@ -11,5 +11,26 @@ describe("Admin identity contract", () => {
     }
     expect(Schema.decodeUnknownSync(AdminUser)(profile)).toEqual(profile)
     expect(Schema.encodeUnknownSync(AdminUser)(profile)).toEqual(profile)
+  })
+})
+
+describe("Admin proxy statistics contract", () => {
+  it("accepts proxy series points without a derived average request rate", () => {
+    const statusCounts = { "2xx": 1, "3xx": 0, "4xx": 0, "5xx": 0 }
+    const response = {
+      now: "2026-09-09T12:00:00Z",
+      windows: {
+        "1m": { requests: 1, avg_rps: 1 / 60, avg_latency_ms: 12, status_counts: statusCounts, proxy_failures: 0 },
+      },
+      series_data: {
+        interval: "5m",
+        lookback: "1h",
+        points: [{
+          start: "2026-09-09T11:00:00Z", end: "2026-09-09T11:05:00Z", requests: 1,
+          avg_latency_ms: 12, status_counts: statusCounts, proxy_failures: 0,
+        }],
+      },
+    }
+    expect(Schema.encodeUnknownSync(ProxyStatsResponse)(response)).toEqual(response)
   })
 })

--- a/packages/api-contracts/src/admin.ts
+++ b/packages/api-contracts/src/admin.ts
@@ -333,7 +333,10 @@ export const ProxyStatsWindow = Schema.Struct({
   requests: Count, avg_rps: Schema.Number, avg_latency_ms: Schema.NullOr(Schema.Number),
   status_counts: ProxyStatusCounts, proxy_failures: Count,
 })
-export const ProxySeriesPoint = Schema.Struct({ ...ProxyStatsWindow.fields, start: Schema.String, end: Schema.String })
+export const ProxySeriesPoint = Schema.Struct({
+  start: Schema.String, end: Schema.String, requests: Count,
+  avg_latency_ms: Schema.NullOr(Schema.Number), status_counts: ProxyStatusCounts, proxy_failures: Count,
+})
 export const ProxyStatsResponse = Schema.Struct({
   now: Schema.String,
   windows: Schema.Record(Schema.String, ProxyStatsWindow),


### PR DESCRIPTION
The Admin proxy health request fails after the proxy returns valid series data because the shared response contract requires `avg_rps` on every series point, while ClashKingProxy only emits that derived rate on summary windows.

This aligns `ProxySeriesPoint` with the live proxy response and adds a regression test covering series points without `avg_rps`.

Validation:
- `npm test -- --run packages/api-contracts/src/admin.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
