### PR TITLE
perf(api): bound player history archive reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clashking/api-workspace",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0-rc.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clashking/api-workspace",
-      "version": "0.1.0-rc.14",
+      "version": "0.1.0-rc.15",
       "workspaces": [
         "packages/*",
         "workers/api"
@@ -4270,10 +4270,10 @@
     },
     "packages/api-client": {
       "name": "@clashking/api-client",
-      "version": "0.1.0-rc.14",
+      "version": "0.1.0-rc.15",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@clashking/api-contracts": "0.1.0-rc.14",
+        "@clashking/api-contracts": "0.1.0-rc.15",
         "effect": "4.0.0-rc.112"
       },
       "devDependencies": {
@@ -4286,7 +4286,7 @@
     },
     "packages/api-contracts": {
       "name": "@clashking/api-contracts",
-      "version": "0.1.0-rc.14",
+      "version": "0.1.0-rc.15",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "effect": "4.0.0-rc.112"
@@ -4302,9 +4302,9 @@
     },
     "workers/api": {
       "name": "@clashking/api-worker",
-      "version": "0.1.0-rc.14",
+      "version": "0.1.0-rc.15",
       "dependencies": {
-        "@clashking/api-contracts": "0.1.0-rc.14",
+        "@clashking/api-contracts": "0.1.0-rc.15",
         "@effect/sql-pg": "4.0.0-rc.112",
         "bcryptjs": "3.0.3",
         "effect": "4.0.0-rc.112",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clashking/api-workspace",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0-rc.15",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clashking/api-client",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0-rc.15",
   "license": "SEE LICENSE IN LICENSE",
   "description": "Effect-based transport, auth, service-binding execution, and decoding for the ClashKing v2 API",
   "repository": {
@@ -26,7 +26,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit --pretty false"
   },
   "dependencies": {
-    "@clashking/api-contracts": "0.1.0-rc.14",
+    "@clashking/api-contracts": "0.1.0-rc.15",
     "effect": "4.0.0-rc.112"
   },
   "devDependencies": {

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clashking/api-contracts",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0-rc.15",
   "license": "SEE LICENSE IN LICENSE",
   "description": "Browser-safe Effect schemas and endpoint metadata for the ClashKing v2 API",
   "repository": {

--- a/packages/api-contracts/src/health.test.ts
+++ b/packages/api-contracts/src/health.test.ts
@@ -12,14 +12,14 @@ describe("Worker liveness contract", () => {
     })
     expect(HealthEndpoint.summary).toContain("does not check database or provider readiness")
     expect(Schema.decodeUnknownSync(HealthResponse)({
-      status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.14",
-    })).toEqual({ status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.14" })
+      status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.15",
+    })).toEqual({ status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.15" })
   })
 
   it("does not describe invented status, runtime, or version values as valid", () => {
     for (const changed of [{ status: "database-healthy" }, { runtime: "go" }, { version: "1.0.0" }]) {
       expect(() => Schema.decodeUnknownSync(HealthResponse)({
-        status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.14", ...changed,
+        status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.15", ...changed,
       })).toThrow()
     }
   })

--- a/packages/api-contracts/src/health.ts
+++ b/packages/api-contracts/src/health.ts
@@ -6,7 +6,7 @@ import { defineEndpoint, NoBody, NoPathParams, NoQuery } from "./endpoint.js"
 export const HealthResponse = Schema.Struct({
   status: Schema.Literal("ok"),
   runtime: Schema.Literal("cloudflare-worker"),
-  version: Schema.Literal("0.1.0-rc.14"),
+  version: Schema.Literal("0.1.0-rc.15"),
 })
 
 export const HealthEndpoint = defineEndpoint({

--- a/scripts/api-package-release.test.mjs
+++ b/scripts/api-package-release.test.mjs
@@ -6,7 +6,7 @@ import { join } from "node:path"
 import { test } from "node:test"
 import { packageNames, parsePackOutput, validatePack, validatePair, verify } from "./api-package-release.mjs"
 
-const version = "0.1.0-rc.14", tag = `v${version}`, commit = "a".repeat(40)
+const version = "0.1.0-rc.15", tag = `v${version}`, commit = "a".repeat(40)
 const packages = () => packageNames.map(name => ({ name, version,
   dependencies: { effect: "4.0.0-rc.112", ...(name === packageNames[1] ? { [packageNames[0]]: version } : {}) },
   peerDependencies: { effect: "4.0.0-rc.112", ...(name === packageNames[0] ? { "@clashking/clash-contract": ">=0.1.2 <2" } : {}) },
@@ -28,11 +28,11 @@ test("accepts npm workspace pack output and rejects ambiguous output", () => {
 
 test("requires a coherent package pair and matching GitHub Release tag", () => {
   assert.equal(validatePair(...packages(), tag), version)
-  for (const badTag of [undefined, "api-packages-v0.1.0-rc.14", "v0.1.0-rc.5"]) {
+  for (const badTag of [undefined, "api-packages-v0.1.0-rc.15", "v0.1.0-rc.5"]) {
     assert.throws(() => validatePair(...packages(), badTag), /Release tag/u)
   }
   const pair = packages()
-  pair[1].dependencies[packageNames[0]] = "^0.1.0-rc.14"
+  pair[1].dependencies[packageNames[0]] = "^0.1.0-rc.15"
   assert.throws(() => validatePair(...pair, tag), /exact contracts/u)
   const invalidPeer = packages()
   invalidPeer[0].peerDependencies["@clashking/clash-contract"] = "0.1.2"

--- a/scripts/api-release-version.test.mjs
+++ b/scripts/api-release-version.test.mjs
@@ -3,23 +3,23 @@ import { readFileSync } from "node:fs"
 import { test } from "node:test"
 import { validatePullRequestVersion, validateReleaseVersion } from "./api-release-version.mjs"
 
-const pair = (version = "0.1.0-rc.14") => [
+const pair = (version = "0.1.0-rc.15") => [
   { name: "@clashking/api-contracts", version },
   { name: "@clashking/api-client", version, dependencies: { "@clashking/api-contracts": version } },
 ]
 
 test("requires one exact semantic version across the release package pair", () => {
-  assert.equal(validateReleaseVersion(...pair()), "0.1.0-rc.14")
+  assert.equal(validateReleaseVersion(...pair()), "0.1.0-rc.15")
   const mismatch = pair(); mismatch[1].version = "0.1.0-rc.12"
   assert.throws(() => validateReleaseVersion(...mismatch), /same valid semantic version/u)
-  const dependency = pair(); dependency[1].dependencies["@clashking/api-contracts"] = "^0.1.0-rc.14"
+  const dependency = pair(); dependency[1].dependencies["@clashking/api-contracts"] = "^0.1.0-rc.15"
   assert.throws(() => validateReleaseVersion(...dependency), /exact contracts version/u)
   assert.throws(() => validateReleaseVersion(...pair("next")), /semantic version/u)
 })
 
 test("blocks unchanged pull-request versions and versions whose tag already exists", () => {
-  assert.equal(validatePullRequestVersion(pair("0.1.0-rc.14"), pair("0.1.0-rc.11"), false), "0.1.0-rc.14")
-  assert.equal(validatePullRequestVersion(pair("0.1.0-rc.14"), undefined, false), "0.1.0-rc.14")
+  assert.equal(validatePullRequestVersion(pair("0.1.0-rc.15"), pair("0.1.0-rc.11"), false), "0.1.0-rc.15")
+  assert.equal(validatePullRequestVersion(pair("0.1.0-rc.15"), undefined, false), "0.1.0-rc.15")
   assert.throws(() => validatePullRequestVersion(pair(), pair(), false), /must update/u)
   assert.throws(() => validatePullRequestVersion(pair(), pair("0.1.0-rc.11"), true), /already exists/u)
 })

--- a/scripts/health-openapi.test.mjs
+++ b/scripts/health-openapi.test.mjs
@@ -21,7 +21,7 @@ test("OpenAPI documents exact public Worker liveness without readiness claims", 
     assert.deepEqual(response.required.sort(), ["runtime", "status", "version"])
     assert.deepEqual(response.properties.status.enum, ["ok"])
     assert.deepEqual(response.properties.runtime.enum, ["cloudflare-worker"])
-    assert.deepEqual(response.properties.version.enum, ["0.1.0-rc.14"])
+    assert.deepEqual(response.properties.version.enum, ["0.1.0-rc.15"])
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clashking/api-worker",
-  "version": "0.1.0-rc.14",
+  "version": "0.1.0-rc.15",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,7 +12,7 @@
     "types": "wrangler types --cwd ../.. workers/api/worker-configuration.d.ts"
   },
   "dependencies": {
-    "@clashking/api-contracts": "0.1.0-rc.14",
+    "@clashking/api-contracts": "0.1.0-rc.15",
     "@effect/sql-pg": "4.0.0-rc.112",
     "bcryptjs": "3.0.3",
     "effect": "4.0.0-rc.112",

--- a/workers/api/src/public-cwl-performance.test.ts
+++ b/workers/api/src/public-cwl-performance.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs"
+import { zstdCompressSync } from "node:zlib"
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { describe, expect, it, vi } from "vitest"
+
+import { WorkerEnvironment, type WorkerBindings } from "./environment.js"
+import { queryPlayerCwlHistory } from "./public-cwl.js"
+
+const dictionary = readFileSync("workers/api/assets/war-json.zdict")
+const storedWar = (warTag: string, clanTag: string, order: number) => ({
+  warTag, state: "warEnded", teamSize: 15, attacksPerMember: 2,
+  preparationStartTime: "2026-08-01T00:00:00Z", startTime: "2026-08-02T00:00:00Z",
+  endTime: "2026-08-03T00:00:00Z", battleModifier: "",
+  clan: { tag: clanTag, name: clanTag, badgeToken: "", clanLevel: 1, attacks: 2, stars: 5,
+    destructionPercentage: 90, members: [
+      { tag: "#PYY", name: "Player", townhallLevel: 18, mapPosition: 1,
+        attacks: [{ defenderTag: "#DEF", stars: 3, destructionPercentage: 100, duration: 90, order }] },
+      { tag: "#ALLY", name: "Ally", townhallLevel: 18, mapPosition: 2,
+        attacks: [{ defenderTag: "#OTHER", stars: 2, destructionPercentage: 80, duration: 100, order: order + 1 }] },
+    ] },
+  opponent: { tag: `#O${order}`, name: "Opponent", badgeToken: "", clanLevel: 1, attacks: 0, stars: 0,
+    destructionPercentage: 0, members: [
+      { tag: "#DEF", name: "Defender", townhallLevel: 18, mapPosition: 1, attacks: [] },
+      { tag: "#OTHER", name: "Other", townhallLevel: 18, mapPosition: 2, attacks: [] },
+    ] },
+})
+
+describe("batched player CWL history", () => {
+  it("loads groups, war metadata, and archive locators once while preserving placement completeness", async () => {
+    const seeds = [
+      { cwl_id: "complete", season: "2026-08", town_hall: 18, cwl_league_id: 48_000_010, war_size: 15,
+        clan_tag: "#A", name: "A", badge_token: "", stars: null, wins: null, losses: null, ties: null, group_rank: null, global_rank: null },
+      { cwl_id: "incomplete", season: "2026-07", town_hall: 18, cwl_league_id: 48_000_010, war_size: 15,
+        clan_tag: "#B", name: "B", badge_token: "", stars: null, wins: null, losses: null, ties: null, group_rank: null, global_rank: null },
+      { cwl_id: "current", season: "2026-06", town_hall: 18, cwl_league_id: 48_000_010, war_size: 15,
+        clan_tag: "#C", name: "C", badge_token: "", stars: null, wins: null, losses: null, ties: null, group_rank: null, global_rank: null },
+    ]
+    const groups = [
+      { ...seeds[0], state: "ended", rounds: [["#W1"]], clan_tags: ["#A", "#O1"] },
+      { ...seeds[1], state: "ended", rounds: [["#W2"], ["#MISSING"]], clan_tags: ["#B", "#O2"] },
+      { ...seeds[2], state: "inWar", rounds: [["#W3"]], clan_tags: ["#C", "#O3"] },
+    ].map(({ cwl_id, season, state, rounds, cwl_league_id, war_size, clan_tags }) =>
+      ({ cwl_id, season, state, rounds, cwl_league_id, war_size, clan_tags }))
+    const wars = [
+      { war_id: "1", war_tag: "#W1", state: "warEnded", size: 15, end_time: "2026-08-03T00:00:00Z", clan_tag: "#A", opponent_tag: "#O1", clan_stars: 5, opponent_stars: 0, clan_destruction_percentage: 90, opponent_destruction_percentage: 0 },
+      { war_id: "2", war_tag: "#W2", state: "warEnded", size: 15, end_time: "2026-07-03T00:00:00Z", clan_tag: "#B", opponent_tag: "#O2", clan_stars: 5, opponent_stars: 0, clan_destruction_percentage: 90, opponent_destruction_percentage: 0 },
+      { war_id: "3", war_tag: "#W3", state: "warEnded", size: 15, end_time: "2026-06-03T00:00:00Z", clan_tag: "#C", opponent_tag: "#O3", clan_stars: 5, opponent_stars: 0, clan_destruction_percentage: 90, opponent_destruction_percentage: 0 },
+    ]
+    const frames = new Map(wars.map((war, index) => [index, zstdCompressSync(
+      JSON.stringify(storedWar(war.war_tag, war.clan_tag, (index + 1) * 10)), { dictionary })]))
+    const counts = { seeds: 0, groups: 0, wars: 0, locators: 0 }
+    const tag = ((strings: TemplateStringsArray, ...parameters: readonly unknown[]) => {
+      const statement = strings.join("?")
+      if (statement.includes("FROM cwl_group_members pm")) { counts.seeds++; return Effect.succeed(seeds) }
+      if (statement.includes("WHERE g.cwl_id = ANY")) { counts.groups++; return Effect.succeed(groups) }
+      if (statement.includes("FROM wars") && statement.includes("war_tag = ANY")) { counts.wars++; return Effect.succeed(wars) }
+      if (statement.includes("AS pending FROM wars")) {
+        counts.locators++
+        return Effect.succeed((parameters[0] as readonly string[]).map((id) => ({
+          war_id: id, war_type: "cwl", archive_pack_id: "1", archive_offset: String(Number(id) - 1),
+          archive_compressed_bytes: frames.get(Number(id) - 1)!.length, payload: null, pending: false,
+        })))
+      }
+      return Effect.die(`Unexpected SQL: ${statement}`)
+    }) as unknown as SqlClient.SqlClient
+    let active = 0, peak = 0
+    const get = vi.fn(async (_key: string, options: { range: { offset: number } }) => {
+      active++; peak = Math.max(peak, active)
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      active--
+      const frame = frames.get(options.range.offset)!
+      return { body: new ReadableStream(), arrayBuffer: async () => frame.buffer.slice(frame.byteOffset, frame.byteOffset + frame.byteLength) }
+    })
+    const layer = Layer.merge(Layer.succeed(SqlClient.SqlClient, tag),
+      Layer.succeed(WorkerEnvironment, { WAR_ARCHIVE: { get } } as unknown as WorkerBindings))
+
+    const result = await Effect.runPromise(queryPlayerCwlHistory("#PYY", new URLSearchParams()).pipe(Effect.provide(layer)))
+
+    expect(counts).toEqual({ seeds: 1, groups: 1, wars: 1, locators: 1 })
+    expect(get).toHaveBeenCalledTimes(3)
+    expect(peak).toBe(3)
+    expect(result.items.map((item) => item.placement)).toEqual([{ clan: 1, group: 1 }, null, null])
+    expect(result.items.map((item) => item.missedAttacks)).toEqual([1, 1, 1])
+    expect(result.items.map((item) => item.attacks[0]?.round)).toEqual([1, 1, 1])
+  })
+})

--- a/workers/api/src/public-cwl.ts
+++ b/workers/api/src/public-cwl.ts
@@ -5,7 +5,7 @@ import { DatabaseFailure, InvalidRequest } from "./errors.js"
 import { publicTag } from "./public-war.js"
 import { lookupStaticItem } from "./static-metadata.js"
 import { badgeUrls } from "./war-archive-model.js"
-import { readArchiveWar } from "./war-archive.js"
+import { forEachArchiveWar } from "./war-archive.js"
 
 const failure = (cause: unknown) => new DatabaseFailure({ cause, message: "CWL history query failed" })
 const unranked = 48_000_000
@@ -33,15 +33,30 @@ const historyLimit = (query: URLSearchParams, fallback: number) => {
   const limit = query.has("limit") ? Number(query.get("limit")) : fallback
   return Number.isSafeInteger(limit) && limit > 0 ? Effect.succeed(limit) : Effect.fail(new InvalidRequest({ message: "Limit must be a positive integer" }))
 }
+type StoredCwlGroup = Omit<CwlGroup, "rounds"> & { rounds: unknown }
+const decodeCwlGroups = (rows: readonly StoredCwlGroup[]) => Effect.forEach(rows, (row) =>
+  decodeStoredCwlRounds(row.rounds).pipe(Effect.map((rounds): CwlGroup => ({ ...row, rounds })), Effect.mapError(failure)))
 export const loadCwlGroups = (clanTag: string) => Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient
-  const rows = yield* sql<Omit<CwlGroup, "rounds"> & { rounds: unknown }>`SELECT g.cwl_id, g.season, g.state, g.rounds, g.cwl_league_id, g.war_size,
+  const rows = yield* sql<StoredCwlGroup>`SELECT g.cwl_id, g.season, g.state, g.rounds, g.cwl_league_id, g.war_size,
     array_agg(all_clans.clan_tag ORDER BY all_clans.clan_tag) AS clan_tags
     FROM cwl_groups g JOIN cwl_group_clans requested ON requested.cwl_id = g.cwl_id
     JOIN cwl_group_clans all_clans ON all_clans.cwl_id = g.cwl_id WHERE requested.clan_tag = ${clanTag}
     GROUP BY g.cwl_id, g.season, g.state, g.rounds, g.cwl_league_id, g.war_size
     ORDER BY CASE WHEN length(g.season) = 7 THEN g.season || '-01' ELSE g.season END, g.cwl_id`.pipe(Effect.mapError(failure))
-  return yield* Effect.forEach(rows, (row) => decodeStoredCwlRounds(row.rounds).pipe(Effect.map((rounds): CwlGroup => ({ ...row, rounds })), Effect.mapError(failure)))
+  return yield* decodeCwlGroups(rows)
+})
+export const loadCwlGroupsByIds = (cwlIds: readonly string[]) => Effect.gen(function* () {
+  const ids = [...new Set(cwlIds)]
+  if (!ids.length) return [] as readonly CwlGroup[]
+  const sql = yield* SqlClient.SqlClient
+  const rows = yield* sql<StoredCwlGroup>`SELECT g.cwl_id, g.season, g.state, g.rounds, g.cwl_league_id, g.war_size,
+    array_agg(all_clans.clan_tag ORDER BY all_clans.clan_tag) AS clan_tags
+    FROM cwl_groups g JOIN cwl_group_clans all_clans ON all_clans.cwl_id = g.cwl_id
+    WHERE g.cwl_id = ANY(${ids}::text[])
+    GROUP BY g.cwl_id, g.season, g.state, g.rounds, g.cwl_league_id, g.war_size
+    ORDER BY CASE WHEN length(g.season) = 7 THEN g.season || '-01' ELSE g.season END DESC, g.cwl_id DESC`.pipe(Effect.mapError(failure))
+  return yield* decodeCwlGroups(rows)
 })
 export const loadCwlWars = (groups: readonly CwlGroup[]) => Effect.gen(function* () {
   const tags = [...new Set(groups.flatMap((group) => group.rounds.flat().filter(validTag)))]
@@ -212,25 +227,40 @@ export const queryPlayerCwlHistory = (rawTag: string, query: URLSearchParams) =>
   const missing = new Set(seeds.filter((seed) => !seed.cwl_league_id).map((seed) => seed.clan_tag))
   for (const clan of missing) yield* ensureCwlLeagueIds(clan)
   if (missing.size) seeds = yield* playerSeeds(tag, limit)
-  const items: PlayerItem[] = []
-  const clanGroups = new Map<string, CwlGroup[]>()
+  const groups = yield* loadCwlGroupsByIds(seeds.map((seed) => seed.cwl_id))
+  const groupById = new Map(groups.map((group) => [group.cwl_id, group]))
+  const wars = yield* loadCwlWars(groups)
+  type HistoryContext = {
+    readonly seed: PlayerSeed; readonly group: CwlGroup; readonly completed: readonly CwlWar[];
+    readonly rounds: ReadonlyMap<string, number>; readonly attacks: PlayerItem["attacks"][number][];
+    readonly scores: Map<string, { clan: string; player: string; stars: number }>; readonly sizes: Set<number>;
+    missedAttacks: number
+  }
+  const contexts: HistoryContext[] = []
+  const contextsByWar = new Map<string, HistoryContext[]>()
   for (const seed of seeds) {
-    let groups = clanGroups.get(seed.clan_tag)
-    if (!groups) { groups = yield* loadCwlGroups(seed.clan_tag); clanGroups.set(seed.clan_tag, groups) }
-    const group = groups.find((entry) => entry.cwl_id === seed.cwl_id)
+    const group = groupById.get(seed.cwl_id)
     if (!group) return yield* failure(new Error("CWL group disappeared during history read"))
-    const wars = yield* loadCwlWars([group])
-    const completed = [...wars.values()].filter((war) => finished(war.state))
+    const expected = new Set(group.rounds.flat().filter(validTag))
+    const completed = [...expected].flatMap((warTag) => {
+      const war = wars.get(warTag)
+      return war && finished(war.state) ? [war] : []
+    })
     const rounds = new Map(group.rounds.flatMap((tags, index) => tags.filter(validTag).map((tag) => [tag, index + 1] as const)))
-    const attacks: PlayerItem["attacks"][number][] = []
-    const scores = new Map<string, { clan: string; player: string; stars: number }>()
-    const sizes = new Set<number>()
-    let missedAttacks = 0
-    // Retain one archive at a time; group placement requires only scalar scores.
+    const context: HistoryContext = { seed, group, completed, rounds, attacks: [], scores: new Map(), sizes: new Set(), missedAttacks: 0 }
+    contexts.push(context)
     for (const row of completed) {
-      const entry = yield* readArchiveWar(row.war_id, row.end_time)
-      if (!entry) continue
-      const war = entry.war
+      const owners = contextsByWar.get(row.war_id) ?? []
+      owners.push(context)
+      contextsByWar.set(row.war_id, owners)
+    }
+  }
+  // Locator rows are fetched in pages and archive I/O is bounded-concurrent.
+  // Each decoded war is released after its scalar/player contribution is kept.
+  yield* forEachArchiveWar([...contextsByWar.keys()], (warId, war) => Effect.sync(() => {
+    for (const context of contextsByWar.get(warId) ?? []) {
+      const { seed, rounds, attacks, scores, sizes } = context
+      const row = context.completed.find((candidate) => candidate.war_id === warId)!
       for (const clan of [war.clan, war.opponent]) for (const member of clan.members) {
         const key = `${clan.tag}\0${member.tag}`
         const score = scores.get(key) ?? { clan: clan.tag, player: member.tag, stars: 0 }
@@ -242,7 +272,7 @@ export const queryPlayerCwlHistory = (rawTag: string, query: URLSearchParams) =>
       const member = own?.members.find((member) => member.tag === tag)
       if (!member) continue
       sizes.add(war.teamSize)
-      missedAttacks += Math.max(0, war.attacksPerMember - (member.attacks?.length ?? 0))
+      context.missedAttacks += Math.max(0, war.attacksPerMember - (member.attacks?.length ?? 0))
       for (const attack of member.attacks ?? []) {
         const defender = opponent.members.find((member) => member.tag === attack.defenderTag)
         attacks.push({ warTag: war.warTag ?? "", round: rounds.get(row.war_tag) ?? 0,
@@ -251,6 +281,10 @@ export const queryPlayerCwlHistory = (rawTag: string, query: URLSearchParams) =>
           stars: attack.stars, destructionPercentage: attack.destructionPercentage, order: attack.order, duration: attack.duration })
       }
     }
+  }))
+  const items: PlayerItem[] = []
+  for (const context of contexts) {
+    const { seed, group, completed, attacks, scores, sizes, missedAttacks } = context
     attacks.sort((a, b) => a.round - b.round || a.order - b.order)
     const summary = cwlSummary(group, wars, seed.clan_tag)
     const hasStanding = seed.stars !== null && seed.wins !== null && seed.losses !== null && seed.ties !== null

--- a/workers/api/src/public-player-extra.ts
+++ b/workers/api/src/public-player-extra.ts
@@ -12,7 +12,7 @@ import { publicHistoryOptions, isoTimestamp } from "./public-player.js"
 import { leaderboardHistoryItem, historicalHomeLeagues } from "./public-history.js"
 import { leaderboardLimit } from "./public-leaderboards.js"
 import { correctedJoinLeaveEvents, type JoinLeaveRow } from "./public-join-leave.js"
-import { forEachPlayerWar } from "./war-archive.js"
+import { forEachNewestPlayerWar } from "./war-archive.js"
 import { lookupStaticItem } from "./static-metadata.js"
 import { badgeUrls, archiveAttackFacts, clashTime, type ArchiveAttackFact } from "./war-archive-model.js"
 import locations from "./data/search-locations.json"
@@ -229,11 +229,11 @@ export const queryPlayerWarAttacks = (rawTag: string, query: URLSearchParams) =>
   if (type && !["random", "friendly", "cwl"].includes(type)) return yield* new InvalidRequest({ message: "Invalid war type" })
   const attacks: ArchiveAttackFact[] = []
   const order = (a: ArchiveAttackFact, b: ArchiveAttackFact) => b.warEndTime.getTime() - a.warEndTime.getTime() || b.attackOrder - a.attackOrder || Number(b.warId) - Number(a.warId)
-  yield* forEachPlayerWar([tag], options.start, options.end, (id, war) => Effect.sync(() => {
-    if (type && war.type !== type) return
+  yield* forEachNewestPlayerWar([tag], options.start, options.end, type ? [type] : [], Math.max(8, options.limit * 2), (id, war) => Effect.sync(() => {
     for (const attack of archiveAttackFacts(id, war)) if (attack.attackerTag === tag || attack.defenderTag === tag) {
       attacks.push(attack); attacks.sort(order); if (attacks.length > options.limit) attacks.pop()
     }
+    return attacks.length >= options.limit
   }))
   return { items: attacks.map(({ warId, warEndTime, ...attack }) => ({ ...attack, war_id: warId, warEndTime: clashTime(warEndTime), side: attack.attackerTag === tag ? "attack" : "defense" })) }
 })

--- a/workers/api/src/public-player-war-attacks.test.ts
+++ b/workers/api/src/public-player-war-attacks.test.ts
@@ -1,0 +1,81 @@
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { describe, expect, it, vi } from "vitest"
+
+import { WorkerEnvironment, type WorkerBindings } from "./environment.js"
+import { queryPlayerWarAttacks } from "./public-player-extra.js"
+
+const clan = (tag: string, attacker: string, defender: string, order: number) => ({
+  tag, name: tag, badgeToken: "", clanLevel: 1, attacks: 1, stars: 3, destructionPercentage: 100,
+  members: [{ tag: attacker, name: attacker, townhallLevel: 18, mapPosition: 1,
+    attacks: [{ defenderTag: defender, stars: 3, destructionPercentage: 100, duration: 100, order }] }],
+})
+const payload = (endTime: string, order: number, target = "#PYY") => ({
+  state: "warEnded", teamSize: 1, attacksPerMember: 1, preparationStartTime: endTime,
+  startTime: endTime, endTime, battleModifier: "", clan: clan("#AAA", target, "#DEF", order),
+  opponent: clan("#BBB", "#OTHER", target, order + 100),
+})
+type HistoryRow = { readonly war_id: number; readonly end_time: string }
+const fixture = (pages: readonly (readonly HistoryRow[])[], payloads: ReadonlyMap<string, unknown>) => {
+  const history = vi.fn((_statement: string, _parameters: readonly unknown[]) =>
+    Effect.succeed(pages[history.mock.calls.length - 1] ?? []))
+  const locator = vi.fn((ids: readonly string[]) => Effect.succeed(ids.map((id) => ({
+    war_id: id, war_type: "cwl", archive_pack_id: null, archive_offset: null,
+    archive_compressed_bytes: null, payload: null, pending: true,
+  }))))
+  const archive = vi.fn((id: string) => Effect.succeed(payloads.has(id) ? [{
+    war_id: id, war_type: "cwl", archive_pack_id: null, archive_offset: null,
+    archive_compressed_bytes: null, payload: payloads.get(id),
+  }] : []))
+  const tag = ((strings: TemplateStringsArray, ...parameters: readonly unknown[]) => {
+    const statement = strings.join("?")
+    if (statement.includes("AS pending FROM wars")) return locator(parameters[0] as readonly string[])
+    if (statement.includes("LEFT JOIN war_archive_pending")) return archive(String(parameters[0]))
+    return Effect.die(`Unexpected SQL: ${statement}`)
+  }) as unknown as SqlClient.SqlClient
+  const sql = Object.assign(tag, { unsafe: history }) as unknown as SqlClient.SqlClient
+  const layer = Layer.merge(Layer.succeed(SqlClient.SqlClient, sql),
+    Layer.succeed(WorkerEnvironment, { WAR_ARCHIVE: { get: vi.fn() } } as unknown as WorkerBindings))
+  return { history, locator, archive, run: (query: string) => Effect.runPromise(
+    queryPlayerWarAttacks("#PYY", new URLSearchParams(query)).pipe(Effect.provide(layer))),
+  }
+}
+
+describe("bounded newest player war attack traversal", () => {
+  it("stops archive work after the newest qualifying result", async () => {
+    const rows = Array.from({ length: 8 }, (_, index) => ({ war_id: 8 - index, end_time: `2026-08-${String(8 - index).padStart(2, "0")}T00:00:00Z` }))
+    const archives = new Map(rows.map((row) => [String(row.war_id), payload(row.end_time, row.war_id)]))
+    const test = fixture([rows], archives)
+    const result = await test.run("limit=1")
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toMatchObject({ war_id: "8", attackOrder: 108, side: "defense" })
+    expect(test.history).toHaveBeenCalledOnce()
+    expect(test.locator).toHaveBeenCalledOnce()
+    expect(test.archive).toHaveBeenCalledTimes(4)
+  })
+
+  it("reads every war tied at the cutoff and preserves attack-order tie breaking", async () => {
+    const end = "2026-08-08T00:00:00Z"
+    const test = fixture([[{ war_id: 9, end_time: end }, { war_id: 8, end_time: end },
+      { war_id: 7, end_time: "2026-08-07T00:00:00Z" }]], new Map([
+      ["9", payload(end, 1)], ["8", payload(end, 50)], ["7", payload("2026-08-07T00:00:00Z", 99)],
+    ]))
+    const result = await test.run("limit=1")
+    expect(result.items[0]).toMatchObject({ war_id: "8", attackOrder: 150 })
+    expect(test.archive).toHaveBeenCalledTimes(3)
+  })
+
+  it("continues beyond one page and pushes the requested war type into SQL", async () => {
+    const first = Array.from({ length: 8 }, (_, index) => ({ war_id: 20 - index, end_time: `2026-07-${String(20 - index).padStart(2, "0")}T00:00:00Z` }))
+    const second = [{ war_id: 12, end_time: "2026-07-12T00:00:00Z" }]
+    const archives = new Map<string, unknown>(first.map((row) => [String(row.war_id), payload(row.end_time, 1, "#NONE")]))
+    archives.set("12", payload(second[0]!.end_time, 3))
+    const test = fixture([first, second], archives)
+    const result = await test.run("limit=1&type=cwl")
+    expect(result.items[0]).toMatchObject({ war_id: "12", warType: "cwl" })
+    expect(test.history).toHaveBeenCalledTimes(2)
+    expect(test.history.mock.calls[0]?.[0]).toContain("w.war_type = ANY")
+    expect(test.history.mock.calls[0]?.[1]).toContainEqual(["cwl"])
+    expect(test.archive).toHaveBeenCalledTimes(9)
+  })
+})

--- a/workers/api/src/router.ts
+++ b/workers/api/src/router.ts
@@ -207,7 +207,7 @@ export const route = (request: Request, bindings: WorkerBindings,
     const staticSections = staticMetadataSectionsForPath(url.pathname)
     if (staticSections.length > 0) yield* prepareStaticMetadata(bindings, staticSections)
     if (request.method === "GET" && url.pathname === "/v2/health") {
-      return yield* encodeJson(HealthResponse, { status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.14" })
+      return yield* encodeJson(HealthResponse, { status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.15" })
     }
     if (request.method === "GET" && url.pathname === "/v2/app/config") {
       return yield* encodeJson(AppConfigResponse, yield* loadAppConfig)

--- a/workers/api/src/war-archive-loading.test.ts
+++ b/workers/api/src/war-archive-loading.test.ts
@@ -3,7 +3,7 @@ import { zstdCompressSync } from "node:zlib"
 import { Effect } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { expect, it, vi } from "vitest"
-import { loadArchiveWars } from "./war-archive.js"
+import { forEachArchiveWar, loadArchiveWars } from "./war-archive.js"
 import { WorkerEnvironment, type WorkerBindings } from "./environment.js"
 
 const clan = { tag: "#ABC", name: "Clan", badgeToken: "", clanLevel: 1, attacks: 0, stars: 0, destructionPercentage: 0, members: [] }
@@ -23,9 +23,17 @@ const fixture = (count: number, padding = "") => {
     archive_compressed_bytes: frame.length, payload: null, pending: false,
   }))))
   const sql = query as unknown as SqlClient.SqlClient
-  return { get, query, peak: () => peak, run: () => Effect.runPromise(loadArchiveWars(Array.from({ length: count }, (_, index) => String(index + 1))).pipe(
+  const provide = <A, E, R>(effect: Effect.Effect<A, E, R>) => effect.pipe(
     Effect.provideService(SqlClient.SqlClient, sql), Effect.provideService(WorkerEnvironment, { WAR_ARCHIVE: { get } } as unknown as WorkerBindings),
-  )) }
+  ) as Effect.Effect<A, E, Exclude<R, SqlClient.SqlClient | WorkerEnvironment>>
+  return { get, query, peak: () => peak,
+    run: () => Effect.runPromise(provide(loadArchiveWars(Array.from({ length: count }, (_, index) => String(index + 1))))),
+    stream: () => {
+      const seen: string[] = []
+      return Effect.runPromise(provide(forEachArchiveWar(Array.from({ length: count }, (_, index) => String(index + 1)),
+        (id) => Effect.sync(() => { seen.push(id) }))).pipe(Effect.as(seen)))
+    },
+  }
 }
 it("loads 50 archive locators in one SQL query and uses bounded parallel R2 reads", async () => {
   const test = fixture(50)
@@ -37,4 +45,11 @@ it("loads 50 archive locators in one SQL query and uses bounded parallel R2 read
 it("still rejects a page whose decoded total exceeds the memory limit", async () => {
   const test = fixture(2, "x".repeat(5 * 1024 * 1024))
   await expect(test.run()).rejects.toMatchObject({ _tag: "InvalidRequest" })
+})
+it("streams 50 archives with one locator query and four concurrent reads", async () => {
+  const test = fixture(50)
+  expect(await test.stream()).toEqual(Array.from({ length: 50 }, (_, index) => String(index + 1)))
+  expect(test.query).toHaveBeenCalledOnce()
+  expect(test.get).toHaveBeenCalledTimes(50)
+  expect(test.peak()).toBe(4)
 })

--- a/workers/api/src/war-archive.ts
+++ b/workers/api/src/war-archive.ts
@@ -67,6 +67,7 @@ const archiveRefs = (ids: readonly string[]) => Effect.gen(function* () {
 const readRef = (ref: ArchiveRef, bindings: WorkerBindings) => ref.pending === true
   ? readArchiveWar(ref.war_id) : decodeArchiveRef(ref, bindings)
 export const archiveReadConcurrency = 2
+export const historyArchiveReadConcurrency = 4
 
 // Public endpoints already support time/limit pagination. Reject oversized
 // pages explicitly; never return a silently truncated history.
@@ -87,6 +88,92 @@ export const loadArchiveWars = (warIds: readonly string[]) => Effect.gen(functio
     }), { concurrency: archiveReadConcurrency, discard: true })
   }
   return wars
+})
+
+/** Read an ordered list of archives with batched locator SQL and bounded I/O.
+ * The callback runs in input order, while each group of archive reads runs in
+ * parallel. Only one small locator page and one I/O batch are retained. */
+export const forEachArchiveWar = <E, R>(
+  warIds: readonly string[],
+  consume: (warId: string, war: ArchivedWar) => Effect.Effect<void, E, R>,
+) => Effect.gen(function* () {
+  const bindings = yield* WorkerEnvironment
+  const ids = [...new Set(warIds)]
+  for (let pageOffset = 0; pageOffset < ids.length; pageOffset += 64) {
+    const page = ids.slice(pageOffset, pageOffset + 64)
+    const refs = new Map((yield* archiveRefs(page)).map((ref) => [ref.war_id, ref]))
+    for (let offset = 0; offset < page.length; offset += historyArchiveReadConcurrency) {
+      const batch = page.slice(offset, offset + historyArchiveReadConcurrency)
+      const entries = yield* Effect.forEach(batch, (id) => {
+        const ref = refs.get(id)
+        return ref === undefined ? Effect.succeed(undefined) : readRef(ref, bindings)
+      }, { concurrency: historyArchiveReadConcurrency })
+      for (const [index, id] of batch.entries()) {
+        const entry = entries[index]
+        if (entry) yield* consume(id, entry.war)
+      }
+    }
+  }
+})
+
+/** Newest-first keyset traversal for bounded feeds. The consumer indicates
+ * when it has enough results. Every war sharing that end time is still read so
+ * attack-order and war-id tie breaking remain exact. */
+export const forEachNewestPlayerWar = <E, R>(
+  playerTags: readonly string[],
+  start: Date,
+  end: Date,
+  warTypes: readonly string[],
+  pageSize: number,
+  consume: (warId: string, war: ArchivedWar) => Effect.Effect<boolean, E, R>,
+) => Effect.gen(function* () {
+  if (!playerTags.length) return
+  const sql = yield* SqlClient.SqlClient
+  const bindings = yield* WorkerEnvironment
+  const size = Math.max(1, Math.min(64, Math.trunc(pageSize)))
+  let cursorEnd: Date | string | undefined
+  let cursorId: number | undefined
+  let satisfiedAt: number | undefined
+  for (;;) {
+    const parameters: unknown[] = [[...playerTags], start, end]
+    let statement = `
+      SELECT DISTINCT w.war_id, w.end_time
+      FROM player_war_history history
+      CROSS JOIN LATERAL unnest(history.war_ids) history_war_id
+      JOIN wars w ON w.war_id = history_war_id
+      WHERE history.player_tag = ANY($1::text[])
+        AND w.end_time >= $2 AND w.end_time <= $3`
+    if (warTypes.length) { parameters.push([...warTypes]); statement += ` AND w.war_type = ANY($${parameters.length}::text[])` }
+    if (cursorEnd !== undefined && cursorId !== undefined) {
+      parameters.push(cursorEnd, cursorId)
+      statement += ` AND (w.end_time < $${parameters.length - 1} OR (w.end_time = $${parameters.length - 1} AND w.war_id < $${parameters.length}))`
+    }
+    parameters.push(size)
+    statement += ` ORDER BY w.end_time DESC, w.war_id DESC LIMIT $${parameters.length}`
+    const rows = yield* sql.unsafe<{ readonly war_id: number; readonly end_time: Date | string }>(statement, parameters)
+      .pipe(Effect.mapError((cause) => new DatabaseFailure({ cause, message: "Player war history query failed" })))
+    if (!rows.length) return
+    const refs = new Map((yield* archiveRefs(rows.map((row) => String(row.war_id)))).map((ref) => [ref.war_id, ref]))
+    for (let offset = 0; offset < rows.length; offset += historyArchiveReadConcurrency) {
+      const firstTimestamp = new Date(rows[offset]!.end_time).getTime()
+      if (satisfiedAt !== undefined && firstTimestamp < satisfiedAt) return
+      const batch = rows.slice(offset, offset + historyArchiveReadConcurrency)
+      const entries = yield* Effect.forEach(batch, (row) => {
+        const ref = refs.get(String(row.war_id))
+        return ref === undefined ? Effect.succeed(undefined) : readRef(ref, bindings)
+      }, { concurrency: historyArchiveReadConcurrency })
+      for (const [index, row] of batch.entries()) {
+        const timestamp = new Date(row.end_time).getTime()
+        if (satisfiedAt !== undefined && timestamp < satisfiedAt) return
+        const entry = entries[index]
+        if (entry && (yield* consume(String(row.war_id), entry.war))) satisfiedAt = timestamp
+      }
+    }
+    const last = rows.at(-1)!
+    cursorEnd = last.end_time
+    cursorId = last.war_id
+    if (rows.length < size) return
+  }
 })
 
 /** Complete keyset scan with at most 128 IDs and one decoded war retained.

--- a/workers/api/test/health-boundary.test.ts
+++ b/workers/api/test/health-boundary.test.ts
@@ -48,7 +48,7 @@ describe("public Worker liveness boundary", () => {
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8")
     expect(response.headers.get("x-request-id")).toBe("health-fixture")
-    expect(await response.json()).toEqual({ status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.14" })
+    expect(await response.json()).toEqual({ status: "ok", runtime: "cloudflare-worker", version: "0.1.0-rc.15" })
   })
 
   it("does not add a POST compatibility route", async () => {


### PR DESCRIPTION
`GET /v2/player/:tag/war/attacks` decoded a player's complete matching archive history before applying its response limit, and `GET /v2/player/:playerTag/cwl/history` repeated group, war, locator, and archive reads serially for each season. Long-lived players consequently saw request times measured in tens of seconds.

This change traverses attack history newest-first in bounded pages, pushes time and war-type filters into PostgreSQL, stops once the requested attack limit and its timestamp ties are complete, and reads archive frames with bounded concurrency. CWL history now loads selected groups and war metadata once, batches locator lookups, decodes each unique war once, and retains only the aggregates needed for placement and missed-attack output.

The response contracts and ordering remain unchanged. Complete, incomplete, and current CWL placement behavior is covered by tests, along with attack ties, mixed types, cross-page traversal, early stopping, locator query count, archive order, and concurrency bounds.

Validation:

- `npm test` (1,328 tests)
- `npm run typecheck`
- `npm run test:scripts`
- `npm run test:archive-runtime` (28 Workerd tests)
- `npm run lint`
- `npm run openapi:check`
- `npm run build`
- `git diff --check`

This also advances the API package/release version to `0.1.0-rc.15`, as required by PR CI.
